### PR TITLE
Allowing import without setting environment variable for ID

### DIFF
--- a/fastfuels_sdk/domains.py
+++ b/fastfuels_sdk/domains.py
@@ -18,7 +18,7 @@ from fastfuels_sdk.client_library.models import (
     UpdateDomainRequest,
 )
 
-_DOMAIN_API = DomainsApi(get_client())
+# _DOMAIN_API = DomainsApi(get_client())
 
 
 class Domain(DomainModel):
@@ -80,6 +80,7 @@ class Domain(DomainModel):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.API = DomainsApi(get_client())
 
     @classmethod
     def from_id(cls, domain_id: str) -> "Domain":
@@ -104,7 +105,7 @@ class Domain(DomainModel):
         >>> domain.id
         'abc123'
         """
-        get_domain_response = _DOMAIN_API.get_domain(domain_id)
+        get_domain_response = self.API.get_domain(domain_id)
         return cls(**get_domain_response.model_dump())
 
     @classmethod
@@ -172,7 +173,7 @@ class Domain(DomainModel):
         }
 
         request = CreateDomainRequest.from_dict(feature_data)
-        response = _DOMAIN_API.create_domain(
+        response = self.API.create_domain(
             create_domain_request=request.model_dump()  # noqa
         )
         return cls(**response.model_dump()) if response else None
@@ -291,7 +292,7 @@ class Domain(DomainModel):
         ensure all references to this Domain instance see the updated data.
         """
         # Fetch latest data from API
-        response = _DOMAIN_API.get_domain(self.id)
+        response = self.API.get_domain(self.id)
 
         if in_place:
             # Update all attributes of current instance
@@ -365,7 +366,7 @@ class Domain(DomainModel):
         # Only make API call if there are fields to update
         if update_data:
             request = UpdateDomainRequest(**update_data)
-            response = _DOMAIN_API.update_domain(
+            response = self.API.update_domain(
                 domain_id=self.id, update_domain_request=request
             )
 
@@ -401,7 +402,7 @@ class Domain(DomainModel):
         >>> domain.get()
         # Raises NotFoundException
         """
-        _DOMAIN_API.delete_domain(domain_id=self.id)
+        self.API.delete_domain(domain_id=self.id)
         return None
 
 
@@ -462,9 +463,11 @@ def list_domains(
     - The maximum page size is 1000 items.
     - When calculating total pages, use: ceil(response.totalItems / response.pageSize)
     """
+
+    API = DomainsApi(get_client())
     sort_by = DomainSortField(sort_by) if sort_by else None
     sort_order = DomainSortOrder(sort_order) if sort_order else None
-    list_response = _DOMAIN_API.list_domains(
+    list_response = API.list_domains(
         page=page, size=size, sort_by=sort_by, sort_order=sort_order
     )
     list_response.domains = [Domain(**d.model_dump()) for d in list_response.domains]

--- a/fastfuels_sdk/exports.py
+++ b/fastfuels_sdk/exports.py
@@ -21,38 +21,6 @@ from fastfuels_sdk.client_library.api import (
     FeatureGridApi,
 )
 
-# Initialize API clients
-_TREE_INVENTORY_API = TreeInventoryApi(get_client())
-_GRIDS_API = GridsApi(get_client())
-_TREE_GRID_API = TreeGridApi(get_client())
-_SURFACE_GRID_API = SurfaceGridApi(get_client())
-_TOPOGRAPHY_GRID_API = TopographyGridApi(get_client())
-_FEATURE_GRID_API = FeatureGridApi(get_client())
-
-# Define a mapping of (resource, sub_resource) tuples to their corresponding API methods
-_API_METHODS = {
-    ("inventories", "tree"): _TREE_INVENTORY_API.get_tree_inventory_export,
-    ("grids", None): _GRIDS_API.get_grid_export,
-    ("grids", "tree"): _TREE_GRID_API.get_tree_grid_export,
-    ("grids", "surface"): _SURFACE_GRID_API.get_surface_grid_export,
-    ("grids", "topography"): _TOPOGRAPHY_GRID_API.get_topography_grid_export,
-    # ("grids", "feature"): _FEATURE_GRID_API.get_feature_grid_export,  # Not yet implemented
-}
-
-_FILE_NAMES = {
-    ("inventories", "tree", "csv"): "tree_inventory.csv",
-    ("inventories", "tree", "parquet"): "tree_inventory.parquet.zip",
-    ("inventories", "tree", "geojson"): "tree_inventory.geojson",
-    ("grids", None, "QUIC-Fire"): "quicfire.zip",
-    ("grids", None, "zarr"): "grid.zarr.zip",
-    ("grids", "tree", "zarr"): "tree_grid.zarr.zip",
-    ("grids", "surface", "zarr"): "surface_grid.zarr.zip",
-    ("grids", "surface", "geotiff"): "surface_grid.tif",
-    ("grids", "topography", "zarr"): "topography_grid.zarr.zip",
-    ("grids", "topography", "geotiff"): "topography_grid.tif",
-}
-
-
 class Export(ExportModel):
     """
     Class for handling exports of various resources from the FastFuels API.
@@ -93,8 +61,37 @@ class Export(ExportModel):
             If the resource and sub_resource combination is not supported
         """
         super().__init__(**data)
+        # Initialize API clients
+        self._TREE_INVENTORY_API = TreeInventoryApi(get_client())
+        self._GRIDS_API = GridsApi(get_client())
+        self._TREE_GRID_API = TreeGridApi(get_client())
+        self._SURFACE_GRID_API = SurfaceGridApi(get_client())
+        self._TOPOGRAPHY_GRID_API = TopographyGridApi(get_client())
+        self._FEATURE_GRID_API = FeatureGridApi(get_client())
 
-        api_method = _API_METHODS.get((self.resource, self.sub_resource))
+        # Define a mapping of (resource, sub_resource) tuples to their corresponding API methods
+        self._API_METHODS = {
+            ("inventories", "tree"): self._TREE_INVENTORY_API.get_tree_inventory_export,
+            ("grids", None): self._GRIDS_API.get_grid_export,
+            ("grids", "tree"): self._TREE_GRID_API.get_tree_grid_export,
+            ("grids", "surface"): self._SURFACE_GRID_API.get_surface_grid_export,
+            ("grids", "topography"): self._TOPOGRAPHY_GRID_API.get_topography_grid_export,
+            # ("grids", "feature"): _FEATURE_GRID_API.get_feature_grid_export,  # Not yet implemented
+        }
+
+        self._FILE_NAMES = {
+            ("inventories", "tree", "csv"): "tree_inventory.csv",
+            ("inventories", "tree", "parquet"): "tree_inventory.parquet.zip",
+            ("inventories", "tree", "geojson"): "tree_inventory.geojson",
+            ("grids", None, "QUIC-Fire"): "quicfire.zip",
+            ("grids", None, "zarr"): "grid.zarr.zip",
+            ("grids", "tree", "zarr"): "tree_grid.zarr.zip",
+            ("grids", "surface", "zarr"): "surface_grid.zarr.zip",
+            ("grids", "surface", "geotiff"): "surface_grid.tif",
+            ("grids", "topography", "zarr"): "topography_grid.zarr.zip",
+            ("grids", "topography", "geotiff"): "topography_grid.tif",
+        }
+        api_method = self._API_METHODS.get((self.resource, self.sub_resource))
         if api_method is None:
             raise NotImplementedError(
                 f"Export not implemented for resource={self.resource}, "

--- a/fastfuels_sdk/features.py
+++ b/fastfuels_sdk/features.py
@@ -24,10 +24,6 @@ from fastfuels_sdk.client_library.models import (
     WaterFeatureSource,
 )
 
-_FEATURES_API = FeaturesApi(get_client())
-_ROAD_FEATURE_API = RoadFeatureApi(get_client())
-_WATER_FEATURE_API = WaterFeatureApi(get_client())
-
 
 class Features(FeaturesModel):
     """Geographic features (roads and water bodies) associated with a domain.
@@ -68,6 +64,12 @@ class Features(FeaturesModel):
     road: Optional[RoadFeature]
     water: Optional[WaterFeature]
 
+    def __init__(self, **kwargs):
+        super.__init__(**kwargs)
+        self._FEATURES_API = FeaturesApi(get_client())
+        self._ROAD_FEATURE_API = RoadFeatureApi(get_client())
+        self._WATER_FEATURE_API = WaterFeatureApi(get_client())
+
     @classmethod
     def from_domain_id(cls, domain_id: str) -> Features:
         """Retrieve the features (roads and water bodies) associated with a domain.
@@ -101,7 +103,7 @@ class Features(FeaturesModel):
         --------
         Features.get : Refresh feature data
         """
-        features_response = _FEATURES_API.get_features(domain_id=domain_id)
+        features_response = self._FEATURES_API.get_features(domain_id=domain_id)
         response_data = _convert_api_models_to_sdk_classes(
             domain_id, features_response.model_dump()
         )
@@ -193,7 +195,7 @@ class Features(FeaturesModel):
         )
 
         # Call API
-        response = _ROAD_FEATURE_API.create_road_feature(
+        response = self._ROAD_FEATURE_API.create_road_feature(
             domain_id=self.domain_id, create_road_feature_request=request
         )
 
@@ -284,7 +286,7 @@ class Features(FeaturesModel):
         )
 
         # Call API
-        response = _WATER_FEATURE_API.create_water_feature(
+        response = self._WATER_FEATURE_API.create_water_feature(
             domain_id=self.domain_id, create_water_feature_request=request
         )
 
@@ -396,7 +398,7 @@ class RoadFeature(RoadFeatureModel):
         >>> # Or update the existing instance
         >>> road.get(in_place=True)
         """
-        response = _ROAD_FEATURE_API.get_road_feature(domain_id=self.domain_id)
+        response = self._ROAD_FEATURE_API.get_road_feature(domain_id=self.domain_id)
         if in_place:
             # Update all attributes of current instance
             for key, value in response.model_dump().items():
@@ -476,7 +478,7 @@ class RoadFeature(RoadFeatureModel):
         >>> # Subsequent operations will raise NotFoundException
         >>> road.get()  # raises NotFoundException
         """
-        _ROAD_FEATURE_API.delete_road_feature(domain_id=self.domain_id)
+        self._ROAD_FEATURE_API.delete_road_feature(domain_id=self.domain_id)
         return None
 
 
@@ -543,7 +545,7 @@ class WaterFeature(WaterFeatureModel):
         >>> # Or update the existing instance
         >>> water.get(in_place=True)
         """
-        response = _WATER_FEATURE_API.get_water_feature(domain_id=self.domain_id)
+        response = self._WATER_FEATURE_API.get_water_feature(domain_id=self.domain_id)
         if in_place:
             # Update all attributes of current instance
             for key, value in response.model_dump().items():
@@ -623,7 +625,7 @@ class WaterFeature(WaterFeatureModel):
         >>> # Subsequent operations will raise NotFoundException
         >>> water.get()  # raises NotFoundException
         """
-        _WATER_FEATURE_API.delete_water_feature(domain_id=self.domain_id)
+        self._WATER_FEATURE_API.delete_water_feature(domain_id=self.domain_id)
         return None
 
 

--- a/fastfuels_sdk/grids/feature_grid.py
+++ b/fastfuels_sdk/grids/feature_grid.py
@@ -13,13 +13,17 @@ from fastfuels_sdk.client_library.models import (
     GridAttributeMetadataResponse,
 )
 
-_SURFACE_GRID_API = FeatureGridApi(get_client())
+
 
 
 class FeatureGrid(FeatureGridModel):
     """Feature grid data within a domain's spatial boundaries."""
 
     domain_id: str
+
+    def __init__(self, **kwargs):
+        super.__init__(**kwargs)
+        self._SURFACE_GRID_API = FeatureGridApi(get_client())
 
     @classmethod
     def from_domain_id(cls, domain_id: str) -> "FeatureGrid":
@@ -41,7 +45,7 @@ class FeatureGrid(FeatureGridModel):
         >>> print(grid.status)
         'completed'
         """
-        response = _SURFACE_GRID_API.get_feature_grid(domain_id=domain_id)
+        response =self._SURFACE_GRID_API.get_feature_grid(domain_id=domain_id)
         return cls(domain_id=domain_id, **response.model_dump())
 
     def get(self, in_place: bool = False) -> "FeatureGrid":
@@ -69,7 +73,7 @@ class FeatureGrid(FeatureGridModel):
         >>> # Or update the existing instance
         >>> grid.get(in_place=True)
         """
-        response = _SURFACE_GRID_API.get_feature_grid(domain_id=self.domain_id)
+        response =self._SURFACE_GRID_API.get_feature_grid(domain_id=self.domain_id)
         if in_place:
             # Update all attributes of current instance
             for key, value in response.model_dump().items():
@@ -194,7 +198,7 @@ class FeatureGrid(FeatureGridModel):
         >>> print(metadata.shape)
         [100, 100, 50]
         """
-        return _SURFACE_GRID_API.get_feature_grid_attribute_metadata(
+        return self._SURFACE_GRID_API.get_feature_grid_attribute_metadata(
             domain_id=self.domain_id
         )
 
@@ -217,5 +221,5 @@ class FeatureGrid(FeatureGridModel):
         >>> # Subsequent operations will raise NotFoundException
         >>> grid.get()  # raises NotFoundException
         """
-        _SURFACE_GRID_API.delete_feature_grid(domain_id=self.domain_id)
+        self._SURFACE_GRID_API.delete_feature_grid(domain_id=self.domain_id)
         return None

--- a/fastfuels_sdk/grids/grids.py
+++ b/fastfuels_sdk/grids/grids.py
@@ -44,11 +44,11 @@ from fastfuels_sdk.client_library.models import (
     CreateFeatureGridRequest,
 )
 
-_GRIDS_API = GridsApi(get_client())
-_TREE_GRID_API = TreeGridApi(get_client())
-_SURFACE_GRID_API = SurfaceGridApi(get_client())
-_TOPOGRAPHY_GRID_API = TopographyGridApi(get_client())
-_FEATURE_GRID_API = FeatureGridApi(get_client())
+# _GRIDS_API = GridsApi(get_client())
+# _TREE_GRID_API = TreeGridApi(get_client())
+# _SURFACE_GRID_API = SurfaceGridApi(get_client())
+# _TOPOGRAPHY_GRID_API = TopographyGridApi(get_client())
+# _FEATURE_GRID_API = FeatureGridApi(get_client())
 
 
 class Grids(GridsModel):
@@ -103,6 +103,14 @@ class Grids(GridsModel):
     topography: Optional[TopographyGrid]
     feature: Optional[FeatureGrid]
 
+    def __init__(self, **kwargs):
+        self._GRIDS_API = GridsApi(get_client())
+        self._TREE_GRID_API = TreeGridApi(get_client())
+        self._SURFACE_GRID_API = SurfaceGridApi(get_client())
+        self._TOPOGRAPHY_GRID_API = TopographyGridApi(get_client())
+        self._FEATURE_GRID_API = FeatureGridApi(get_client())
+        super.__init__(**kwargs)
+
     @classmethod
     def from_domain_id(cls, domain_id: str) -> Grids:
         """Retrieve the grids associated with a domain.
@@ -127,7 +135,7 @@ class Grids(GridsModel):
         >>> if grids.surface:
         ...     print("Domain has surface grid data")
         """
-        grids_response = _GRIDS_API.get_grids(domain_id=domain_id)
+        grids_response =self._GRIDS_API.get_grids(domain_id=domain_id)
         response_data = grids_response.model_dump()
         response_data = _convert_api_models_to_sdk_classes(domain_id, response_data)
 
@@ -157,7 +165,7 @@ class Grids(GridsModel):
         >>> # Or update the existing instance
         >>> grids.get(in_place=True)
         """
-        response = _GRIDS_API.get_grids(domain_id=self.domain_id)
+        response =self._GRIDS_API.get_grids(domain_id=self.domain_id)
         response_data = response.model_dump()
         response_data = _convert_api_models_to_sdk_classes(
             self.domain_id, response_data
@@ -270,7 +278,7 @@ class Grids(GridsModel):
             ),
         )
 
-        response = _SURFACE_GRID_API.create_surface_grid(
+        response = self._SURFACE_GRID_API.create_surface_grid(
             domain_id=self.domain_id, create_surface_grid_request=request
         )
 
@@ -407,7 +415,7 @@ class Grids(GridsModel):
             aspect=(TopographyGridAspectSource.from_dict(aspect) if aspect else None),
         )
 
-        response = _TOPOGRAPHY_GRID_API.create_topography_grid(
+        response = self._TOPOGRAPHY_GRID_API.create_topography_grid(
             domain_id=self.domain_id, create_topography_grid_request=request
         )
 
@@ -541,7 +549,7 @@ class Grids(GridsModel):
             SAVR=(TreeGridSAVRSource.from_dict(savr) if savr else None),
         )
 
-        response = _TREE_GRID_API.create_tree_grid(
+        response = self._TREE_GRID_API.create_tree_grid(
             domain_id=self.domain_id, create_tree_grid_request=request
         )
 
@@ -613,7 +621,7 @@ class Grids(GridsModel):
             attributes=attributes,  # type: ignore # pydantic handles this for us
         )
 
-        response = _FEATURE_GRID_API.create_feature_grid(
+        response = self._FEATURE_GRID_API.create_feature_grid(
             domain_id=self.domain_id, create_feature_grid_request=request
         )
 
@@ -656,7 +664,7 @@ class Grids(GridsModel):
         >>> export.wait_until_completed()
         >>> export.to_file("grid_data.zip")
         """
-        response = _GRIDS_API.create_grid_export(
+        response =self._GRIDS_API.create_grid_export(
             domain_id=self.domain_id, export_format=export_format
         )
         return Export(**response.model_dump())
@@ -686,7 +694,7 @@ class Grids(GridsModel):
         >>> if export.status == "completed":
         ...     export.to_file("grid_data.zarr")
         """
-        response = _GRIDS_API.get_grid_export(
+        response =self._GRIDS_API.get_grid_export(
             domain_id=self.domain_id, export_format=export_format
         )
         return Export(**response.model_dump())

--- a/fastfuels_sdk/grids/surface_grid.py
+++ b/fastfuels_sdk/grids/surface_grid.py
@@ -14,13 +14,14 @@ from fastfuels_sdk.client_library.models import (
     GridAttributeMetadataResponse,
 )
 
-_SURFACE_GRID_API = SurfaceGridApi(get_client())
-
-
 class SurfaceGrid(SurfaceGridModel):
     """Surface grid data within a domain's spatial boundaries."""
 
     domain_id: str
+
+    def __init__(self, **kwargs):
+        super.__init__(**kwargs)
+        self._SURFACE_GRID_API = SurfaceGridApi(get_client())
 
     @classmethod
     def from_domain_id(cls, domain_id: str) -> "SurfaceGrid":
@@ -42,7 +43,7 @@ class SurfaceGrid(SurfaceGridModel):
         >>> print(grid.status)
         'completed'
         """
-        response = _SURFACE_GRID_API.get_surface_grid(domain_id=domain_id)
+        response = self._SURFACE_GRID_API.get_surface_grid(domain_id=domain_id)
         return cls(domain_id=domain_id, **response.model_dump())
 
     def get(self, in_place: bool = False) -> "SurfaceGrid":
@@ -70,7 +71,7 @@ class SurfaceGrid(SurfaceGridModel):
         >>> # Or update the existing instance
         >>> grid.get(in_place=True)
         """
-        response = _SURFACE_GRID_API.get_surface_grid(domain_id=self.domain_id)
+        response = self._SURFACE_GRID_API.get_surface_grid(domain_id=self.domain_id)
         if in_place:
             # Update all attributes of current instance
             for key, value in response.model_dump().items():
@@ -195,7 +196,7 @@ class SurfaceGrid(SurfaceGridModel):
         >>> print(metadata.shape)
         [100, 100, 50]
         """
-        return _SURFACE_GRID_API.get_surface_grid_attribute_metadata(
+        return self._SURFACE_GRID_API.get_surface_grid_attribute_metadata(
             domain_id=self.domain_id
         )
 
@@ -222,7 +223,7 @@ class SurfaceGrid(SurfaceGridModel):
         >>> export.wait_until_completed()
         >>> export.to_file("grid_data.zarr")
         """
-        response = _SURFACE_GRID_API.create_surface_grid_export(
+        response = self._SURFACE_GRID_API.create_surface_grid_export(
             domain_id=self.domain_id, export_format=export_format
         )
         return Export(**response.model_dump())
@@ -250,7 +251,7 @@ class SurfaceGrid(SurfaceGridModel):
         >>> export.wait_until_completed()
         >>> export.to_file("grid_data.zarr")
         """
-        response = _SURFACE_GRID_API.get_surface_grid_export(
+        response = self._SURFACE_GRID_API.get_surface_grid_export(
             domain_id=self.domain_id, export_format=export_format
         )
         return Export(**response.model_dump())
@@ -274,5 +275,5 @@ class SurfaceGrid(SurfaceGridModel):
         >>> # Subsequent operations will raise NotFoundException
         >>> grid.get()  # raises NotFoundException
         """
-        _SURFACE_GRID_API.delete_surface_grid(domain_id=self.domain_id)
+        self._SURFACE_GRID_API.delete_surface_grid(domain_id=self.domain_id)
         return None

--- a/fastfuels_sdk/grids/topography_grid.py
+++ b/fastfuels_sdk/grids/topography_grid.py
@@ -14,13 +14,13 @@ from fastfuels_sdk.client_library.models import (
     GridAttributeMetadataResponse,
 )
 
-_TOPOGRAPHY_GRID_API = TopographyGridApi(get_client())
-
-
 class TopographyGrid(TopographyGridModel):
     """Topography grid data within a domain's spatial boundaries."""
 
     domain_id: str
+
+    def __init__(self, **kwargs):
+        self._TOPOGRAPHY_GRID_API = TopographyGridApi(get_client())
 
     @classmethod
     def from_domain_id(cls, domain_id: str) -> "TopographyGrid":
@@ -42,7 +42,7 @@ class TopographyGrid(TopographyGridModel):
         >>> print(grid.status)
         'completed'
         """
-        response = _TOPOGRAPHY_GRID_API.get_topography_grid(domain_id=domain_id)
+        response = self._TOPOGRAPHY_GRID_API.get_topography_grid(domain_id=domain_id)
         return cls(domain_id=domain_id, **response.model_dump())
 
     def get(self, in_place: bool = False) -> "TopographyGrid":
@@ -70,7 +70,7 @@ class TopographyGrid(TopographyGridModel):
         >>> # Or update the existing instance
         >>> grid.get(in_place=True)
         """
-        response = _TOPOGRAPHY_GRID_API.get_topography_grid(domain_id=self.domain_id)
+        response = self._TOPOGRAPHY_GRID_API.get_topography_grid(domain_id=self.domain_id)
         if in_place:
             # Update all attributes of current instance
             for key, value in response.model_dump().items():
@@ -195,7 +195,7 @@ class TopographyGrid(TopographyGridModel):
         >>> print(metadata.shape)
         [100, 100, 50]
         """
-        return _TOPOGRAPHY_GRID_API.get_topography_grid_attribute_metadata(
+        return self._TOPOGRAPHY_GRID_API.get_topography_grid_attribute_metadata(
             domain_id=self.domain_id
         )
 
@@ -222,7 +222,7 @@ class TopographyGrid(TopographyGridModel):
         >>> export.wait_until_completed()
         >>> export.to_file("grid_data.zarr")
         """
-        response = _TOPOGRAPHY_GRID_API.create_topography_grid_export(
+        response = self._TOPOGRAPHY_GRID_API.create_topography_grid_export(
             domain_id=self.domain_id, export_format=export_format
         )
         return Export(**response.model_dump())
@@ -250,7 +250,7 @@ class TopographyGrid(TopographyGridModel):
         >>> export.wait_until_completed()
         >>> export.to_file("grid_data.zarr")
         """
-        response = _TOPOGRAPHY_GRID_API.get_topography_grid_export(
+        response = self._TOPOGRAPHY_GRID_API.get_topography_grid_export(
             domain_id=self.domain_id, export_format=export_format
         )
         return Export(**response.model_dump())
@@ -274,5 +274,5 @@ class TopographyGrid(TopographyGridModel):
         >>> # Subsequent operations will raise NotFoundException
         >>> grid.get()  # raises NotFoundException
         """
-        _TOPOGRAPHY_GRID_API.delete_topography_grid(domain_id=self.domain_id)
+        self._TOPOGRAPHY_GRID_API.delete_topography_grid(domain_id=self.domain_id)
         return None

--- a/fastfuels_sdk/grids/tree_grid.py
+++ b/fastfuels_sdk/grids/tree_grid.py
@@ -14,13 +14,14 @@ from fastfuels_sdk.client_library.models import (
     GridAttributeMetadataResponse,
 )
 
-_TREE_GRID_API = TreeGridApi(get_client())
-
-
 class TreeGrid(TreeGridModel):
     """Tree grid data within a domain's spatial boundaries."""
 
     domain_id: str
+
+    def __init__(self, **kwargs):
+        super.__init__(**kwargs)
+        self._TREE_GRID_API = TreeGridApi(get_client())
 
     @classmethod
     def from_domain_id(cls, domain_id: str) -> TreeGrid:
@@ -42,7 +43,7 @@ class TreeGrid(TreeGridModel):
         >>> tree_grid.status
         'completed'
         """
-        response = _TREE_GRID_API.get_tree_grid(domain_id=domain_id)
+        response =self._TREE_GRID_API.get_tree_grid(domain_id=domain_id)
         return cls(domain_id=domain_id, **response.model_dump())
 
     def get(self, in_place: bool = False) -> TreeGrid:
@@ -70,7 +71,7 @@ class TreeGrid(TreeGridModel):
         >>> # Or update the existing instance
         >>> tree_grid.get(in_place=True)
         """
-        response = _TREE_GRID_API.get_tree_grid(domain_id=self.domain_id)
+        response =self._TREE_GRID_API.get_tree_grid(domain_id=self.domain_id)
         if in_place:
             # Update all attributes of current instance
             for key, value in response.model_dump().items():
@@ -182,7 +183,7 @@ class TreeGrid(TreeGridModel):
         >>> print(metadata.shape)
         [100, 100, 50]
         """
-        return _TREE_GRID_API.get_tree_grid_attribute_metadata(domain_id=self.domain_id)
+        returnself._TREE_GRID_API.get_tree_grid_attribute_metadata(domain_id=self.domain_id)
 
     def create_export(self, export_format: str) -> Export:
         """Create an export of the tree grid data.
@@ -207,7 +208,7 @@ class TreeGrid(TreeGridModel):
         >>> export.wait_until_completed()
         >>> export.to_file("grid_data.zarr")
         """
-        response = _TREE_GRID_API.create_tree_grid_export(
+        response =self._TREE_GRID_API.create_tree_grid_export(
             domain_id=self.domain_id, export_format=export_format
         )
         return Export(**response.model_dump())
@@ -234,7 +235,7 @@ class TreeGrid(TreeGridModel):
         >>> export.wait_until_completed()
         >>> export.to_file("grid_data.zarr")
         """
-        response = _TREE_GRID_API.get_tree_grid_export(
+        response =self._TREE_GRID_API.get_tree_grid_export(
             domain_id=self.domain_id, export_format=export_format
         )
         return Export(**response.model_dump())
@@ -258,5 +259,5 @@ class TreeGrid(TreeGridModel):
         >>> # Subsequent operations will raise NotFoundException
         >>> tree_grid.get()  # raises NotFoundException
         """
-        _TREE_GRID_API.delete_tree_grid(domain_id=self.domain_id)
+        self._TREE_GRID_API.delete_tree_grid(domain_id=self.domain_id)
         return None

--- a/fastfuels_sdk/inventories.py
+++ b/fastfuels_sdk/inventories.py
@@ -28,8 +28,8 @@ from fastfuels_sdk.client_library.models import (
 # External imports
 import requests
 
-_INVENTORIES_API = InventoriesApi(get_client())
-_TREE_INVENTORY_API = TreeInventoryApi(get_client())
+# _INVENTORIES_API = InventoriesApi(get_client())
+# _TREE_INVENTORY_API = TreeInventoryApi(get_client())
 
 
 class Inventories(InventoriesModel):
@@ -48,6 +48,11 @@ class Inventories(InventoriesModel):
 
     domain_id: str
     tree: Optional[TreeInventory]  # Override the default TreeInventoryModel type
+
+    def __init__(self, **kwargs):
+        self._INVENTORIES_API = InventoriesApi(get_client())
+        self._TREE_INVENTORY_API = TreeInventoryApi(get_client)
+        super.__init__(**kwargs)
 
     @classmethod
     def from_domain_id(cls, domain_id: str) -> Inventories:
@@ -73,7 +78,7 @@ class Inventories(InventoriesModel):
         >>> from fastfuels_sdk import Inventories
         >>> inventories = Inventories.from_domain_id("abc123")
         """
-        inventories_response = _INVENTORIES_API.get_inventories(domain_id=domain_id)
+        inventories_response = self._INVENTORIES_API.get_inventories(domain_id=domain_id)
         response_data = inventories_response.model_dump()
         response_data = _convert_api_models_to_sdk_classes(domain_id, response_data)
 
@@ -107,7 +112,7 @@ class Inventories(InventoriesModel):
         >>> # Fetch and update the inventory data in place
         >>> inventories.get(in_place=True)
         """
-        response = _INVENTORIES_API.get_inventories(domain_id=self.domain_id)
+        response = self._INVENTORIES_API.get_inventories(domain_id=self.domain_id)
         response_data = response.model_dump()
         response_data = _convert_api_models_to_sdk_classes(
             self.domain_id, response_data
@@ -254,7 +259,7 @@ class Inventories(InventoriesModel):
                 [feature_masks] if isinstance(feature_masks, str) else feature_masks
             ),
         )
-        response = _TREE_INVENTORY_API.create_tree_inventory(
+        response = self._TREE_INVENTORY_API.create_tree_inventory(
             self.domain_id, request_body
         )
         tree_inventory = TreeInventory(
@@ -528,7 +533,7 @@ class Inventories(InventoriesModel):
             raise ValueError(f"File must be a CSV: {file_path}")
 
         # Create tree inventory resource with "file" source
-        signed_url_response = _TREE_INVENTORY_API.create_tree_inventory(
+        signed_url_response = self._TREE_INVENTORY_API.create_tree_inventory(
             self.domain_id,
             CreateTreeInventoryRequest(sources=[TreeInventorySource.FILE]),
         )
@@ -620,6 +625,10 @@ class TreeInventory(TreeInventoryModel):
 
     domain_id: str
 
+    def __init__(self, **kwargs):
+        self._TREE_INVENTORY_API = TreeInventoryApi(get_client())
+        super.__init__(**kwargs)
+
     @classmethod
     def from_domain_id(cls, domain_id: str) -> TreeInventory:
         """
@@ -662,7 +671,7 @@ class TreeInventory(TreeInventoryModel):
         - Use get() to refresh the inventory data and wait_until_completed() to wait
           for processing to finish
         """
-        response = _TREE_INVENTORY_API.get_tree_inventory(domain_id=domain_id)
+        response = self._TREE_INVENTORY_API.get_tree_inventory(domain_id=domain_id)
         return cls(domain_id=domain_id, **response.model_dump())
 
     def get(self, in_place: bool = False):
@@ -727,7 +736,7 @@ class TreeInventory(TreeInventoryModel):
         - This method is often used in conjunction with wait_until_completed()
           to monitor the progress of tree inventory processing.
         """
-        response = _TREE_INVENTORY_API.get_tree_inventory(domain_id=self.domain_id)
+        response = self._TREE_INVENTORY_API.get_tree_inventory(domain_id=self.domain_id)
         if in_place:
             # Update all attributes of current instance
             for key, value in response.model_dump().items():
@@ -874,7 +883,7 @@ class TreeInventory(TreeInventoryModel):
         - Consider creating an export of important inventory data before deletion
           using create_export()
         """
-        _TREE_INVENTORY_API.delete_tree_inventory(domain_id=self.domain_id)
+        self._TREE_INVENTORY_API.delete_tree_inventory(domain_id=self.domain_id)
 
         return None
 
@@ -955,7 +964,7 @@ class TreeInventory(TreeInventoryModel):
           process - use get() to check status, wait_until_completed() to wait for
           completion, and to_file() to download
         """
-        response = _TREE_INVENTORY_API.create_tree_inventory_export(
+        response = self._TREE_INVENTORY_API.create_tree_inventory_export(
             domain_id=self.domain_id, export_format=export_format
         )
         return Export(**response.model_dump())
@@ -1019,7 +1028,7 @@ class TreeInventory(TreeInventoryModel):
           create_export().wait_until_completed() is simpler
         - Always check the export's status before attempting to download using to_file()
         """
-        response = _TREE_INVENTORY_API.get_tree_inventory_export(
+        response = self._TREE_INVENTORY_API.get_tree_inventory_export(
             domain_id=self.domain_id, export_format=export_format
         )
         return Export(**response.model_dump())


### PR DESCRIPTION
In response to issue #112

Anything outside of the `class` keyword in python code gets called statically upon import of that script. DomainApi(get_client) was being called when importing domain.py and, by extension, fastfuels_sdk. (This occurred in multiple instances, domain.py is just an example.) There's never an instance where statically calling the API is necessary, so I put the api calls in constructors for all the classes and called for the API within the one static function, that way the api's are only fetched when necessary.