### PR TITLE
Require zarr>=3 so environments can open v2 API exports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,10 @@ dependencies = [
     "requests",
     "scipy",
     "urllib3>=2.1.0",
-    "zarr",
+    # Not imported by the SDK: present so environments can open the API's
+    # zipped-Zarr grid exports, which are written as format v3. zarr-python
+    # 2.x cannot read v3 at all.
+    "zarr>=3",
 ]
 
 [project.urls]


### PR DESCRIPTION
Client-side half of silvxlabs/FastFuels-API-v2#447. Paired with the API change that pins the zarr export to format v3 explicitly.

The SDK **never imports zarr** — the dependency exists so that a user's environment can open the zipped-Zarr grid exports the API hands out via signed download URLs. Those exports are Zarr format v3, and zarr-python 2.x cannot read v3 at all, so an unpinned `zarr` that resolves to 2.x leaves the user unable to open an export the SDK just downloaded for them.

This mainly affects v1 migrants:

```
v1:  zarr==2.18.2   -> exports were format v2
v2:  zarr 3.x       -> exports are format v3
```

An environment carried over from v1 can be sitting on a zarr that silently cannot read v2 exports. `zarr>=3` makes installing the SDK sufficient to open what it downloads.

## Changes

- `"zarr"` -> `"zarr>=3"` in `pyproject.toml`, with a comment explaining that the dep is not imported and exists to provision the user's environment.

## Release

Version is dynamic via `hatch-vcs`, so there's no version field to bump — this needs a tag/publish to reach users.
