### PR TITLE
Add Export class

### DIFF
--- a/fastfuels_sdk/exports.py
+++ b/fastfuels_sdk/exports.py
@@ -1,0 +1,183 @@
+"""
+exports.py
+"""
+
+# Core imports
+from __future__ import annotations
+from time import sleep
+from pathlib import Path
+from typing import Any, Callable
+from urllib.request import urlretrieve
+
+# Internal imports
+from fastfuels_sdk.api import get_client
+from fastfuels_sdk.client_library.models import Export as ExportModel
+from fastfuels_sdk.client_library.api import TreeInventoryApi
+
+# Initialize API clients
+_TREE_INVENTORY_API = TreeInventoryApi(get_client())
+
+
+class Export(ExportModel):
+    """
+    Class for handling exports of various resources from the FastFuels API.
+    Inherits from the base ExportModel and adds functionality for fetching,
+    waiting for completion, and downloading exports.
+
+    Attributes
+    ----------
+    domain_id : str
+        The ID of the domain associated with the export
+    resource : str
+        The type of resource being exported (e.g. "inventories")
+    sub_resource : str
+        The specific sub-resource being exported (e.g. "tree")
+    format : str
+        The format of the export (e.g. "csv", "parquet", "geojson")
+    status : str
+        Current status of the export ("pending", "running", "completed")
+    signed_url : str, optional
+        URL for downloading the completed export
+    _api_get_method : Callable
+        The API method to use for getting the export status
+    """
+
+    _api_get_method: Callable
+
+    def __init__(self, **data: Any):
+        """
+        Initialize the Export object and set up the appropriate API method
+        based on the resource and sub_resource.
+
+        Parameters
+        ----------
+        **data : Any
+            Keyword arguments that match the ExportModel fields
+
+        Raises
+        ------
+        NotImplementedError
+            If the resource and sub_resource combination is not supported
+        """
+        super().__init__(**data)
+
+        # Set up the appropriate API method based on resource type
+        if self.resource == "inventories" and self.sub_resource == "tree":
+            self._api_get_method = (
+                lambda: _TREE_INVENTORY_API.get_tree_inventory_export(
+                    domain_id=self.domain_id, export_format=self.format
+                )
+            )
+        else:
+            raise NotImplementedError(
+                f"Export not implemented for resource={self.resource}, "
+                f"sub_resource={self.sub_resource}"
+            )
+
+    def get(self, in_place: bool = False) -> Export:
+        """
+        Fetches the current state of the export from the API.
+
+        Parameters
+        ----------
+        in_place : bool, optional
+            If True, updates the current object with fetched data.
+            If False, returns a new Export object. Default is False.
+
+        Returns
+        -------
+        Export
+            Either the current object updated with fresh data (in_place=True)
+            or a new Export object with the fetched data (in_place=False)
+        """
+        response = self._api_get_method()
+
+        if in_place:
+            # Update all attributes of current instance
+            for key, value in response.model_dump().items():
+                setattr(self, key, value)
+            return self
+
+        return Export(**response.model_dump())
+
+    def wait_until_completed(
+        self,
+        step: float = 5,
+        timeout: float = 600,
+        in_place: bool = True,
+        verbose: bool = False,
+    ) -> Export:
+        """
+        Waits for the export to complete, polling at regular intervals.
+
+        Parameters
+        ----------
+        step : float, optional
+            Time in seconds between status checks. Default is 5.
+        timeout : float, optional
+            Maximum time in seconds to wait for completion. Default is 600.
+        in_place : bool, optional
+            If True, updates the current object with the completed export data.
+            If False, returns a new Export object. Default is True.
+        verbose : bool, optional
+            If True, prints status updates during the wait. Default is False.
+
+        Returns
+        -------
+        Export
+            The completed export object
+
+        Raises
+        ------
+        TimeoutError
+            If the export does not complete within the specified timeout period.
+        """
+        elapsed_time = 0
+        export = self.get(in_place=in_place if in_place else False)
+
+        while export.status != "completed":
+            if elapsed_time >= timeout:
+                raise TimeoutError(
+                    f"Timed out waiting for export to finish after {timeout} seconds."
+                )
+            sleep(step)
+            elapsed_time += step
+            export = self.get(in_place=in_place if in_place else False)
+            if verbose:
+                print(f"Export has status `{export.status}` ({elapsed_time:.2f}s)")
+
+        return export
+
+    def to_file(self, path: Path | str) -> None:
+        """
+        Downloads the export to a local file once it's completed.
+
+        Parameters
+        ----------
+        path : Path or str
+            The path where the export should be saved. If a directory is provided,
+            the file will be saved as "{resource}_{sub_resource}.{format}" in that directory.
+
+        Raises
+        ------
+        ValueError
+            If the export is not yet completed or if the signed URL is missing
+        """
+        if isinstance(path, str):
+            path = Path(path)
+
+        if path.is_dir():
+            fname = f"{self.resource}{'_' if self.sub_resource else None}{self.sub_resource}.{self.format}"
+            path = path / fname
+
+        if self.status != "completed":
+            raise ValueError(
+                "Export is not yet completed. Please wait for completion before downloading."
+            )
+
+        if not self.signed_url:
+            raise ValueError(
+                "Export does not have a signed URL. Please ensure the export is completed."
+            )
+
+        urlretrieve(self.signed_url, path)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,3 +2,4 @@ from pathlib import Path
 
 TEST_DIR = Path(__file__).parent
 TEST_DATA_DIR = TEST_DIR / "data"
+TEST_TMP_DIR = TEST_DIR / "tmp"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+"""
+tests/conftest.py
+"""
+
+import pytest
+from shutil import rmtree
+from tests import TEST_TMP_DIR
+
+
+@pytest.fixture(scope="function", autouse=True)
+def setup_and_teardown_tmpdir():
+    """
+    Everytime a test function is run, this fixture will automatically delete the
+    existing tmp directory and create a new one before the test function is run.
+    This solves any potential side effects from previous tests that may have left
+    files in the tmp directory.
+
+    I elected to keep the tmp directory after the test function is run so that
+    the user can inspect the contents of the directory after the test is run.
+    If it becomes necessary to delete the directory in the future, add the line
+    `rmtree(TMP_DIR)` to the teardown (after the yield statement).
+    """
+    if TEST_TMP_DIR.exists():
+        rmtree(TEST_TMP_DIR)
+    TEST_TMP_DIR.mkdir()
+    yield

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,0 +1,95 @@
+"""
+tests/test_exports.py
+"""
+
+# Internal imports
+from tests import TEST_TMP_DIR
+from tests.utils import create_default_domain
+from fastfuels_sdk.inventories import Inventories
+
+# External imports
+import pytest
+
+
+class TestTreeInventoryExports:
+    """Tests specific to tree inventory exports"""
+
+    @pytest.fixture(scope="class")
+    def domain(self):
+        """Creates a test domain"""
+        domain = create_default_domain()
+        yield domain
+        domain.delete()
+
+    @pytest.fixture(scope="class")
+    def tree_inventory(self, domain):
+        """Creates and completes a tree inventory"""
+        inventories = Inventories.from_domain(domain)
+        tree_inventory = inventories.create_tree_inventory(sources="TreeMap")
+        tree_inventory.wait_until_completed(in_place=True)
+        return tree_inventory
+
+    @pytest.fixture(scope="class")
+    def tree_inventory_export_csv(self, tree_inventory):
+        export = tree_inventory.create_export(export_format="csv")
+        return export
+
+    @pytest.fixture(scope="class")
+    def tree_inventory_export_parquet(self, tree_inventory):
+        export = tree_inventory.create_export(export_format="parquet")
+        return export
+
+    @pytest.fixture(scope="class")
+    def tree_inventory_export_geojson(self, tree_inventory):
+        export = tree_inventory.create_export(export_format="geojson")
+        return export
+
+    @pytest.mark.parametrize(
+        "export_fixture",
+        [
+            "tree_inventory_export_csv",
+            "tree_inventory_export_parquet",
+            "tree_inventory_export_geojson",
+        ],
+        ids=["csv", "parquet", "geojson"],
+    )
+    def test_to_file_with_filename(self, tree_inventory, export_fixture, request):
+        """Test downloading exports with specific filenames"""
+        # Create and wait for export to complete
+        export = request.getfixturevalue(export_fixture)
+        export.wait_until_completed(in_place=True)
+
+        # Download with specific filename
+        filename = f"trees.{export.format}"
+        file_path = TEST_TMP_DIR / filename
+        export.to_file(file_path)
+
+        # Verify file was downloaded with correct name
+        assert file_path.exists()
+        assert file_path.is_file()
+        assert filename in [f.name for f in TEST_TMP_DIR.iterdir()]
+
+    @pytest.mark.parametrize(
+        "export_fixture",
+        [
+            "tree_inventory_export_csv",
+            "tree_inventory_export_parquet",
+            "tree_inventory_export_geojson",
+        ],
+        ids=["csv", "parquet", "geojson"],
+    )
+    def test_to_file_with_directory(self, tree_inventory, export_fixture, request):
+        """Test downloading exports to directory without specifying filename"""
+        # Create and wait for export to complete
+        export = request.getfixturevalue(export_fixture)
+        export.wait_until_completed(in_place=True)
+
+        # Download to directory
+        export.to_file(TEST_TMP_DIR)
+
+        # Verify file was downloaded with default name
+        expected_filename = f"inventories_tree.{export.format}"
+        expected_path = TEST_TMP_DIR / expected_filename
+        assert expected_path.exists()
+        assert expected_path.is_file()
+        assert expected_filename in [f.name for f in TEST_TMP_DIR.iterdir()]


### PR DESCRIPTION
Introduce `Export` class for managing resource exports, including methods for fetching, polling, and downloading exports. Add corresponding unit tests and fixtures to verify export functionality for multiple formats (CSV, Parquet, GeoJSON). Update test utils with temporary directory setup for isolated test environments.