### PR TITLE
Phase 2 prep: v2 dev dependencies and build exclude

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,14 @@ Homepage = "https://github.com/silvxlabs/fastfuels-sdk-python"
 "Bug Tracker" = "https://github.com/silvxlabs/fastfuels-sdk-python/issues"
 
 [dependency-groups]
-dev = ["pytest", "pre-commit", "ipykernel"]
+dev = [
+    "pytest",
+    "pre-commit",
+    "ipykernel",
+    "httpx>=0.23.0,<0.29.0",
+    "attrs>=22.2.0",
+    "python-dateutil>=2.9.0.post0",
+]
 docs = ["mkdocs", "mkdocs-material", "mkdocstrings", "mkdocstrings-python"]
 
 [tool.hatch.version]
@@ -44,8 +51,11 @@ source = "vcs"
 
 [tool.hatch.build]
 exclude = [
-    # Scratch v2 client; promoted to fastfuels_sdk/v2/client_library in Phase 2
-    "fastfuels_sdk/client_library_v2",
+    # v2 is under development and not yet distributable: its runtime deps
+    # (httpx, attrs, python-dateutil) live in the dev group until the v2
+    # preview ships. The Phase 2 release swaps this for fine-grained
+    # excludes (v2/*.sh, v2/COMPARISON.md, v2/draft_*.py), mirroring v1's.
+    "fastfuels_sdk/v2",
     # Client regeneration scaffolding — repo-only, not for distribution
     "fastfuels_sdk/v1/client_library/*.sh",
     "fastfuels_sdk/v1/client_library/README.md",

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,19 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "appnope"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -31,6 +44,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
 ]
 
 [[package]]
@@ -326,9 +348,12 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "attrs" },
+    { name = "httpx" },
     { name = "ipykernel" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "python-dateutil" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -351,9 +376,12 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "attrs", specifier = ">=22.2.0" },
+    { name = "httpx", specifier = ">=0.23.0,<0.29.0" },
     { name = "ipykernel" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "python-dateutil", specifier = ">=2.9.0.post0" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -434,6 +462,43 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The packaging slice of #173's Phase 2 prep — just `pyproject.toml` + `uv.lock`:

- **`httpx>=0.23.0,<0.29.0`, `attrs>=22.2.0`, `python-dateutil` added to the dev dependency group.** These are the runtime stack of the v2 generated client (openapi-python-client; see `fastfuels_sdk/v2/COMPARISON.md` once it lands via #176). They stay dev-only until the v2 preview ships, at which point they move to `[project.dependencies]`.
- **`fastfuels_sdk/v2` excluded from wheels/sdists.** v2 is under active development (#176–#180); without the exclude, a wheel built from a working tree containing v2 code would ship importable modules whose dependencies aren't declared. The Phase 2 preview release swaps this for fine-grained excludes mirroring v1's (`v2/*.sh`, `v2/COMPARISON.md`, drafts).
- Removes the build exclude for the `fastfuels_sdk/client_library_v2` scratch tree, which is deleted — superseded by the freshly regenerated client at `fastfuels_sdk/v2/client_library/` (landing via #176).

The v2 client library, draft wrappers, and generator-comparison record intentionally do **not** ride on this PR — they land through the #176 umbrella work (#177–#180).

## Verification

- `uv build` from a tree containing the v2 code: wheel contains exactly the top-level `__init__.py` + the 186-file `fastfuels_sdk/v1/` set (the verified 0.19.1-parity content) + dist-info; sdist equally clean — zero v2 leakage
- Editable dev install unaffected by the exclude: v1 surface and v2 modules both importable in the dev environment

Part of #173; unblocks #176