### PR TITLE
Fix fuel moisture examples to use percent instead of fractions

### DIFF
--- a/docs/v1/tutorials/export_to_quicfire.md
+++ b/docs/v1/tutorials/export_to_quicfire.md
@@ -181,7 +181,7 @@ surface_grid = (
         remove_non_burnable=["NB1", "NB2"],
     )
     .with_uniform_fuel_moisture(
-        value=0.15,
+        value=15.0,
         feature_masks=["road", "water"]
     )
     .build()
@@ -264,7 +264,7 @@ This replaces the manual `.with_uniform_fuel_moisture()` call from Step 8 above:
 surface_config = {
     "fuelMoisture": {
         "source": "uniform",
-        "value": 0.05,  # 5% moisture content
+        "value": 5,  # 5% moisture content
         "featureMasks": ["road", "water"]
     }
 }
@@ -356,7 +356,7 @@ surface_config = {
 
     "fuelMoisture": {
         "source": "uniform",  # Currently only uniform supported
-        "value": 0.15,        # Moisture content (0.0-1.0)
+        "value": 15,          # Moisture content (%)
         "featureMasks": ["road", "water"]
     }
 }
@@ -475,7 +475,7 @@ surface_config = {
     },
     "fuelMoisture": {
         "source": "uniform",
-        "value": 0.08,  # Very dry conditions (8%)
+        "value": 8,  # Very dry conditions (8%)
         "featureMasks": ["road"]
     }
 }
@@ -515,7 +515,7 @@ features_config = {
 surface_config = {
     "fuelMoisture": {
         "source": "uniform",
-        "value": 0.12,
+        "value": 12,
         "featureMasks": ["road"]  # Only road masks
     }
 }

--- a/fastfuels_sdk/v1/convenience.py
+++ b/fastfuels_sdk/v1/convenience.py
@@ -427,7 +427,7 @@ def export_roi(
                 },
                 "fuelMoisture": {
                     "source": "uniform",
-                    "value": 0.15,  # Fuel moisture content (0.0-1.0)
+                    "value": 15,  # Fuel moisture content (%)
                     "featureMasks": ["road", "water"]
                 }
             }
@@ -521,7 +521,7 @@ def export_roi(
     >>> surface_config = {
     ...     "fuelMoisture": {
     ...         "source": "uniform",
-    ...         "value": 0.05,
+    ...         "value": 5,
     ...         "featureMasks": ["road", "water"]
     ...     }
     ... }

--- a/fastfuels_sdk/v1/grids/grids.py
+++ b/fastfuels_sdk/v1/grids/grids.py
@@ -241,7 +241,7 @@ class Grids(GridsModel):
         >>> grid = grids.create_surface_grid(
         ...     attributes=["fuelLoad", "fuelMoisture"],
         ...     fuel_load={"source": "uniform", "value": 0.5},
-        ...     fuel_moisture={"source": "uniform", "value": 0.1}
+        ...     fuel_moisture={"source": "uniform", "value": 15.0}
         ... )
 
         See Also


### PR DESCRIPTION
## What

Fuel moisture is **percent** everywhere a user supplies it. The QUIC-Fire exporter divides by 100 (`fmc_array /= 100`) before writing `treesmoist.dat`, so a value of `0.08` stores `0.08%` and ends up as `0.0008` — near-zero moisture. Several docstrings and the export tutorial showed fractions, so users copying them got moisture 100× too low.

## Changes

- `docs/v1/tutorials/export_to_quicfire.md`: `0.15 → 15.0`, `0.05 → 5` (5%), `0.15 → 15`, `0.08 → 8` (8%), `0.12 → 12`; comment `(0.0-1.0) → (%)`.
- `fastfuels_sdk/v1/convenience.py`: `export_roi` default surface config `0.15 → 15`, "5%" example `0.05 → 5`; comment `(0.0-1.0) → (%)`.
- `fastfuels_sdk/v1/grids/grids.py`: `create_surface_grid` docstring example `0.1 → 15.0`.

Docs-only; no runtime behavior changes. The pipeline was already correct — builder methods, `guides/grids.md`, and tree-grid examples already used percent and are untouched.

## Reported by

A collaborator setting "8%" surface moisture followed the docs, sent `0.08`, and saw `0.08%` in their QUIC-Fire inputs; sending `8` produced the correct result.

Closes #186
