### PR TITLE
Complete v2 post-regen SDK backlog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,18 @@
 Do NOT add "Co-Authored-By: Claude", "Generated with Claude Code", or any other
 AI-attribution lines to commit messages, PR descriptions, or GitHub issues.
 
+## Live API testing
+
+- Local live-test credentials are stored in the repository-root `.env`, which
+  is ignored by Git. The SDK authenticates with the `FASTFUELS_API_KEY` value
+  from that file.
+- Before running live tests, load `.env` into the current shell without
+  printing its contents: `set -a; source .env; set +a`.
+- Check and load `.env` before concluding that live API credentials are
+  unavailable or asking the user to provide them.
+- Never print, stage, commit, or copy credential values from `.env` into code,
+  documentation, logs, commit messages, pull requests, or issues.
+
 ## Documentation
 
 FastFuels has two documentation properties that must stay in concert:

--- a/docs/v2/SUMMARY.md
+++ b/docs/v2/SUMMARY.md
@@ -12,5 +12,5 @@
     * [Modify and treat inventories](guides/modify-treat-inventories.md)
     * [Point clouds](guides/point-clouds.md)
     * [Exports](guides/exports.md)
-    * [Quota rejections](guides/quotas.md)
+    * [Quotas and usage](guides/quotas.md)
 * [Reference](reference.md)

--- a/docs/v2/SUMMARY.md
+++ b/docs/v2/SUMMARY.md
@@ -7,6 +7,7 @@
     * [Features](guides/features.md)
     * Grids
         * [Creating grids](guides/creating-grids.md)
+        * [Composing grids](guides/composing-grids.md)
         * [Working with grids](guides/working-with-grids.md)
     * [Inventories](guides/inventories.md)
     * [Modify and treat inventories](guides/modify-treat-inventories.md)

--- a/docs/v2/SUMMARY.md
+++ b/docs/v2/SUMMARY.md
@@ -12,4 +12,5 @@
     * [Modify and treat inventories](guides/modify-treat-inventories.md)
     * [Point clouds](guides/point-clouds.md)
     * [Exports](guides/exports.md)
+    * [Quota rejections](guides/quotas.md)
 * [Reference](reference.md)

--- a/docs/v2/guides/composing-grids.md
+++ b/docs/v2/guides/composing-grids.md
@@ -1,0 +1,65 @@
+# How to Compose Grids
+
+!!! warning "Beta"
+    The v2 SDK targets the FastFuels v2 API and is under active
+    development. The v1 SDK remains the default — import v2 explicitly
+    from `fastfuels_sdk.v2`.
+
+Use grid composition to copy and calculate bands from completed grids on the
+same two-dimensional lattice. For creating the source grids, see
+[Creating grids](creating-grids.md); for alignment options, see
+[Align grids to each other](creating-grids.md#align-grids-to-each-other).
+
+## Prerequisites
+
+- The FastFuels SDK installed: `pip install fastfuels-sdk`
+- A FastFuels API key in the `FASTFUELS_API_KEY` environment variable
+- One or more completed 2D grids in the same domain, with the same CRS,
+  transform, and shape
+- For the example below, a completed FBFM40 grid assigned to `fbfm40`
+
+## Select and calculate output bands
+
+Give each input grid an alias. Use that alias when referring to its bands in
+select and compute operations:
+
+```python
+import fastfuels_sdk.v2 as ff
+
+fuel_grid = ff.grids.create_fuel_grid_from_fbfm40_lookup(
+    fbfm40,
+    bands=["fuel_load.1hr", "fuel_depth"],
+)
+fuel_grid.wait()
+
+composed = ff.grids.create_grid_from_compose(
+    {"fuels": fuel_grid},
+    select=[
+        ff.compose.select("fuel_depth", "fuels.fuel_depth"),
+    ],
+    compute=[
+        ff.compose.compute(
+            "fuel_load.1hr",
+            "multiply",
+            ["fuels.fuel_load.1hr", 0.5],
+            conditions=[
+                ff.compose.condition("fuels.fuel_load.1hr", "gt", 0),
+            ],
+            else_=ff.compose.literal(0, unit="kg/m**2"),
+        ),
+    ],
+)
+composed.wait()
+```
+
+The alias mapping can contain more than one grid. Every band reference uses
+the form `alias.band_key`; output names must be unique across the `select` and
+`compute` lists.
+
+The arithmetic operators are `add`, `subtract`, `multiply`, `divide`, `min`,
+`max`, and `average`. Conditions are ANDed together and require an `else_`
+fallback. A fallback may be another band, a number, a typed literal, a fuel
+model label, or an `ff.compose.inline_compute(...)` result.
+
+The API derives output units from compute operands. Pass `unit=` to
+`ff.compose.compute` only to request a dimensionally compatible output unit.

--- a/docs/v2/guides/creating-grids.md
+++ b/docs/v2/guides/creating-grids.md
@@ -170,13 +170,30 @@ fuels.wait()
 
 ### From FCCS instead
 
-Alternatively, build an already-parameterized fuels grid from the Fuel
-Characteristic Classification System (FCCS), skipping the lookup step:
+To use Fuel Characteristic Classification System (FCCS) fuelbeds, create the
+categorical source grid and wait for it to complete:
 
 ```python
-grid = ff.grids.create_fuel_model_grid_from_landfire_fccs(
+fccs = ff.grids.create_fuel_model_grid_from_landfire_fccs(
     domain, remove_bare_ground=True, output_resolution_m=30
 )
+fccs.wait()
+```
+
+Then look up any of the 12 available FCCS fuel-parameter bands, including
+duff and live components:
+
+```python
+fuels = ff.grids.create_fuel_grid_from_fccs_lookup(
+    fccs,
+    bands=[
+        "fuel_load.litter",
+        "fuel_load.duff",
+        "duff_depth",
+        "fuel_load.live_shrub",
+    ],
+)
+fuels.wait()
 ```
 
 FCCS takes the same alignment arguments as the other source grids

--- a/docs/v2/guides/creating-grids.md
+++ b/docs/v2/guides/creating-grids.md
@@ -200,6 +200,9 @@ FCCS takes the same alignment arguments as the other source grids
 (`output_resolution_m`, `align_to`, `align`, `resampling`) — see
 [Align grids to each other](#align-grids-to-each-other).
 
+To select and calculate bands across one or more completed grids, see
+[Compose grids](composing-grids.md).
+
 ## Canopy grids
 
 For crown-fire inputs, `create_canopy_fuel_grid_from_landfire` produces the

--- a/docs/v2/guides/creating-grids.md
+++ b/docs/v2/guides/creating-grids.md
@@ -142,6 +142,32 @@ fuels.wait()
 [('fuel_load.1hr', 'kg/m**2'), ('fuel_load.10hr', 'kg/m**2'), ('fuel_depth', 'm')]
 ```
 
+### Use Anderson 13 fuel models
+
+To create the Anderson 13 model set instead, select a LANDFIRE version and
+use the FBFM13 creator:
+
+```python
+grid = ff.grids.create_fuel_model_grid_from_landfire_fbfm13(
+    domain,
+    version="2024",
+    remove_non_burnable=["NB1", "NB2"],
+    output_resolution_m=30,
+)
+grid.wait()
+```
+
+Its categorical source band is `fbfm13`. Convert it to any of the nine
+FBFM13 parameter bands with the matching lookup:
+
+```python
+fuels = ff.grids.create_fuel_grid_from_fbfm13_lookup(
+    grid,
+    bands=["fuel_load.1hr", "fuel_load.live_foliage", "fuel_depth"],
+)
+fuels.wait()
+```
+
 ### From FCCS instead
 
 Alternatively, build an already-parameterized fuels grid from the Fuel

--- a/docs/v2/guides/creating-grids.md
+++ b/docs/v2/guides/creating-grids.md
@@ -250,6 +250,57 @@ before voxelizing (see
 For the concepts behind plot imputation and voxelization, see the
 [FastFuels documentation](https://docs.fastfuels.silvxlabs.com).
 
+### Derive surface fuels with DUET
+
+To create a two-dimensional DUET surface-fuel grid, include the three DUET
+input bands when voxelizing the inventory:
+
+```python
+voxels = inventory.voxelize(
+    horizontal_resolution_m=2,
+    vertical_resolution_m=1,
+    bands=[
+        "bulk_density.foliage.live",
+        "spcd",
+        "fuel_moisture.live",
+    ],
+)
+voxels.wait()
+```
+
+Build calibration targets from ordinary mappings, then pass them with the
+output bands and time since fire:
+
+```python
+calibration = ff.duet_calibration(
+    fuel_load={
+        "grass": {"mean": 0.5, "sd": 0.25},
+        "litter": {"max": 5, "min": 0},
+    },
+    fuel_depth={
+        "grass": {"value": 0.3},
+        "litter": {"value": 0.06},
+    },
+)
+
+surface = ff.grids.create_surface_fuel_grid_from_duet(
+    voxels,
+    years_since_burn=25,
+    bands=[
+        "fuel_load.grass",
+        "fuel_load.litter",
+        "fuel_depth.grass",
+        "fuel_depth.litter",
+    ],
+    calibration=calibration,
+)
+surface.wait()
+```
+
+Use a `value` target to set every occupied cell to a constant, `max` with an
+optional `min` to scale by extrema, or `mean` and `sd` to scale by moments.
+Omit `calibration` only when you want the raw DUET values.
+
 ## Uniform grids
 
 To fill the whole domain with constant band values at a chosen resolution —

--- a/docs/v2/guides/creating-grids.md
+++ b/docs/v2/guides/creating-grids.md
@@ -181,6 +181,18 @@ meta = ff.grids.create_canopy_height_grid_from_meta(domain, output_resolution_m=
 naip = ff.grids.create_canopy_height_grid_from_naip_chm(domain, output_resolution_m=1)
 ```
 
+To rasterize a completed airborne point cloud into the same `chm` band, pass
+the point cloud directly. The output defaults to 1 m cells:
+
+```python
+chm = ff.grids.create_canopy_height_grid_from_point_cloud(point_cloud)
+chm.wait()
+```
+
+Use `output_resolution_m` or `align_to` to choose a different lattice. See the
+[Point clouds guide](point-clouds.md#create-a-point-cloud-from-usgs-3dep) to
+create an airborne point cloud from USGS 3DEP.
+
 !!! tip "NAIP-CHM is a surface model"
     NAIP-CHM is a digital surface model and retains buildings and other
     infrastructure. To keep only vegetation, mask out built-up areas — see

--- a/docs/v2/guides/exports.md
+++ b/docs/v2/guides/exports.md
@@ -8,13 +8,14 @@
 An export packages a resource's data into a downloadable file: a
 [grid](working-with-grids.md) as GeoTIFF/NetCDF/zarr, an
 [inventory](inventories.md) as Parquet/CSV/GeoJSON/GeoPackage, or several
-grids bundled into a QUIC-Fire-loadable archive. Exports run as background
-jobs and expose a signed download URL on completion.
+grids assembled into a fire-behavior landscape or QUIC-Fire-loadable archive.
+Exports run as background jobs and expose a signed download URL on completion.
 
 The pattern is the same everywhere: exporting a resource you **hold** is a
 method on it (`grid.export(...)`, `inventory.export(...)`); the QUIC-Fire
-bundle is **assembled from many** grids, so it is a module-level function
-(`ff.exports.create_quicfire_export(...)`).
+bundle and landscape are **assembled from many** grids, so they are
+module-level functions (`ff.exports.create_quicfire_export(...)` and
+`ff.exports.create_landscape_export(...)`).
 
 ## Prerequisites
 
@@ -63,6 +64,35 @@ path = export.wait().to_file("trees.csv")
 >>> path.read_text().splitlines()[0]
 'x,y,fia_species_code,fia_status_code,dbh,height,crown_ratio'
 ```
+
+## Create a fire-behavior landscape
+
+To create an 8-band LANDFIRE-style GeoTIFF for FlamMap, IFTDSS, or WFDSS,
+assign the terrain, fuel-model, and canopy roles to completed 30 m grids:
+
+```python
+export = ff.exports.create_landscape_export(
+    domain,
+    fire_behavior_fuel_model="fbfm40",
+    elevation=(topography, "elevation"),
+    slope=(topography, "slope"),
+    aspect=(topography, "aspect"),
+    fuel_model=(fuel_models, "fbfm"),
+    canopy_cover=(canopy, "cc"),
+    canopy_height=(canopy, "chm"),
+    canopy_base_height=(canopy, "cbh"),
+    canopy_bulk_density=(canopy, "cbd"),
+    name="Landscape",
+)
+export.wait().to_file("landscape.tif")
+```
+
+Use `fire_behavior_fuel_model="fbfm13"` with an FBFM13 source. To export a
+different domain-anchored cell size, pass `resolution_m=` after building all
+role grids at that resolution. To preserve an existing lattice instead, pass
+`align_to=<grid>`. The exporter can crop oversized inputs but does not
+resample or reproject them; use the grid alignment options before exporting
+if the API reports an alignment error.
 
 ## Bundle grids for QUIC-Fire
 
@@ -146,10 +176,11 @@ export = ff.get_export("4a56bae0cd5e481aa1617cb894a9a7f3")
 ## List exports
 
 To list your exports, optionally narrowed to a domain, a source name
-(the format, or `"quicfire"` for bundles), or a tag:
+(the format, `"landscape"`, or `"quicfire"`), or a tag:
 
 ```python
 exports = ff.list_exports(domain)
+landscapes = ff.list_exports(source="landscape")
 bundles = ff.list_exports(source="quicfire")
 tagged = ff.list_exports(tag="run-42")
 ```

--- a/docs/v2/guides/features.md
+++ b/docs/v2/guides/features.md
@@ -243,6 +243,16 @@ osm_features = ff.list_features(domain, product="osm")
 tagged = ff.list_features(domain, tag="roads")
 ```
 
+Sort a page by name, creation time, or modification time:
+
+```python
+newest_first = ff.list_features(
+    domain,
+    sort_by="created_on",
+    sort_order="descending",
+)
+```
+
 ## Delete a Feature
 
 To permanently delete a feature and its generated data:

--- a/docs/v2/guides/inventories.md
+++ b/docs/v2/guides/inventories.md
@@ -170,8 +170,8 @@ Inventory 7b02df6f583a418da3ec9929037d876d: completed (5s)
 ## Access the tree records
 
 For most workflows, `to_dataframe()` (shown above) is all you need — it
-retrieves every partition and assembles one DataFrame. Pass `columns=` to
-retrieve a subset.
+retrieves each partition through the CSV endpoint, parses it with pandas, and
+assembles one DataFrame. Pass `columns=` to retrieve a subset.
 
 The records are served in fixed-size partitions; to control retrieval
 partition by partition (useful for large inventories), read the partition
@@ -186,6 +186,17 @@ layout first:
 >>> partition = inventory.get_data_partition(0)
 >>> partition.num_rows
 34831
+```
+
+`get_data_partition` uses the compact `"split"` JSON layout by default, where
+each row in `partition.data` follows `partition.columns`. To receive
+self-describing row mappings instead, request the `"records"` layout:
+
+```python
+partition = inventory.get_data_partition(
+    0, columns=["x", "y", "height"], json_orientation="records"
+)
+first_tree = partition.data[0]
 ```
 
 Data is only available once the inventory is `"completed"` — earlier calls

--- a/docs/v2/guides/inventories.md
+++ b/docs/v2/guides/inventories.md
@@ -191,6 +191,30 @@ layout first:
 Data is only available once the inventory is `"completed"` — earlier calls
 raise `UnprocessableEntityException`.
 
+## Inspect stand-level forestry metrics
+
+Once a tree inventory completes, read its server-computed forestry metrics
+without downloading the tree records:
+
+```python
+metrics = inventory.forestry_metrics
+
+tree_count = metrics.tree_count
+basal_area_per_acre = metrics.basal_area_per_area
+trees_per_acre = metrics.tree_density
+quadratic_mean_diameter_inches = metrics.quadratic_mean_diameter
+
+dominant_groups = [
+    (group.spgrpcd, group.name, group.basal_area_share)
+    for group in metrics.dominant_species_groups
+]
+```
+
+`dominant_species_groups` is ordered by decreasing basal-area share and
+contains the leading FIA species groups. Only the leading groups are returned,
+so their shares may sum to less than one. `forestry_metrics` is `None` when
+metrics are unavailable, including before processing completes.
+
 ## Reshape the trees
 
 Every creator accepts `modifications=` (rules that filter trees by conditions

--- a/docs/v2/guides/inventories.md
+++ b/docs/v2/guides/inventories.md
@@ -191,6 +191,27 @@ layout first:
 Data is only available once the inventory is `"completed"` — earlier calls
 raise `UnprocessableEntityException`.
 
+## Summarize a column without downloading records
+
+Once an inventory completes, inspect a column's server-computed summary by
+passing its key to `column_summary`:
+
+```python
+dbh = inventory.column_summary("dbh")
+mean_dbh = dbh.mean
+minimum_dbh = dbh.min_
+maximum_dbh = dbh.max_
+
+species = inventory.column_summary("fia_species_code")
+species_count = species.unique_count
+```
+
+A continuous column reports `count`, `null_count`, `min_`, `max_`, `mean`, and
+`std`; a categorical column reports `count`, `null_count`, and `unique_count`.
+The `type_` field identifies the shape. `column_summary` returns `None` when
+the requested column exists but its summary is unavailable; an unknown column
+key raises `ValueError`.
+
 ## Inspect stand-level forestry metrics
 
 Once a tree inventory completes, read its server-computed forestry metrics

--- a/docs/v2/guides/migration.md
+++ b/docs/v2/guides/migration.md
@@ -46,9 +46,9 @@ Available now — see the [Domains guide](domains.md) and the
   `horizontal_resolution`/`vertical_resolution`. Use the optional
   `pad_to_resolution` argument to pad the domain bounding box outward so
   grids of that resolution align with it.
-- **Responses are richer.** A v2 domain carries two named GeoJSON
-  features: `"domain"` (the projected working extent) and `"input"`
-  (your original geometry).
+- **Responses carry the working extent.** A v2 domain contains one named
+  GeoJSON feature, `"domain"`: the projected bounding box used by child
+  resources. Keep the original input geometry separately if you need it.
 - **GeoDataFrame CRS is honored.** `from_geodataframe` forwards the
   GeoDataFrame's CRS to the API, so projected inputs (e.g. EPSG:5070)
   are interpreted correctly. The v1 SDK assumed EPSG:4326.

--- a/docs/v2/guides/modify-treat-inventories.md
+++ b/docs/v2/guides/modify-treat-inventories.md
@@ -92,9 +92,10 @@ thinned.wait()
 ## Apply to an inventory you hold
 
 `apply_modifications` and `apply_treatments` reshape an inventory **in place**:
-the submitted rules are appended to the inventory's cumulative `modifications`
-/ `treatments` list, its ID is kept, and the data is re-derived as a background
-job — the inventory returns to `"pending"`, so `wait()` before using it again.
+its ID is kept and the data is re-derived as a background job. The submitted
+rules are queued while the inventory is `"pending"`, then appended to the
+cumulative `modifications` / `treatments` list when processing completes. Call
+`wait()` before using the inventory again or reading those ledgers.
 
 ```python
 inventory.apply_treatments([ff.basal_area_treatment("from_below", 25.0)])

--- a/docs/v2/guides/point-clouds.md
+++ b/docs/v2/guides/point-clouds.md
@@ -5,15 +5,15 @@
     development. The v1 SDK remains the default — import v2 explicitly
     from `fastfuels_sdk.v2`.
 
-A point cloud is a 3D LiDAR dataset within a domain, uploaded from your own
-airborne (ALS) or terrestrial (TLS) scan. For what point clouds *are* and how
-they fit the platform, see the
+A point cloud is a 3D LiDAR dataset within a domain, fetched from USGS 3DEP or
+uploaded from your own airborne (ALS) or terrestrial (TLS) scan. For what
+point clouds *are* and how they fit the platform, see the
 [FastFuels documentation](https://docs.fastfuels.silvxlabs.com); this guide
-covers uploading and managing them from Python.
+covers creating and managing them from Python.
 
-The v2 surface is functional: you **create** a point cloud by uploading a file
-to a domain, and everything you do with one you already hold is a **method** on
-it.
+The v2 surface is functional: you **create** a point cloud from a domain and
+data source, and everything you do with one you already hold is a **method**
+on it.
 
 ```python
 import fastfuels_sdk.v2 as ff
@@ -30,7 +30,43 @@ pc.wait()
 - A FastFuels API key in the `FASTFUELS_API_KEY` environment variable
 - An existing [domain](domains.md) — the first argument is a `Domain` (or a
   bare domain id string)
-- A local LiDAR file (`.las`/`.laz`)
+- A local LiDAR file (`.las`/`.laz`) when uploading your own scan
+
+## Create a point cloud from USGS 3DEP
+
+Check coverage and the per-fetch point budget before starting the background
+job:
+
+```python
+coverage = ff.point_clouds.check_3dep_coverage(domain)
+
+if not coverage.available:
+    raise RuntimeError("No 3DEP LiDAR covers this domain")
+if coverage.exceeds_point_budget:
+    raise RuntimeError("Shrink the domain before fetching 3DEP LiDAR")
+```
+
+Create the point cloud with automatic acquisition selection:
+
+```python
+pc = ff.point_clouds.create_point_cloud_from_3dep(
+    domain,
+    name="USGS 3DEP",
+)
+pc.wait()
+```
+
+To pin specific acquisitions, pass names returned by the coverage check in
+priority order:
+
+```python
+pc = ff.point_clouds.create_point_cloud_from_3dep(
+    domain,
+    datasets=[coverage.datasets[0].name],
+)
+```
+
+The returned point cloud is always airborne (`type_ == "als"`).
 
 ## Upload a point cloud
 

--- a/docs/v2/guides/point-clouds.md
+++ b/docs/v2/guides/point-clouds.md
@@ -141,4 +141,6 @@ except NotFoundException:
 
 ## Next steps
 
+- Turn a completed airborne point cloud into a canopy-height grid with
+  [`create_canopy_height_grid_from_point_cloud`](creating-grids.md#canopy-grids)
 - Full signatures — see the [Reference](../reference.md)

--- a/docs/v2/guides/quotas.md
+++ b/docs/v2/guides/quotas.md
@@ -1,0 +1,41 @@
+# How to Handle Quota Rejections
+
+!!! warning "Beta"
+    The v2 SDK targets the FastFuels v2 API and is under active
+    development. The v1 SDK remains the default — import v2 explicitly
+    from `fastfuels_sdk.v2`.
+
+## Prerequisites
+
+- The FastFuels SDK installed: `pip install fastfuels-sdk`
+- A FastFuels API key in the `FASTFUELS_API_KEY` environment variable
+
+Use this guide to handle quota rejections from SDK resource creators.
+
+## Handle a quota rejection
+
+Catch `QuotaExceededException` around any operation that creates or re-derives
+a resource:
+
+```python
+import fastfuels_sdk.v2 as ff
+from fastfuels_sdk.v2.exceptions import QuotaExceededException
+
+try:
+    grid = ff.grids.create_topography_grid_from_3dep(
+        domain,
+        output_resolution_m=30,
+    )
+except QuotaExceededException as exc:
+    print(exc.quota, exc.current, exc.limit)
+    print(exc.message)
+    if exc.retry_after is not None:
+        print(f"Retry in {exc.retry_after} seconds")
+```
+
+For an active-job limit, `retry_after` contains the number of seconds the API
+recommends waiting before another attempt.
+
+For a weekly dispatch limit, `window_reset_on` contains the reset time. Count
+and storage limits provide neither retry field; delete unneeded resources or
+request a higher limit before retrying.

--- a/docs/v2/guides/quotas.md
+++ b/docs/v2/guides/quotas.md
@@ -1,4 +1,4 @@
-# How to Handle Quota Rejections
+# How to Check Usage and Handle Quota Rejections
 
 !!! warning "Beta"
     The v2 SDK targets the FastFuels v2 API and is under active
@@ -10,7 +10,49 @@
 - The FastFuels SDK installed: `pip install fastfuels-sdk`
 - A FastFuels API key in the `FASTFUELS_API_KEY` environment variable
 
-Use this guide to handle quota rejections from SDK resource creators.
+Use this guide to inspect the current owner's limits and usage and to handle
+quota rejections from SDK resource creators.
+
+## Check your limits
+
+Call `get_quotas` to retrieve the limits resolved for the owner authenticated
+by the current API key:
+
+```python
+import fastfuels_sdk.v2 as ff
+
+quotas = ff.get_quotas()
+
+print(quotas.max_active_grids)
+print(quotas.max_weekly_grid_dispatches)
+print(quotas.max_grid_storage_bytes)
+```
+
+## Check your current usage
+
+Call `get_usage` to compare current usage with the corresponding limits:
+
+```python
+usage = ff.get_usage()
+
+print(usage.grids.active.usage, usage.grids.active.limit)
+print(usage.grids.total.usage, usage.grids.total.limit)
+print(usage.grids.storage.usage_bytes, usage.grids.storage.limit_bytes)
+```
+
+Count-only resources are available through `usage.domains`,
+`usage.applications`, and `usage.api_keys`. The active, total, and storage
+fields are also available for exports, inventories, features, and point
+clouds.
+
+Inspect `usage.lifecycle` for the resource-retention policy currently applied
+to the owner:
+
+```python
+print(usage.lifecycle.resource_ttl_days)
+print(usage.lifecycle.failed_resource_ttl_days)
+print(usage.lifecycle.next_expiry_on)
+```
 
 ## Handle a quota rejection
 

--- a/docs/v2/index.md
+++ b/docs/v2/index.md
@@ -45,3 +45,7 @@ from fastfuels_sdk.v2 import Domain   # v2 (Beta)
 ```
 
 Coming from v1? Start with [Migrating from v1](guides/migration.md).
+
+The SDK authenticates with an existing API key. Creating applications and
+creating, rotating, or revoking keys are account-management operations handled
+outside the high-level Python SDK through the FastFuels console.

--- a/docs/v2/reference.md
+++ b/docs/v2/reference.md
@@ -14,6 +14,8 @@
 
 ::: fastfuels_sdk.v2.treatments
 
+::: fastfuels_sdk.v2.calibrations
+
 ::: fastfuels_sdk.v2._jobs
 
 ::: fastfuels_sdk.v2.api

--- a/docs/v2/reference.md
+++ b/docs/v2/reference.md
@@ -16,6 +16,8 @@
 
 ::: fastfuels_sdk.v2.calibrations
 
+::: fastfuels_sdk.v2.compose
+
 ::: fastfuels_sdk.v2._jobs
 
 ::: fastfuels_sdk.v2.api

--- a/fastfuels_sdk/v2/__init__.py
+++ b/fastfuels_sdk/v2/__init__.py
@@ -20,7 +20,7 @@ package namespace::
 
 from fastfuels_sdk.v2 import exports, features, grids, inventories, point_clouds
 from fastfuels_sdk.v2._jobs import JobFailedError, wait_all
-from fastfuels_sdk.v2.api import set_api_key
+from fastfuels_sdk.v2.api import get_quotas, get_usage, set_api_key
 from fastfuels_sdk.v2.domains import Domain, list_domains, reproject_geojson
 from fastfuels_sdk.v2.exports import Export, get_export, list_exports
 from fastfuels_sdk.v2.features import Feature, get_feature, list_features
@@ -49,6 +49,9 @@ __all__ = [
     "point_clouds",
     # Configuration
     "set_api_key",
+    # Quotas and usage
+    "get_quotas",
+    "get_usage",
     # Records
     "Domain",
     "Export",

--- a/fastfuels_sdk/v2/__init__.py
+++ b/fastfuels_sdk/v2/__init__.py
@@ -18,7 +18,14 @@ package namespace::
   ``ff.list_grids``, ``ff.wait_all``, ``ff.set_api_key``.
 """
 
-from fastfuels_sdk.v2 import exports, features, grids, inventories, point_clouds
+from fastfuels_sdk.v2 import (
+    compose,
+    exports,
+    features,
+    grids,
+    inventories,
+    point_clouds,
+)
 from fastfuels_sdk.v2._jobs import JobFailedError, wait_all
 from fastfuels_sdk.v2.api import get_quotas, get_usage, set_api_key
 from fastfuels_sdk.v2.calibrations import duet_calibration
@@ -43,6 +50,7 @@ from fastfuels_sdk.v2.treatments import basal_area_treatment, diameter_treatment
 
 __all__ = [
     # Submodules (resource creators live here: ff.grids.create_*, ff.features.create_*)
+    "compose",
     "exports",
     "features",
     "grids",

--- a/fastfuels_sdk/v2/__init__.py
+++ b/fastfuels_sdk/v2/__init__.py
@@ -21,6 +21,7 @@ package namespace::
 from fastfuels_sdk.v2 import exports, features, grids, inventories, point_clouds
 from fastfuels_sdk.v2._jobs import JobFailedError, wait_all
 from fastfuels_sdk.v2.api import get_quotas, get_usage, set_api_key
+from fastfuels_sdk.v2.calibrations import duet_calibration
 from fastfuels_sdk.v2.domains import Domain, list_domains, reproject_geojson
 from fastfuels_sdk.v2.exports import Export, get_export, list_exports
 from fastfuels_sdk.v2.features import Feature, get_feature, list_features
@@ -52,6 +53,8 @@ __all__ = [
     # Quotas and usage
     "get_quotas",
     "get_usage",
+    # Calibrations
+    "duet_calibration",
     # Records
     "Domain",
     "Export",

--- a/fastfuels_sdk/v2/api.py
+++ b/fastfuels_sdk/v2/api.py
@@ -13,7 +13,10 @@ from typing import Optional
 # deployment for now — a stable domain should front it before GA (tracked in
 # #176); until then FASTFUELS_API_V2_URL overrides it without an SDK upgrade.
 from fastfuels_sdk.v2.client_library.base_url import DEFAULT_BASE_URL
+from fastfuels_sdk.v2.client_library.api.users import get_me, get_me_usage
 from fastfuels_sdk.v2.client_library.client import AuthenticatedClient
+from fastfuels_sdk.v2.client_library.models import Quotas, Usage
+from fastfuels_sdk.v2.exceptions import expect
 
 _client: Optional[AuthenticatedClient] = None
 
@@ -96,3 +99,42 @@ def ensure_client() -> AuthenticatedClient:
             "before making API calls"
         )
     return client
+
+
+def get_quotas() -> Quotas:
+    """Return the authenticated owner's resolved quotas.
+
+    Returns
+    -------
+    Quotas
+        Count, concurrency, storage, dispatch, and retention limits for the
+        owner authenticated by the current API key.
+
+    Raises
+    ------
+    RuntimeError
+        If no API key is configured.
+    ApiException
+        If the API request fails.
+    """
+    owner = expect(get_me.sync_detailed(client=ensure_client()))
+    return owner.quotas
+
+
+def get_usage() -> Usage:
+    """Return the authenticated owner's current usage and limits.
+
+    Returns
+    -------
+    Usage
+        Usage for job resources, count-only resources, storage, and the
+        owner's resource-retention policy.
+
+    Raises
+    ------
+    RuntimeError
+        If no API key is configured.
+    ApiException
+        If the API request fails.
+    """
+    return expect(get_me_usage.sync_detailed(client=ensure_client()))

--- a/fastfuels_sdk/v2/calibrations.py
+++ b/fastfuels_sdk/v2/calibrations.py
@@ -1,0 +1,196 @@
+"""Calibration builders for generated v2 request models."""
+
+from collections.abc import Mapping
+from numbers import Real
+
+from fastfuels_sdk.v2.client_library.models import (
+    DuetCalibration,
+    DuetConstantCalibrationTarget,
+    DuetMaxMinCalibrationTarget,
+    DuetMeanSdCalibrationTarget,
+    DuetParameterCalibration,
+)
+from fastfuels_sdk.v2.client_library.types import UNSET
+
+__all__ = ["duet_calibration"]
+
+_DUET_FUEL_TYPES = {"grass", "coniferous", "deciduous", "litter", "all"}
+_DUET_TARGET_TYPES = (
+    DuetConstantCalibrationTarget,
+    DuetMaxMinCalibrationTarget,
+    DuetMeanSdCalibrationTarget,
+)
+
+
+def duet_calibration(
+    *,
+    fuel_load=None,
+    fuel_depth=None,
+    fuel_moisture=None,
+) -> DuetCalibration:
+    """Build calibration targets for a DUET surface-fuel grid.
+
+    Each argument maps fuel types (``"grass"``, ``"coniferous"``,
+    ``"deciduous"``, ``"litter"``, or ``"all"``) to a target. Target fields
+    select the calibration method: ``value`` for constant, ``max`` and
+    optional ``min`` for max-min, or ``mean`` and ``sd`` for mean-standard
+    deviation. An explicit ``method`` field is also accepted.
+
+    Parameters
+    ----------
+    fuel_load : mapping, optional
+        Per-fuel-type load targets.
+    fuel_depth : mapping, optional
+        Per-fuel-type depth targets.
+    fuel_moisture : mapping, optional
+        Per-fuel-type moisture targets.
+
+    Returns
+    -------
+    DuetCalibration
+        Calibration for
+        :func:`fastfuels_sdk.v2.grids.create_surface_fuel_grid_from_duet`.
+
+    Raises
+    ------
+    TypeError
+        If a parameter or target is not a mapping or generated target model.
+    ValueError
+        If no parameter is provided, a target is invalid, or mutually
+        exclusive fuel types are combined.
+
+    Examples
+    --------
+    >>> import fastfuels_sdk.v2 as ff
+    >>> calibration = ff.duet_calibration(
+    ...     fuel_load={
+    ...         "grass": {"mean": 0.5, "sd": 0.25},
+    ...         "litter": {"max": 5.0, "min": 0.0},
+    ...     },
+    ...     fuel_depth={
+    ...         "grass": {"value": 0.3},
+    ...         "litter": {"value": 0.06},
+    ...     },
+    ... )
+    """
+    parameters = {
+        "fuel_load": fuel_load,
+        "fuel_depth": fuel_depth,
+        "fuel_moisture": fuel_moisture,
+    }
+    if not any(value is not None for value in parameters.values()):
+        raise ValueError(
+            "duet_calibration requires at least one of fuel_load, fuel_depth, "
+            "or fuel_moisture."
+        )
+
+    return DuetCalibration(
+        **{
+            name: _duet_parameter(value, name) if value is not None else UNSET
+            for name, value in parameters.items()
+        }
+    )
+
+
+def _duet_parameter(value, parameter: str) -> DuetParameterCalibration:
+    if isinstance(value, DuetParameterCalibration):
+        value = value.to_dict()
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{parameter} must be a mapping of fuel types to targets.")
+    if not value:
+        raise ValueError(f"{parameter} requires at least one fuel-type target.")
+
+    unknown = set(value) - _DUET_FUEL_TYPES
+    if unknown:
+        raise ValueError(
+            f"Unknown {parameter} fuel types: {sorted(unknown)}. Use one of "
+            f"{sorted(_DUET_FUEL_TYPES)}."
+        )
+    if "all" in value and len(value) > 1:
+        raise ValueError(
+            f"{parameter} 'all' cannot be combined with per-fuel-type targets."
+        )
+    if "litter" in value and ({"coniferous", "deciduous"} & set(value)):
+        raise ValueError(
+            f"{parameter} 'litter' cannot be combined with 'coniferous' or "
+            "'deciduous'."
+        )
+
+    targets = {
+        name: _duet_target(target, f"{parameter}.{name}")
+        for name, target in value.items()
+    }
+    if "all" in targets:
+        targets["all_"] = targets.pop("all")
+    return DuetParameterCalibration(**targets)
+
+
+def _duet_target(value, path: str):
+    if isinstance(value, _DUET_TARGET_TYPES):
+        value = value.to_dict()
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{path} must be a calibration-target mapping.")
+
+    data = dict(value)
+    method = data.pop("method", None)
+    if method is None:
+        method = _infer_duet_method(data, path)
+
+    if method == "constant":
+        _require_fields(data, path, required={"value"})
+        return DuetConstantCalibrationTarget(value=_nonnegative(data["value"], path))
+    if method == "maxmin":
+        _require_fields(data, path, required={"max"}, optional={"min"})
+        maximum = _nonnegative(data["max"], f"{path}.max")
+        minimum = _nonnegative(data.get("min", 0.0), f"{path}.min")
+        if maximum < minimum:
+            raise ValueError(f"{path}.max must be greater than or equal to min.")
+        return DuetMaxMinCalibrationTarget(max_=maximum, min_=minimum)
+    if method == "meansd":
+        _require_fields(data, path, required={"mean", "sd"})
+        return DuetMeanSdCalibrationTarget(
+            mean=_nonnegative(data["mean"], f"{path}.mean"),
+            sd=_nonnegative(data["sd"], f"{path}.sd"),
+        )
+    raise ValueError(
+        f"Unknown calibration method {method!r} for {path}. Use 'constant', "
+        "'maxmin', or 'meansd'."
+    )
+
+
+def _infer_duet_method(data: Mapping, path: str) -> str:
+    fields = set(data)
+    if "value" in fields:
+        return "constant"
+    if fields & {"max", "min"}:
+        return "maxmin"
+    if fields & {"mean", "sd"}:
+        return "meansd"
+    raise ValueError(
+        f"Cannot infer a calibration method for {path}; provide value, max, "
+        "or mean and sd."
+    )
+
+
+def _require_fields(
+    data: Mapping,
+    path: str,
+    *,
+    required: set[str],
+    optional: set[str] | None = None,
+) -> None:
+    optional = optional or set()
+    missing = required - set(data)
+    if missing:
+        raise ValueError(f"{path} is missing required fields: {sorted(missing)}.")
+    extra = set(data) - required - optional
+    if extra:
+        raise ValueError(f"{path} has fields not used by this method: {sorted(extra)}.")
+
+
+def _nonnegative(value, path: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise TypeError(f"{path} must be a number.")
+    if value < 0:
+        raise ValueError(f"{path} must be nonnegative.")
+    return float(value)

--- a/fastfuels_sdk/v2/client_library/api/applications/create_application.py
+++ b/fastfuels_sdk/v2/client_library/api/applications/create_application.py
@@ -8,6 +8,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.application import Application
 from ...models.create_application_request import CreateApplicationRequest
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -32,7 +33,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Application | HTTPValidationError | None:
+) -> Application | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Application.from_dict(response.json())
 
@@ -43,6 +44,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -51,7 +57,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Application | HTTPValidationError]:
+) -> Response[Application | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -64,7 +70,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateApplicationRequest,
-) -> Response[Application | HTTPValidationError]:
+) -> Response[Application | HTTPValidationError | QuotaExceededDetail]:
     """Create an application
 
      Create a new application. Only personal-access users can create applications.
@@ -77,7 +83,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Application | HTTPValidationError]
+        Response[Application | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -95,7 +101,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateApplicationRequest,
-) -> Application | HTTPValidationError | None:
+) -> Application | HTTPValidationError | QuotaExceededDetail | None:
     """Create an application
 
      Create a new application. Only personal-access users can create applications.
@@ -108,7 +114,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Application | HTTPValidationError
+        Application | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -121,7 +127,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateApplicationRequest,
-) -> Response[Application | HTTPValidationError]:
+) -> Response[Application | HTTPValidationError | QuotaExceededDetail]:
     """Create an application
 
      Create a new application. Only personal-access users can create applications.
@@ -134,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Application | HTTPValidationError]
+        Response[Application | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -150,7 +156,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateApplicationRequest,
-) -> Application | HTTPValidationError | None:
+) -> Application | HTTPValidationError | QuotaExceededDetail | None:
     """Create an application
 
      Create a new application. Only personal-access users can create applications.
@@ -163,7 +169,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Application | HTTPValidationError
+        Application | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/applications/get_application_usage.py
+++ b/fastfuels_sdk/v2/client_library/api/applications/get_application_usage.py
@@ -1,0 +1,181 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.usage import Usage
+from ...types import Response
+
+
+def _get_kwargs(
+    application_id: str,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/applications/{application_id}/usage".format(
+            application_id=quote(str(application_id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Usage | None:
+    if response.status_code == 200:
+        response_200 = Usage.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Usage]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    application_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[HTTPValidationError | Usage]:
+    """Get an application's usage
+
+     Get an owned application's usage against its resolved limits, per resource type.
+
+    Same shape as `GET /users/me/usage`, for an application the caller owns —
+    so a user can read an application's usage without authenticating as it.
+
+    Args:
+        application_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Usage]
+    """
+
+    kwargs = _get_kwargs(
+        application_id=application_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    application_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> HTTPValidationError | Usage | None:
+    """Get an application's usage
+
+     Get an owned application's usage against its resolved limits, per resource type.
+
+    Same shape as `GET /users/me/usage`, for an application the caller owns —
+    so a user can read an application's usage without authenticating as it.
+
+    Args:
+        application_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Usage
+    """
+
+    return sync_detailed(
+        application_id=application_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    application_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[HTTPValidationError | Usage]:
+    """Get an application's usage
+
+     Get an owned application's usage against its resolved limits, per resource type.
+
+    Same shape as `GET /users/me/usage`, for an application the caller owns —
+    so a user can read an application's usage without authenticating as it.
+
+    Args:
+        application_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Usage]
+    """
+
+    kwargs = _get_kwargs(
+        application_id=application_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    application_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> HTTPValidationError | Usage | None:
+    """Get an application's usage
+
+     Get an owned application's usage against its resolved limits, per resource type.
+
+    Same shape as `GET /users/me/usage`, for an application the caller owns —
+    so a user can read an application's usage without authenticating as it.
+
+    Args:
+        application_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Usage
+    """
+
+    return (
+        await asyncio_detailed(
+            application_id=application_id,
+            client=client,
+        )
+    ).parsed

--- a/fastfuels_sdk/v2/client_library/api/domains/create_domain.py
+++ b/fastfuels_sdk/v2/client_library/api/domains/create_domain.py
@@ -8,6 +8,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_domain_request_body import CreateDomainRequestBody
 from ...models.domain import Domain
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -32,7 +33,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Domain | HTTPValidationError | None:
+) -> Domain | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Domain.from_dict(response.json())
 
@@ -43,6 +44,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -51,7 +57,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Domain | HTTPValidationError]:
+) -> Response[Domain | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -64,7 +70,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateDomainRequestBody,
-) -> Response[Domain | HTTPValidationError]:
+) -> Response[Domain | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a new domain
 
      # Create Domain Endpoint
@@ -128,12 +134,10 @@ def sync_detailed(
     - **modified_on**: (datetime) When the domain was last modified.
     - **tags**: (array) The tags associated with the domain.
     - **crs**: (object) The coordinate reference system (always projected).
-    - **features**: (array) Two named features:
-      - **`name: \"domain\"`** — A polygon covering the working extent (bounding
-        box of the input, possibly padded). This is what griddle, standgen,
-        and exporter use as the authoritative spatial extent.
-      - **`name: \"input\"`** — The user's original projected geometry, preserved
-        for visualization and reference.
+    - **features**: (array) A single feature named `\"domain\"` — a polygon
+      covering the working extent (bounding box of the input, possibly
+      padded). This is what griddle, standgen, and exporter use as the
+      authoritative spatial extent.
     - **bbox**: (array) Standard GeoJSON bbox `[minx, miny, maxx, maxy]` in the
       domain's projected CRS. Equals the bounds of the \"domain\" feature.
     - **pad_to_resolution**: (number, optional) The padding value, if set.
@@ -166,10 +170,10 @@ def sync_detailed(
        FeatureCollection input, not individual Feature objects. Wrap single
        features in a FeatureCollection.
 
-    2. **Two-Feature Output**: The created domain stores two named features:
-       a \"domain\" feature (bounding box, the working extent used by all
-       downstream services) and an \"input\" feature (the user's original
-       polygon, preserved for visualization).
+    2. **Working-Extent Output**: The created domain stores a single \"domain\"
+       feature — the bounding box of the input geometry, which is the working
+       extent used by all downstream services. The submitted geometry itself
+       is not stored.
 
     3. **Projection**: Geographic coordinates are always projected to a suitable
        UTM zone for accurate area calculations and grid operations.
@@ -193,7 +197,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Domain | HTTPValidationError]
+        Response[Domain | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -211,7 +215,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateDomainRequestBody,
-) -> Domain | HTTPValidationError | None:
+) -> Domain | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a new domain
 
      # Create Domain Endpoint
@@ -275,12 +279,10 @@ def sync(
     - **modified_on**: (datetime) When the domain was last modified.
     - **tags**: (array) The tags associated with the domain.
     - **crs**: (object) The coordinate reference system (always projected).
-    - **features**: (array) Two named features:
-      - **`name: \"domain\"`** — A polygon covering the working extent (bounding
-        box of the input, possibly padded). This is what griddle, standgen,
-        and exporter use as the authoritative spatial extent.
-      - **`name: \"input\"`** — The user's original projected geometry, preserved
-        for visualization and reference.
+    - **features**: (array) A single feature named `\"domain\"` — a polygon
+      covering the working extent (bounding box of the input, possibly
+      padded). This is what griddle, standgen, and exporter use as the
+      authoritative spatial extent.
     - **bbox**: (array) Standard GeoJSON bbox `[minx, miny, maxx, maxy]` in the
       domain's projected CRS. Equals the bounds of the \"domain\" feature.
     - **pad_to_resolution**: (number, optional) The padding value, if set.
@@ -313,10 +315,10 @@ def sync(
        FeatureCollection input, not individual Feature objects. Wrap single
        features in a FeatureCollection.
 
-    2. **Two-Feature Output**: The created domain stores two named features:
-       a \"domain\" feature (bounding box, the working extent used by all
-       downstream services) and an \"input\" feature (the user's original
-       polygon, preserved for visualization).
+    2. **Working-Extent Output**: The created domain stores a single \"domain\"
+       feature — the bounding box of the input geometry, which is the working
+       extent used by all downstream services. The submitted geometry itself
+       is not stored.
 
     3. **Projection**: Geographic coordinates are always projected to a suitable
        UTM zone for accurate area calculations and grid operations.
@@ -340,7 +342,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Domain | HTTPValidationError
+        Domain | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -353,7 +355,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateDomainRequestBody,
-) -> Response[Domain | HTTPValidationError]:
+) -> Response[Domain | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a new domain
 
      # Create Domain Endpoint
@@ -417,12 +419,10 @@ async def asyncio_detailed(
     - **modified_on**: (datetime) When the domain was last modified.
     - **tags**: (array) The tags associated with the domain.
     - **crs**: (object) The coordinate reference system (always projected).
-    - **features**: (array) Two named features:
-      - **`name: \"domain\"`** — A polygon covering the working extent (bounding
-        box of the input, possibly padded). This is what griddle, standgen,
-        and exporter use as the authoritative spatial extent.
-      - **`name: \"input\"`** — The user's original projected geometry, preserved
-        for visualization and reference.
+    - **features**: (array) A single feature named `\"domain\"` — a polygon
+      covering the working extent (bounding box of the input, possibly
+      padded). This is what griddle, standgen, and exporter use as the
+      authoritative spatial extent.
     - **bbox**: (array) Standard GeoJSON bbox `[minx, miny, maxx, maxy]` in the
       domain's projected CRS. Equals the bounds of the \"domain\" feature.
     - **pad_to_resolution**: (number, optional) The padding value, if set.
@@ -455,10 +455,10 @@ async def asyncio_detailed(
        FeatureCollection input, not individual Feature objects. Wrap single
        features in a FeatureCollection.
 
-    2. **Two-Feature Output**: The created domain stores two named features:
-       a \"domain\" feature (bounding box, the working extent used by all
-       downstream services) and an \"input\" feature (the user's original
-       polygon, preserved for visualization).
+    2. **Working-Extent Output**: The created domain stores a single \"domain\"
+       feature — the bounding box of the input geometry, which is the working
+       extent used by all downstream services. The submitted geometry itself
+       is not stored.
 
     3. **Projection**: Geographic coordinates are always projected to a suitable
        UTM zone for accurate area calculations and grid operations.
@@ -482,7 +482,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Domain | HTTPValidationError]
+        Response[Domain | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -498,7 +498,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateDomainRequestBody,
-) -> Domain | HTTPValidationError | None:
+) -> Domain | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a new domain
 
      # Create Domain Endpoint
@@ -562,12 +562,10 @@ async def asyncio(
     - **modified_on**: (datetime) When the domain was last modified.
     - **tags**: (array) The tags associated with the domain.
     - **crs**: (object) The coordinate reference system (always projected).
-    - **features**: (array) Two named features:
-      - **`name: \"domain\"`** — A polygon covering the working extent (bounding
-        box of the input, possibly padded). This is what griddle, standgen,
-        and exporter use as the authoritative spatial extent.
-      - **`name: \"input\"`** — The user's original projected geometry, preserved
-        for visualization and reference.
+    - **features**: (array) A single feature named `\"domain\"` — a polygon
+      covering the working extent (bounding box of the input, possibly
+      padded). This is what griddle, standgen, and exporter use as the
+      authoritative spatial extent.
     - **bbox**: (array) Standard GeoJSON bbox `[minx, miny, maxx, maxy]` in the
       domain's projected CRS. Equals the bounds of the \"domain\" feature.
     - **pad_to_resolution**: (number, optional) The padding value, if set.
@@ -600,10 +598,10 @@ async def asyncio(
        FeatureCollection input, not individual Feature objects. Wrap single
        features in a FeatureCollection.
 
-    2. **Two-Feature Output**: The created domain stores two named features:
-       a \"domain\" feature (bounding box, the working extent used by all
-       downstream services) and an \"input\" feature (the user's original
-       polygon, preserved for visualization).
+    2. **Working-Extent Output**: The created domain stores a single \"domain\"
+       feature — the bounding box of the input geometry, which is the working
+       extent used by all downstream services. The submitted geometry itself
+       is not stored.
 
     3. **Projection**: Geographic coordinates are always projected to a suitable
        UTM zone for accurate area calculations and grid operations.
@@ -627,7 +625,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Domain | HTTPValidationError
+        Domain | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/domains/create_domain.py
+++ b/fastfuels_sdk/v2/client_library/api/domains/create_domain.py
@@ -5,8 +5,8 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.create_domain_request_body import CreateDomainRequestBody
 from ...models.domain import Domain
+from ...models.geo_json_feature_collection import GeoJsonFeatureCollection
 from ...models.http_validation_error import HTTPValidationError
 from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
@@ -14,7 +14,7 @@ from ...types import Response
 
 def _get_kwargs(
     *,
-    body: CreateDomainRequestBody,
+    body: GeoJsonFeatureCollection,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
@@ -69,7 +69,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: AuthenticatedClient,
-    body: CreateDomainRequestBody,
+    body: GeoJsonFeatureCollection,
 ) -> Response[Domain | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a new domain
 
@@ -190,7 +190,7 @@ def sync_detailed(
       - \"Invalid spatial extent. The domain must be entirely within CONUS.\"
 
     Args:
-        body (CreateDomainRequestBody):
+        body (GeoJsonFeatureCollection):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -214,7 +214,7 @@ def sync_detailed(
 def sync(
     *,
     client: AuthenticatedClient,
-    body: CreateDomainRequestBody,
+    body: GeoJsonFeatureCollection,
 ) -> Domain | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a new domain
 
@@ -335,7 +335,7 @@ def sync(
       - \"Invalid spatial extent. The domain must be entirely within CONUS.\"
 
     Args:
-        body (CreateDomainRequestBody):
+        body (GeoJsonFeatureCollection):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -354,7 +354,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
-    body: CreateDomainRequestBody,
+    body: GeoJsonFeatureCollection,
 ) -> Response[Domain | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a new domain
 
@@ -475,7 +475,7 @@ async def asyncio_detailed(
       - \"Invalid spatial extent. The domain must be entirely within CONUS.\"
 
     Args:
-        body (CreateDomainRequestBody):
+        body (GeoJsonFeatureCollection):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -497,7 +497,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: AuthenticatedClient,
-    body: CreateDomainRequestBody,
+    body: GeoJsonFeatureCollection,
 ) -> Domain | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a new domain
 
@@ -618,7 +618,7 @@ async def asyncio(
       - \"Invalid spatial extent. The domain must be entirely within CONUS.\"
 
     Args:
-        body (CreateDomainRequestBody):
+        body (GeoJsonFeatureCollection):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/fastfuels_sdk/v2/client_library/api/domains/preview_domain.py
+++ b/fastfuels_sdk/v2/client_library/api/domains/preview_domain.py
@@ -84,8 +84,8 @@ def sync_detailed(
 
     - **id**: Always `\"preview\"` — not a real domain identifier.
     - **created_on** / **modified_on**: Set to the current request time (not persisted).
-    - **features**: Two named features — `\"domain\"` (working extent) and `\"input\"`
-      (original polygon), identical to what create would return.
+    - **features**: A single `\"domain\"` feature (the working extent),
+      identical to what create would return.
     - **bbox**: Bounding box of the `\"domain\"` feature.
     - **crs**: Projected CRS, identical to what create would return.
 
@@ -144,8 +144,8 @@ def sync(
 
     - **id**: Always `\"preview\"` — not a real domain identifier.
     - **created_on** / **modified_on**: Set to the current request time (not persisted).
-    - **features**: Two named features — `\"domain\"` (working extent) and `\"input\"`
-      (original polygon), identical to what create would return.
+    - **features**: A single `\"domain\"` feature (the working extent),
+      identical to what create would return.
     - **bbox**: Bounding box of the `\"domain\"` feature.
     - **crs**: Projected CRS, identical to what create would return.
 
@@ -199,8 +199,8 @@ async def asyncio_detailed(
 
     - **id**: Always `\"preview\"` — not a real domain identifier.
     - **created_on** / **modified_on**: Set to the current request time (not persisted).
-    - **features**: Two named features — `\"domain\"` (working extent) and `\"input\"`
-      (original polygon), identical to what create would return.
+    - **features**: A single `\"domain\"` feature (the working extent),
+      identical to what create would return.
     - **bbox**: Bounding box of the `\"domain\"` feature.
     - **crs**: Projected CRS, identical to what create would return.
 
@@ -257,8 +257,8 @@ async def asyncio(
 
     - **id**: Always `\"preview\"` — not a real domain identifier.
     - **created_on** / **modified_on**: Set to the current request time (not persisted).
-    - **features**: Two named features — `\"domain\"` (working extent) and `\"input\"`
-      (original polygon), identical to what create would return.
+    - **features**: A single `\"domain\"` feature (the working extent),
+      identical to what create would return.
     - **bbox**: Bounding box of the `\"domain\"` feature.
     - **crs**: Projected CRS, identical to what create would return.
 

--- a/fastfuels_sdk/v2/client_library/api/domains/preview_domain.py
+++ b/fastfuels_sdk/v2/client_library/api/domains/preview_domain.py
@@ -5,15 +5,15 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.create_domain_request_body import CreateDomainRequestBody
 from ...models.domain import Domain
+from ...models.geo_json_feature_collection import GeoJsonFeatureCollection
 from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
 def _get_kwargs(
     *,
-    body: CreateDomainRequestBody,
+    body: GeoJsonFeatureCollection,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
@@ -63,7 +63,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: AuthenticatedClient,
-    body: CreateDomainRequestBody,
+    body: GeoJsonFeatureCollection,
 ) -> Response[Domain | HTTPValidationError]:
     r"""Preview a domain without persisting it
 
@@ -99,7 +99,7 @@ def sync_detailed(
     - \"Invalid spatial extent. The domain must be entirely within CONUS.\"
 
     Args:
-        body (CreateDomainRequestBody):
+        body (GeoJsonFeatureCollection):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -123,7 +123,7 @@ def sync_detailed(
 def sync(
     *,
     client: AuthenticatedClient,
-    body: CreateDomainRequestBody,
+    body: GeoJsonFeatureCollection,
 ) -> Domain | HTTPValidationError | None:
     r"""Preview a domain without persisting it
 
@@ -159,7 +159,7 @@ def sync(
     - \"Invalid spatial extent. The domain must be entirely within CONUS.\"
 
     Args:
-        body (CreateDomainRequestBody):
+        body (GeoJsonFeatureCollection):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -178,7 +178,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
-    body: CreateDomainRequestBody,
+    body: GeoJsonFeatureCollection,
 ) -> Response[Domain | HTTPValidationError]:
     r"""Preview a domain without persisting it
 
@@ -214,7 +214,7 @@ async def asyncio_detailed(
     - \"Invalid spatial extent. The domain must be entirely within CONUS.\"
 
     Args:
-        body (CreateDomainRequestBody):
+        body (GeoJsonFeatureCollection):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -236,7 +236,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: AuthenticatedClient,
-    body: CreateDomainRequestBody,
+    body: GeoJsonFeatureCollection,
 ) -> Domain | HTTPValidationError | None:
     r"""Preview a domain without persisting it
 
@@ -272,7 +272,7 @@ async def asyncio(
     - \"Invalid spatial extent. The domain must be entirely within CONUS.\"
 
     Args:
-        body (CreateDomainRequestBody):
+        body (GeoJsonFeatureCollection):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/fastfuels_sdk/v2/client_library/api/domains/reproject_domain.py
+++ b/fastfuels_sdk/v2/client_library/api/domains/reproject_domain.py
@@ -5,14 +5,14 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.create_domain_request_body import CreateDomainRequestBody
+from ...models.geo_json_feature_collection import GeoJsonFeatureCollection
 from ...models.http_validation_error import HTTPValidationError
 from ...types import UNSET, Response
 
 
 def _get_kwargs(
     *,
-    body: CreateDomainRequestBody,
+    body: GeoJsonFeatureCollection,
     target_epsg: int,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
@@ -39,9 +39,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> CreateDomainRequestBody | HTTPValidationError | None:
+) -> GeoJsonFeatureCollection | HTTPValidationError | None:
     if response.status_code == 200:
-        response_200 = CreateDomainRequestBody.from_dict(response.json())
+        response_200 = GeoJsonFeatureCollection.from_dict(response.json())
 
         return response_200
 
@@ -58,7 +58,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[CreateDomainRequestBody | HTTPValidationError]:
+) -> Response[GeoJsonFeatureCollection | HTTPValidationError]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -70,9 +70,9 @@ def _build_response(
 def sync_detailed(
     *,
     client: AuthenticatedClient,
-    body: CreateDomainRequestBody,
+    body: GeoJsonFeatureCollection,
     target_epsg: int,
-) -> Response[CreateDomainRequestBody | HTTPValidationError]:
+) -> Response[GeoJsonFeatureCollection | HTTPValidationError]:
     """Reproject a FeatureCollection to a target CRS
 
      # Reproject Domain Endpoint
@@ -106,14 +106,14 @@ def sync_detailed(
 
     Args:
         target_epsg (int): EPSG code of the target CRS.
-        body (CreateDomainRequestBody):
+        body (GeoJsonFeatureCollection):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[CreateDomainRequestBody | HTTPValidationError]
+        Response[GeoJsonFeatureCollection | HTTPValidationError]
     """
 
     kwargs = _get_kwargs(
@@ -131,9 +131,9 @@ def sync_detailed(
 def sync(
     *,
     client: AuthenticatedClient,
-    body: CreateDomainRequestBody,
+    body: GeoJsonFeatureCollection,
     target_epsg: int,
-) -> CreateDomainRequestBody | HTTPValidationError | None:
+) -> GeoJsonFeatureCollection | HTTPValidationError | None:
     """Reproject a FeatureCollection to a target CRS
 
      # Reproject Domain Endpoint
@@ -167,14 +167,14 @@ def sync(
 
     Args:
         target_epsg (int): EPSG code of the target CRS.
-        body (CreateDomainRequestBody):
+        body (GeoJsonFeatureCollection):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        CreateDomainRequestBody | HTTPValidationError
+        GeoJsonFeatureCollection | HTTPValidationError
     """
 
     return sync_detailed(
@@ -187,9 +187,9 @@ def sync(
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
-    body: CreateDomainRequestBody,
+    body: GeoJsonFeatureCollection,
     target_epsg: int,
-) -> Response[CreateDomainRequestBody | HTTPValidationError]:
+) -> Response[GeoJsonFeatureCollection | HTTPValidationError]:
     """Reproject a FeatureCollection to a target CRS
 
      # Reproject Domain Endpoint
@@ -223,14 +223,14 @@ async def asyncio_detailed(
 
     Args:
         target_epsg (int): EPSG code of the target CRS.
-        body (CreateDomainRequestBody):
+        body (GeoJsonFeatureCollection):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[CreateDomainRequestBody | HTTPValidationError]
+        Response[GeoJsonFeatureCollection | HTTPValidationError]
     """
 
     kwargs = _get_kwargs(
@@ -246,9 +246,9 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: AuthenticatedClient,
-    body: CreateDomainRequestBody,
+    body: GeoJsonFeatureCollection,
     target_epsg: int,
-) -> CreateDomainRequestBody | HTTPValidationError | None:
+) -> GeoJsonFeatureCollection | HTTPValidationError | None:
     """Reproject a FeatureCollection to a target CRS
 
      # Reproject Domain Endpoint
@@ -282,14 +282,14 @@ async def asyncio(
 
     Args:
         target_epsg (int): EPSG code of the target CRS.
-        body (CreateDomainRequestBody):
+        body (GeoJsonFeatureCollection):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        CreateDomainRequestBody | HTTPValidationError
+        GeoJsonFeatureCollection | HTTPValidationError
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/features/create_layerset.py
+++ b/fastfuels_sdk/v2/client_library/api/features/create_layerset.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_layerset_request_body import CreateLayersetRequestBody
 from ...models.feature import Feature
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -36,7 +37,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Feature | HTTPValidationError | None:
+) -> Feature | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Feature.from_dict(response.json())
 
@@ -47,6 +48,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,7 +61,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Feature | HTTPValidationError]:
+) -> Response[Feature | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +75,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateLayersetRequestBody,
-) -> Response[Feature | HTTPValidationError]:
+) -> Response[Feature | HTTPValidationError | QuotaExceededDetail]:
     r"""Upload a custom Layerset
 
      # Create Layerset Endpoint
@@ -119,7 +125,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Feature | HTTPValidationError]
+        Response[Feature | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -139,7 +145,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateLayersetRequestBody,
-) -> Feature | HTTPValidationError | None:
+) -> Feature | HTTPValidationError | QuotaExceededDetail | None:
     r"""Upload a custom Layerset
 
      # Create Layerset Endpoint
@@ -189,7 +195,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Feature | HTTPValidationError
+        Feature | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -204,7 +210,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateLayersetRequestBody,
-) -> Response[Feature | HTTPValidationError]:
+) -> Response[Feature | HTTPValidationError | QuotaExceededDetail]:
     r"""Upload a custom Layerset
 
      # Create Layerset Endpoint
@@ -254,7 +260,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Feature | HTTPValidationError]
+        Response[Feature | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -272,7 +278,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateLayersetRequestBody,
-) -> Feature | HTTPValidationError | None:
+) -> Feature | HTTPValidationError | QuotaExceededDetail | None:
     r"""Upload a custom Layerset
 
      # Create Layerset Endpoint
@@ -322,7 +328,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Feature | HTTPValidationError
+        Feature | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/features/create_osm_road_feature.py
+++ b/fastfuels_sdk/v2/client_library/api/features/create_osm_road_feature.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_osm_road_feature_request import CreateOsmRoadFeatureRequest
 from ...models.feature import Feature
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -36,7 +37,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Feature | HTTPValidationError | None:
+) -> Feature | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Feature.from_dict(response.json())
 
@@ -47,6 +48,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,7 +61,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Feature | HTTPValidationError]:
+) -> Response[Feature | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +75,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateOsmRoadFeatureRequest,
-) -> Response[Feature | HTTPValidationError]:
+) -> Response[Feature | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a road feature from OpenStreetMap
 
      # Create OSM Road Feature
@@ -113,7 +119,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Feature | HTTPValidationError]
+        Response[Feature | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -133,7 +139,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateOsmRoadFeatureRequest,
-) -> Feature | HTTPValidationError | None:
+) -> Feature | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a road feature from OpenStreetMap
 
      # Create OSM Road Feature
@@ -177,7 +183,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Feature | HTTPValidationError
+        Feature | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -192,7 +198,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateOsmRoadFeatureRequest,
-) -> Response[Feature | HTTPValidationError]:
+) -> Response[Feature | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a road feature from OpenStreetMap
 
      # Create OSM Road Feature
@@ -236,7 +242,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Feature | HTTPValidationError]
+        Response[Feature | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -254,7 +260,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateOsmRoadFeatureRequest,
-) -> Feature | HTTPValidationError | None:
+) -> Feature | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a road feature from OpenStreetMap
 
      # Create OSM Road Feature
@@ -298,7 +304,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Feature | HTTPValidationError
+        Feature | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/features/create_osm_water_feature.py
+++ b/fastfuels_sdk/v2/client_library/api/features/create_osm_water_feature.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_osm_water_feature_request import CreateOsmWaterFeatureRequest
 from ...models.feature import Feature
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -36,7 +37,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Feature | HTTPValidationError | None:
+) -> Feature | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Feature.from_dict(response.json())
 
@@ -47,6 +48,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,7 +61,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Feature | HTTPValidationError]:
+) -> Response[Feature | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +75,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateOsmWaterFeatureRequest,
-) -> Response[Feature | HTTPValidationError]:
+) -> Response[Feature | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a water feature from OpenStreetMap
 
      # Create OSM Water Feature
@@ -113,7 +119,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Feature | HTTPValidationError]
+        Response[Feature | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -133,7 +139,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateOsmWaterFeatureRequest,
-) -> Feature | HTTPValidationError | None:
+) -> Feature | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a water feature from OpenStreetMap
 
      # Create OSM Water Feature
@@ -177,7 +183,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Feature | HTTPValidationError
+        Feature | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -192,7 +198,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateOsmWaterFeatureRequest,
-) -> Response[Feature | HTTPValidationError]:
+) -> Response[Feature | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a water feature from OpenStreetMap
 
      # Create OSM Water Feature
@@ -236,7 +242,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Feature | HTTPValidationError]
+        Response[Feature | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -254,7 +260,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateOsmWaterFeatureRequest,
-) -> Feature | HTTPValidationError | None:
+) -> Feature | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a water feature from OpenStreetMap
 
      # Create OSM Water Feature
@@ -298,7 +304,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Feature | HTTPValidationError
+        Feature | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/grids/apply_grid_modifications.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/apply_grid_modifications.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.apply_grid_modifications_request import ApplyGridModificationsRequest
 from ...models.grid import Grid
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -38,7 +39,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 200:
         response_200 = Grid.from_dict(response.json())
 
@@ -49,6 +50,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -57,7 +63,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -72,7 +78,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: ApplyGridModificationsRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Apply modifications to a grid in place
 
      # Apply Modifications to a Grid (in place)
@@ -113,7 +119,9 @@ def sync_detailed(
     - `band`: dot-notation band key (e.g., `fbfm`, `fuel_load.1hr`)
     - `operator`: `eq`, `ne`, `gt`, `lt`, `ge`, `le`
       (`eq`/`ne` also accept a list of values)
-    - `value`: number, string, or list for `eq`/`ne`
+    - `value`: number or list for `eq`/`ne`. For `fbfm` bands you may use the
+      human-readable Scott-Burgan labels (`\"GR1\"`) or the numeric codes (`101`)
+      interchangeably — labels are resolved to codes when the rule is stored.
 
     **Spatial conditions** test each cell's location against a geometry. Two
     variants discriminated by the required `source` field:
@@ -161,6 +169,10 @@ def sync_detailed(
       grid (apply modifications to the source tree inventory and re-voxelize
       instead); a referenced `feature_id` is missing, cross-domain, or not
       completed; or a referenced band does not exist on this grid.
+    - **429 Too Many Requests**: You have too many active grid jobs in progress
+      (your `max_active_grids` quota). Wait for jobs to complete or delete
+      unneeded grids, then retry. The response detail names the exact `quota`
+      and includes a `Retry-After` header.
 
     Args:
         domain_id (str):
@@ -176,7 +188,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -198,7 +210,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: ApplyGridModificationsRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Apply modifications to a grid in place
 
      # Apply Modifications to a Grid (in place)
@@ -239,7 +251,9 @@ def sync(
     - `band`: dot-notation band key (e.g., `fbfm`, `fuel_load.1hr`)
     - `operator`: `eq`, `ne`, `gt`, `lt`, `ge`, `le`
       (`eq`/`ne` also accept a list of values)
-    - `value`: number, string, or list for `eq`/`ne`
+    - `value`: number or list for `eq`/`ne`. For `fbfm` bands you may use the
+      human-readable Scott-Burgan labels (`\"GR1\"`) or the numeric codes (`101`)
+      interchangeably — labels are resolved to codes when the rule is stored.
 
     **Spatial conditions** test each cell's location against a geometry. Two
     variants discriminated by the required `source` field:
@@ -287,6 +301,10 @@ def sync(
       grid (apply modifications to the source tree inventory and re-voxelize
       instead); a referenced `feature_id` is missing, cross-domain, or not
       completed; or a referenced band does not exist on this grid.
+    - **429 Too Many Requests**: You have too many active grid jobs in progress
+      (your `max_active_grids` quota). Wait for jobs to complete or delete
+      unneeded grids, then retry. The response detail names the exact `quota`
+      and includes a `Retry-After` header.
 
     Args:
         domain_id (str):
@@ -302,7 +320,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -319,7 +337,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: ApplyGridModificationsRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Apply modifications to a grid in place
 
      # Apply Modifications to a Grid (in place)
@@ -360,7 +378,9 @@ async def asyncio_detailed(
     - `band`: dot-notation band key (e.g., `fbfm`, `fuel_load.1hr`)
     - `operator`: `eq`, `ne`, `gt`, `lt`, `ge`, `le`
       (`eq`/`ne` also accept a list of values)
-    - `value`: number, string, or list for `eq`/`ne`
+    - `value`: number or list for `eq`/`ne`. For `fbfm` bands you may use the
+      human-readable Scott-Burgan labels (`\"GR1\"`) or the numeric codes (`101`)
+      interchangeably — labels are resolved to codes when the rule is stored.
 
     **Spatial conditions** test each cell's location against a geometry. Two
     variants discriminated by the required `source` field:
@@ -408,6 +428,10 @@ async def asyncio_detailed(
       grid (apply modifications to the source tree inventory and re-voxelize
       instead); a referenced `feature_id` is missing, cross-domain, or not
       completed; or a referenced band does not exist on this grid.
+    - **429 Too Many Requests**: You have too many active grid jobs in progress
+      (your `max_active_grids` quota). Wait for jobs to complete or delete
+      unneeded grids, then retry. The response detail names the exact `quota`
+      and includes a `Retry-After` header.
 
     Args:
         domain_id (str):
@@ -423,7 +447,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -443,7 +467,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: ApplyGridModificationsRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Apply modifications to a grid in place
 
      # Apply Modifications to a Grid (in place)
@@ -484,7 +508,9 @@ async def asyncio(
     - `band`: dot-notation band key (e.g., `fbfm`, `fuel_load.1hr`)
     - `operator`: `eq`, `ne`, `gt`, `lt`, `ge`, `le`
       (`eq`/`ne` also accept a list of values)
-    - `value`: number, string, or list for `eq`/`ne`
+    - `value`: number or list for `eq`/`ne`. For `fbfm` bands you may use the
+      human-readable Scott-Burgan labels (`\"GR1\"`) or the numeric codes (`101`)
+      interchangeably — labels are resolved to codes when the rule is stored.
 
     **Spatial conditions** test each cell's location against a geometry. Two
     variants discriminated by the required `source` field:
@@ -532,6 +558,10 @@ async def asyncio(
       grid (apply modifications to the source tree inventory and re-voxelize
       instead); a referenced `feature_id` is missing, cross-domain, or not
       completed; or a referenced band does not exist on this grid.
+    - **429 Too Many Requests**: You have too many active grid jobs in progress
+      (your `max_active_grids` quota). Wait for jobs to complete or delete
+      unneeded grids, then retry. The response detail names the exact `quota`
+      and includes a `Retry-After` header.
 
     Args:
         domain_id (str):
@@ -547,7 +577,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/grids/check_3dep_coverage.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/check_3dep_coverage.py
@@ -7,8 +7,10 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
-from ...models.three_dep_coverage_response import ThreeDepCoverageResponse
 from ...models.three_dep_resolution import ThreeDepResolution
+from ...models.topography_three_dep_coverage_response import (
+    TopographyThreeDepCoverageResponse,
+)
 from ...types import UNSET, Response, Unset
 
 
@@ -41,9 +43,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | ThreeDepCoverageResponse | None:
+) -> HTTPValidationError | TopographyThreeDepCoverageResponse | None:
     if response.status_code == 200:
-        response_200 = ThreeDepCoverageResponse.from_dict(response.json())
+        response_200 = TopographyThreeDepCoverageResponse.from_dict(response.json())
 
         return response_200
 
@@ -60,7 +62,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | ThreeDepCoverageResponse]:
+) -> Response[HTTPValidationError | TopographyThreeDepCoverageResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -74,7 +76,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     resolution: ThreeDepResolution | Unset = UNSET,
-) -> Response[HTTPValidationError | ThreeDepCoverageResponse]:
+) -> Response[HTTPValidationError | TopographyThreeDepCoverageResponse]:
     """Check 3DEP tile coverage for a domain
 
      # Check 3DEP Tile Coverage
@@ -102,7 +104,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | ThreeDepCoverageResponse]
+        Response[HTTPValidationError | TopographyThreeDepCoverageResponse]
     """
 
     kwargs = _get_kwargs(
@@ -122,7 +124,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     resolution: ThreeDepResolution | Unset = UNSET,
-) -> HTTPValidationError | ThreeDepCoverageResponse | None:
+) -> HTTPValidationError | TopographyThreeDepCoverageResponse | None:
     """Check 3DEP tile coverage for a domain
 
      # Check 3DEP Tile Coverage
@@ -150,7 +152,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | ThreeDepCoverageResponse
+        HTTPValidationError | TopographyThreeDepCoverageResponse
     """
 
     return sync_detailed(
@@ -165,7 +167,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     resolution: ThreeDepResolution | Unset = UNSET,
-) -> Response[HTTPValidationError | ThreeDepCoverageResponse]:
+) -> Response[HTTPValidationError | TopographyThreeDepCoverageResponse]:
     """Check 3DEP tile coverage for a domain
 
      # Check 3DEP Tile Coverage
@@ -193,7 +195,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | ThreeDepCoverageResponse]
+        Response[HTTPValidationError | TopographyThreeDepCoverageResponse]
     """
 
     kwargs = _get_kwargs(
@@ -211,7 +213,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     resolution: ThreeDepResolution | Unset = UNSET,
-) -> HTTPValidationError | ThreeDepCoverageResponse | None:
+) -> HTTPValidationError | TopographyThreeDepCoverageResponse | None:
     """Check 3DEP tile coverage for a domain
 
      # Check 3DEP Tile Coverage
@@ -239,7 +241,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | ThreeDepCoverageResponse
+        HTTPValidationError | TopographyThreeDepCoverageResponse
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/grids/create_3dep_topography.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_3dep_topography.py
@@ -11,6 +11,7 @@ from ...models.create_three_dep_topography_request import (
 )
 from ...models.grid import Grid
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -38,7 +39,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Grid.from_dict(response.json())
 
@@ -49,6 +50,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -57,7 +63,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -71,7 +77,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateThreeDepTopographyRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid from 3DEP topographic data
 
      # Create 3DEP Topography Grid
@@ -123,7 +129,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -143,7 +149,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateThreeDepTopographyRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid from 3DEP topographic data
 
      # Create 3DEP Topography Grid
@@ -195,7 +201,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -210,7 +216,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateThreeDepTopographyRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid from 3DEP topographic data
 
      # Create 3DEP Topography Grid
@@ -262,7 +268,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -280,7 +286,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateThreeDepTopographyRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid from 3DEP topographic data
 
      # Create 3DEP Topography Grid
@@ -332,7 +338,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/grids/create_compose_grid.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_compose_grid.py
@@ -1,0 +1,212 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.create_compose_request import CreateComposeRequest
+from ...models.grid import Grid
+from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
+from ...types import Response
+
+
+def _get_kwargs(
+    domain_id: str,
+    *,
+    body: CreateComposeRequest,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/domains/{domain_id}/grids/compose".format(
+            domain_id=quote(str(domain_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
+    if response.status_code == 201:
+        response_201 = Grid.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateComposeRequest,
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
+    """Create a grid by composing existing grids
+
+     # Create Compose Grid
+
+    Creates a new grid by selecting bands, computing bands, and applying
+    optional conditional fallback rules across one or more completed grids.
+
+    Args:
+        domain_id (str):
+        body (CreateComposeRequest): Request to create a grid by composing one or more existing
+            grids.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
+    """
+
+    kwargs = _get_kwargs(
+        domain_id=domain_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateComposeRequest,
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
+    """Create a grid by composing existing grids
+
+     # Create Compose Grid
+
+    Creates a new grid by selecting bands, computing bands, and applying
+    optional conditional fallback rules across one or more completed grids.
+
+    Args:
+        domain_id (str):
+        body (CreateComposeRequest): Request to create a grid by composing one or more existing
+            grids.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Grid | HTTPValidationError | QuotaExceededDetail
+    """
+
+    return sync_detailed(
+        domain_id=domain_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateComposeRequest,
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
+    """Create a grid by composing existing grids
+
+     # Create Compose Grid
+
+    Creates a new grid by selecting bands, computing bands, and applying
+    optional conditional fallback rules across one or more completed grids.
+
+    Args:
+        domain_id (str):
+        body (CreateComposeRequest): Request to create a grid by composing one or more existing
+            grids.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
+    """
+
+    kwargs = _get_kwargs(
+        domain_id=domain_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateComposeRequest,
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
+    """Create a grid by composing existing grids
+
+     # Create Compose Grid
+
+    Creates a new grid by selecting bands, computing bands, and applying
+    optional conditional fallback rules across one or more completed grids.
+
+    Args:
+        domain_id (str):
+        body (CreateComposeRequest): Request to create a grid by composing one or more existing
+            grids.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Grid | HTTPValidationError | QuotaExceededDetail
+    """
+
+    return (
+        await asyncio_detailed(
+            domain_id=domain_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/fastfuels_sdk/v2/client_library/api/grids/create_duet_grid.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_duet_grid.py
@@ -1,0 +1,452 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.create_duet_request import CreateDuetRequest
+from ...models.grid import Grid
+from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
+from ...types import Response
+
+
+def _get_kwargs(
+    domain_id: str,
+    *,
+    body: CreateDuetRequest,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/domains/{domain_id}/grids/duet".format(
+            domain_id=quote(str(domain_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
+    if response.status_code == 201:
+        response_201 = Grid.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateDuetRequest,
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
+    r"""Create a surface fuel grid with DUET
+
+     # Create a DUET Surface Fuel Grid
+
+    Runs DUET (Distribution of Understory using Elliptical Transport) over a 3D
+    tree grid to produce 2D surface fuels. DUET drops leaf and needle litter
+    from each tree's crown along wind-driven elliptical fall trajectories, then
+    grows grass as a function of shade and litter cover — so litter accumulates
+    under and downwind of crowns, and grass fills the gaps between them.
+
+    ## What DUET does and does not give you
+
+    DUET supplies the **spatial pattern** of surface fuels, keyed to real canopy
+    structure. It does **not** supply physical magnitudes: raw DUET loadings are
+    idiosyncratic to the model and should not be read as fuel loads or fed to a
+    fire model as-is. Use `calibration` to impose magnitudes you trust — from
+    field data, from the literature, or from an FBFM40 grid.
+
+    ## Request Body
+
+    - **source_grid_id**: (required) A completed 3D tree grid carrying the
+      `bulk_density.foliage.live`, `spcd`, and `fuel_moisture.live` bands.
+      Create one with `POST /grids/voxelize/inventory/tree`, requesting those
+      three bands — `spcd` in particular is not voxelized by default.
+    - **years_since_burn**: (required) Years of litter accumulation to simulate,
+      1–100. DUET starts from the year of the last fire, with grass and litter
+      consumed, so this is the stand's time since fire. It is the single most
+      consequential parameter: a low value yields almost no litter because there
+      has been no time for any to fall. It also drives runtime.
+    - **wind_direction**: (optional) Degrees clockwise from north. Default 270.
+    - **wind_variability**: (optional) Angular spread in degrees. Default 30.
+    - **bands**: (optional) Output bands. Defaults to `fuel_load.grass` and
+      `fuel_load.litter`. DUET separates fuels by type rather than size class,
+      so bands are named for `grass`, `litter` (and its `litter.coniferous` /
+      `litter.deciduous` parts), and `total`.
+    - **calibration**: (optional) Per-parameter, per-fuel-type targets. Omit to
+      store raw output.
+    - **name**, **description**, **tags**: (optional) Standard metadata.
+
+    ## Calibration
+
+    Each of `fuel_load`, `fuel_depth`, and `fuel_moisture` is calibrated
+    independently, and within each, per fuel type (`grass`, `coniferous`,
+    `deciduous`, `litter`, or `all` — which is exclusive of the others). Methods:
+
+    - `maxmin` — rescale to a target maximum and minimum. Best when fuel data
+      are limited, or when their distribution does not resemble DUET's.
+    - `meansd` — rescale to a target mean and standard deviation. Appropriate
+      only when the targets come from a dataset large enough to approximate a
+      normal distribution.
+    - `constant` — assign a single value. Reasonable only when that is the only
+      value available.
+
+    Calibration rescales only cells that already carry fuel; cells DUET left
+    empty stay empty. A consequence worth expecting: where cover is sparse, the
+    domain-wide mean will sit well below a `meansd` target, because the target
+    applies to the covered cells rather than to the domain.
+
+    ## Response
+
+    Returns the created Grid with status `\"pending\"` and `georeference: null`.
+    Treevox runs DUET asynchronously and updates the grid to `\"completed\"` with
+    a 2D `Georeference` when done.
+
+    Args:
+        domain_id (str):
+        body (CreateDuetRequest): Request body for creating a DUET surface fuel grid from a tree
+            grid.
+
+            Does not extend CreateGridRequestBase: like the 3D grids it derives from,
+            DUET grids do not support modifications.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
+    """
+
+    kwargs = _get_kwargs(
+        domain_id=domain_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateDuetRequest,
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
+    r"""Create a surface fuel grid with DUET
+
+     # Create a DUET Surface Fuel Grid
+
+    Runs DUET (Distribution of Understory using Elliptical Transport) over a 3D
+    tree grid to produce 2D surface fuels. DUET drops leaf and needle litter
+    from each tree's crown along wind-driven elliptical fall trajectories, then
+    grows grass as a function of shade and litter cover — so litter accumulates
+    under and downwind of crowns, and grass fills the gaps between them.
+
+    ## What DUET does and does not give you
+
+    DUET supplies the **spatial pattern** of surface fuels, keyed to real canopy
+    structure. It does **not** supply physical magnitudes: raw DUET loadings are
+    idiosyncratic to the model and should not be read as fuel loads or fed to a
+    fire model as-is. Use `calibration` to impose magnitudes you trust — from
+    field data, from the literature, or from an FBFM40 grid.
+
+    ## Request Body
+
+    - **source_grid_id**: (required) A completed 3D tree grid carrying the
+      `bulk_density.foliage.live`, `spcd`, and `fuel_moisture.live` bands.
+      Create one with `POST /grids/voxelize/inventory/tree`, requesting those
+      three bands — `spcd` in particular is not voxelized by default.
+    - **years_since_burn**: (required) Years of litter accumulation to simulate,
+      1–100. DUET starts from the year of the last fire, with grass and litter
+      consumed, so this is the stand's time since fire. It is the single most
+      consequential parameter: a low value yields almost no litter because there
+      has been no time for any to fall. It also drives runtime.
+    - **wind_direction**: (optional) Degrees clockwise from north. Default 270.
+    - **wind_variability**: (optional) Angular spread in degrees. Default 30.
+    - **bands**: (optional) Output bands. Defaults to `fuel_load.grass` and
+      `fuel_load.litter`. DUET separates fuels by type rather than size class,
+      so bands are named for `grass`, `litter` (and its `litter.coniferous` /
+      `litter.deciduous` parts), and `total`.
+    - **calibration**: (optional) Per-parameter, per-fuel-type targets. Omit to
+      store raw output.
+    - **name**, **description**, **tags**: (optional) Standard metadata.
+
+    ## Calibration
+
+    Each of `fuel_load`, `fuel_depth`, and `fuel_moisture` is calibrated
+    independently, and within each, per fuel type (`grass`, `coniferous`,
+    `deciduous`, `litter`, or `all` — which is exclusive of the others). Methods:
+
+    - `maxmin` — rescale to a target maximum and minimum. Best when fuel data
+      are limited, or when their distribution does not resemble DUET's.
+    - `meansd` — rescale to a target mean and standard deviation. Appropriate
+      only when the targets come from a dataset large enough to approximate a
+      normal distribution.
+    - `constant` — assign a single value. Reasonable only when that is the only
+      value available.
+
+    Calibration rescales only cells that already carry fuel; cells DUET left
+    empty stay empty. A consequence worth expecting: where cover is sparse, the
+    domain-wide mean will sit well below a `meansd` target, because the target
+    applies to the covered cells rather than to the domain.
+
+    ## Response
+
+    Returns the created Grid with status `\"pending\"` and `georeference: null`.
+    Treevox runs DUET asynchronously and updates the grid to `\"completed\"` with
+    a 2D `Georeference` when done.
+
+    Args:
+        domain_id (str):
+        body (CreateDuetRequest): Request body for creating a DUET surface fuel grid from a tree
+            grid.
+
+            Does not extend CreateGridRequestBase: like the 3D grids it derives from,
+            DUET grids do not support modifications.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Grid | HTTPValidationError | QuotaExceededDetail
+    """
+
+    return sync_detailed(
+        domain_id=domain_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateDuetRequest,
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
+    r"""Create a surface fuel grid with DUET
+
+     # Create a DUET Surface Fuel Grid
+
+    Runs DUET (Distribution of Understory using Elliptical Transport) over a 3D
+    tree grid to produce 2D surface fuels. DUET drops leaf and needle litter
+    from each tree's crown along wind-driven elliptical fall trajectories, then
+    grows grass as a function of shade and litter cover — so litter accumulates
+    under and downwind of crowns, and grass fills the gaps between them.
+
+    ## What DUET does and does not give you
+
+    DUET supplies the **spatial pattern** of surface fuels, keyed to real canopy
+    structure. It does **not** supply physical magnitudes: raw DUET loadings are
+    idiosyncratic to the model and should not be read as fuel loads or fed to a
+    fire model as-is. Use `calibration` to impose magnitudes you trust — from
+    field data, from the literature, or from an FBFM40 grid.
+
+    ## Request Body
+
+    - **source_grid_id**: (required) A completed 3D tree grid carrying the
+      `bulk_density.foliage.live`, `spcd`, and `fuel_moisture.live` bands.
+      Create one with `POST /grids/voxelize/inventory/tree`, requesting those
+      three bands — `spcd` in particular is not voxelized by default.
+    - **years_since_burn**: (required) Years of litter accumulation to simulate,
+      1–100. DUET starts from the year of the last fire, with grass and litter
+      consumed, so this is the stand's time since fire. It is the single most
+      consequential parameter: a low value yields almost no litter because there
+      has been no time for any to fall. It also drives runtime.
+    - **wind_direction**: (optional) Degrees clockwise from north. Default 270.
+    - **wind_variability**: (optional) Angular spread in degrees. Default 30.
+    - **bands**: (optional) Output bands. Defaults to `fuel_load.grass` and
+      `fuel_load.litter`. DUET separates fuels by type rather than size class,
+      so bands are named for `grass`, `litter` (and its `litter.coniferous` /
+      `litter.deciduous` parts), and `total`.
+    - **calibration**: (optional) Per-parameter, per-fuel-type targets. Omit to
+      store raw output.
+    - **name**, **description**, **tags**: (optional) Standard metadata.
+
+    ## Calibration
+
+    Each of `fuel_load`, `fuel_depth`, and `fuel_moisture` is calibrated
+    independently, and within each, per fuel type (`grass`, `coniferous`,
+    `deciduous`, `litter`, or `all` — which is exclusive of the others). Methods:
+
+    - `maxmin` — rescale to a target maximum and minimum. Best when fuel data
+      are limited, or when their distribution does not resemble DUET's.
+    - `meansd` — rescale to a target mean and standard deviation. Appropriate
+      only when the targets come from a dataset large enough to approximate a
+      normal distribution.
+    - `constant` — assign a single value. Reasonable only when that is the only
+      value available.
+
+    Calibration rescales only cells that already carry fuel; cells DUET left
+    empty stay empty. A consequence worth expecting: where cover is sparse, the
+    domain-wide mean will sit well below a `meansd` target, because the target
+    applies to the covered cells rather than to the domain.
+
+    ## Response
+
+    Returns the created Grid with status `\"pending\"` and `georeference: null`.
+    Treevox runs DUET asynchronously and updates the grid to `\"completed\"` with
+    a 2D `Georeference` when done.
+
+    Args:
+        domain_id (str):
+        body (CreateDuetRequest): Request body for creating a DUET surface fuel grid from a tree
+            grid.
+
+            Does not extend CreateGridRequestBase: like the 3D grids it derives from,
+            DUET grids do not support modifications.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
+    """
+
+    kwargs = _get_kwargs(
+        domain_id=domain_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateDuetRequest,
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
+    r"""Create a surface fuel grid with DUET
+
+     # Create a DUET Surface Fuel Grid
+
+    Runs DUET (Distribution of Understory using Elliptical Transport) over a 3D
+    tree grid to produce 2D surface fuels. DUET drops leaf and needle litter
+    from each tree's crown along wind-driven elliptical fall trajectories, then
+    grows grass as a function of shade and litter cover — so litter accumulates
+    under and downwind of crowns, and grass fills the gaps between them.
+
+    ## What DUET does and does not give you
+
+    DUET supplies the **spatial pattern** of surface fuels, keyed to real canopy
+    structure. It does **not** supply physical magnitudes: raw DUET loadings are
+    idiosyncratic to the model and should not be read as fuel loads or fed to a
+    fire model as-is. Use `calibration` to impose magnitudes you trust — from
+    field data, from the literature, or from an FBFM40 grid.
+
+    ## Request Body
+
+    - **source_grid_id**: (required) A completed 3D tree grid carrying the
+      `bulk_density.foliage.live`, `spcd`, and `fuel_moisture.live` bands.
+      Create one with `POST /grids/voxelize/inventory/tree`, requesting those
+      three bands — `spcd` in particular is not voxelized by default.
+    - **years_since_burn**: (required) Years of litter accumulation to simulate,
+      1–100. DUET starts from the year of the last fire, with grass and litter
+      consumed, so this is the stand's time since fire. It is the single most
+      consequential parameter: a low value yields almost no litter because there
+      has been no time for any to fall. It also drives runtime.
+    - **wind_direction**: (optional) Degrees clockwise from north. Default 270.
+    - **wind_variability**: (optional) Angular spread in degrees. Default 30.
+    - **bands**: (optional) Output bands. Defaults to `fuel_load.grass` and
+      `fuel_load.litter`. DUET separates fuels by type rather than size class,
+      so bands are named for `grass`, `litter` (and its `litter.coniferous` /
+      `litter.deciduous` parts), and `total`.
+    - **calibration**: (optional) Per-parameter, per-fuel-type targets. Omit to
+      store raw output.
+    - **name**, **description**, **tags**: (optional) Standard metadata.
+
+    ## Calibration
+
+    Each of `fuel_load`, `fuel_depth`, and `fuel_moisture` is calibrated
+    independently, and within each, per fuel type (`grass`, `coniferous`,
+    `deciduous`, `litter`, or `all` — which is exclusive of the others). Methods:
+
+    - `maxmin` — rescale to a target maximum and minimum. Best when fuel data
+      are limited, or when their distribution does not resemble DUET's.
+    - `meansd` — rescale to a target mean and standard deviation. Appropriate
+      only when the targets come from a dataset large enough to approximate a
+      normal distribution.
+    - `constant` — assign a single value. Reasonable only when that is the only
+      value available.
+
+    Calibration rescales only cells that already carry fuel; cells DUET left
+    empty stay empty. A consequence worth expecting: where cover is sparse, the
+    domain-wide mean will sit well below a `meansd` target, because the target
+    applies to the covered cells rather than to the domain.
+
+    ## Response
+
+    Returns the created Grid with status `\"pending\"` and `georeference: null`.
+    Treevox runs DUET asynchronously and updates the grid to `\"completed\"` with
+    a 2D `Georeference` when done.
+
+    Args:
+        domain_id (str):
+        body (CreateDuetRequest): Request body for creating a DUET surface fuel grid from a tree
+            grid.
+
+            Does not extend CreateGridRequestBase: like the 3D grids it derives from,
+            DUET grids do not support modifications.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Grid | HTTPValidationError | QuotaExceededDetail
+    """
+
+    return (
+        await asyncio_detailed(
+            domain_id=domain_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/fastfuels_sdk/v2/client_library/api/grids/create_fbfm13_lookup.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_fbfm13_lookup.py
@@ -1,0 +1,408 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.create_fbfm_13_lookup_request import CreateFbfm13LookupRequest
+from ...models.grid import Grid
+from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
+from ...types import Response
+
+
+def _get_kwargs(
+    domain_id: str,
+    *,
+    body: CreateFbfm13LookupRequest,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/domains/{domain_id}/grids/lookup/fbfm13".format(
+            domain_id=quote(str(domain_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
+    if response.status_code == 201:
+        response_201 = Grid.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateFbfm13LookupRequest,
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
+    r"""Create a grid by looking up FBFM13 fuel parameters
+
+     # Create FBFM13 Lookup Grid
+
+    Converts Anderson 13 fuel model codes to fuel parameters using the
+    Anderson 13 lookup table.
+
+    Takes a source grid containing categorical FBFM13 codes (from
+    `/grids/fbfm13/landfire`) and produces a new grid with the requested
+    continuous fuel parameters.
+
+    ## Request Body
+
+    - **source_grid_id**: (required) Grid containing FBFM13 codes.
+    - **bands**: (required) Bands to look up. Valid values:
+      - `fuel_load.1hr`, `fuel_load.10hr`, `fuel_load.100hr` - Dead fuel loads (kg/m**2)
+      - `fuel_load.live_foliage` - Live foliage fuel loads (kg/m**2)
+      - `savr.1hr`, `savr.10hr`, `savr.100hr` - Dead fuel SAV ratios (1/m)
+      - `savr.live_foliage` - Live foliage fuel SAV ratios (1/m)
+      - `fuel_depth` - Fuel bed depth (m)
+    - **source_band**: (optional) Band in source grid containing FBFM13 codes. Defaults to `\"fbfm13\"`.
+    - **name**: (optional) Name for the grid.
+    - **description**: (optional) Description.
+    - **tags**: (optional) Tags for organizing grids.
+
+    ## Valid FBFM13 Codes
+
+    The source grid must contain only valid Anderson 13 fuel model codes.
+    The 18 valid codes are:
+
+    - **NB** (non-burnable): 91, 92, 93, 98, 99
+    - **Anderson 13 models**: 1–13
+
+    If any cell in the source grid contains a code not in this set (including 0
+    or nodata), the job will fail with an `INVALID_FBFM_CODES` error listing
+    the invalid codes found.
+
+    ## Response
+
+    Returns the created Grid with status \"pending\". The backend applies the
+    lookup transformation and updates status to \"completed\" when ready.
+
+    ## Notes
+
+    - Domain is propagated from the source grid (derived grids carry the
+      same domain reference as their source).
+    - The output grid inherits georeference from the source grid.
+    - Non-burnable codes (91-99) produce zero values for all bands.
+    - Fuel parameter values are from Anderson, Hal E. 1982. *Aids to
+      determining fuel models for estimating fire behavior.* USDA Forest
+      Service General Technical Report INT-122.
+    - All output values are in metric units (converted from Anderson 13 imperial values).
+
+    Args:
+        domain_id (str):
+        body (CreateFbfm13LookupRequest): Request to create a grid by looking up FBFM13 fuel
+            parameters.
+
+            Unlike entry-point grid creation requests, domain_id is not required
+            because derived grids carry the same domain reference as their source.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
+    """
+
+    kwargs = _get_kwargs(
+        domain_id=domain_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateFbfm13LookupRequest,
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
+    r"""Create a grid by looking up FBFM13 fuel parameters
+
+     # Create FBFM13 Lookup Grid
+
+    Converts Anderson 13 fuel model codes to fuel parameters using the
+    Anderson 13 lookup table.
+
+    Takes a source grid containing categorical FBFM13 codes (from
+    `/grids/fbfm13/landfire`) and produces a new grid with the requested
+    continuous fuel parameters.
+
+    ## Request Body
+
+    - **source_grid_id**: (required) Grid containing FBFM13 codes.
+    - **bands**: (required) Bands to look up. Valid values:
+      - `fuel_load.1hr`, `fuel_load.10hr`, `fuel_load.100hr` - Dead fuel loads (kg/m**2)
+      - `fuel_load.live_foliage` - Live foliage fuel loads (kg/m**2)
+      - `savr.1hr`, `savr.10hr`, `savr.100hr` - Dead fuel SAV ratios (1/m)
+      - `savr.live_foliage` - Live foliage fuel SAV ratios (1/m)
+      - `fuel_depth` - Fuel bed depth (m)
+    - **source_band**: (optional) Band in source grid containing FBFM13 codes. Defaults to `\"fbfm13\"`.
+    - **name**: (optional) Name for the grid.
+    - **description**: (optional) Description.
+    - **tags**: (optional) Tags for organizing grids.
+
+    ## Valid FBFM13 Codes
+
+    The source grid must contain only valid Anderson 13 fuel model codes.
+    The 18 valid codes are:
+
+    - **NB** (non-burnable): 91, 92, 93, 98, 99
+    - **Anderson 13 models**: 1–13
+
+    If any cell in the source grid contains a code not in this set (including 0
+    or nodata), the job will fail with an `INVALID_FBFM_CODES` error listing
+    the invalid codes found.
+
+    ## Response
+
+    Returns the created Grid with status \"pending\". The backend applies the
+    lookup transformation and updates status to \"completed\" when ready.
+
+    ## Notes
+
+    - Domain is propagated from the source grid (derived grids carry the
+      same domain reference as their source).
+    - The output grid inherits georeference from the source grid.
+    - Non-burnable codes (91-99) produce zero values for all bands.
+    - Fuel parameter values are from Anderson, Hal E. 1982. *Aids to
+      determining fuel models for estimating fire behavior.* USDA Forest
+      Service General Technical Report INT-122.
+    - All output values are in metric units (converted from Anderson 13 imperial values).
+
+    Args:
+        domain_id (str):
+        body (CreateFbfm13LookupRequest): Request to create a grid by looking up FBFM13 fuel
+            parameters.
+
+            Unlike entry-point grid creation requests, domain_id is not required
+            because derived grids carry the same domain reference as their source.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Grid | HTTPValidationError | QuotaExceededDetail
+    """
+
+    return sync_detailed(
+        domain_id=domain_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateFbfm13LookupRequest,
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
+    r"""Create a grid by looking up FBFM13 fuel parameters
+
+     # Create FBFM13 Lookup Grid
+
+    Converts Anderson 13 fuel model codes to fuel parameters using the
+    Anderson 13 lookup table.
+
+    Takes a source grid containing categorical FBFM13 codes (from
+    `/grids/fbfm13/landfire`) and produces a new grid with the requested
+    continuous fuel parameters.
+
+    ## Request Body
+
+    - **source_grid_id**: (required) Grid containing FBFM13 codes.
+    - **bands**: (required) Bands to look up. Valid values:
+      - `fuel_load.1hr`, `fuel_load.10hr`, `fuel_load.100hr` - Dead fuel loads (kg/m**2)
+      - `fuel_load.live_foliage` - Live foliage fuel loads (kg/m**2)
+      - `savr.1hr`, `savr.10hr`, `savr.100hr` - Dead fuel SAV ratios (1/m)
+      - `savr.live_foliage` - Live foliage fuel SAV ratios (1/m)
+      - `fuel_depth` - Fuel bed depth (m)
+    - **source_band**: (optional) Band in source grid containing FBFM13 codes. Defaults to `\"fbfm13\"`.
+    - **name**: (optional) Name for the grid.
+    - **description**: (optional) Description.
+    - **tags**: (optional) Tags for organizing grids.
+
+    ## Valid FBFM13 Codes
+
+    The source grid must contain only valid Anderson 13 fuel model codes.
+    The 18 valid codes are:
+
+    - **NB** (non-burnable): 91, 92, 93, 98, 99
+    - **Anderson 13 models**: 1–13
+
+    If any cell in the source grid contains a code not in this set (including 0
+    or nodata), the job will fail with an `INVALID_FBFM_CODES` error listing
+    the invalid codes found.
+
+    ## Response
+
+    Returns the created Grid with status \"pending\". The backend applies the
+    lookup transformation and updates status to \"completed\" when ready.
+
+    ## Notes
+
+    - Domain is propagated from the source grid (derived grids carry the
+      same domain reference as their source).
+    - The output grid inherits georeference from the source grid.
+    - Non-burnable codes (91-99) produce zero values for all bands.
+    - Fuel parameter values are from Anderson, Hal E. 1982. *Aids to
+      determining fuel models for estimating fire behavior.* USDA Forest
+      Service General Technical Report INT-122.
+    - All output values are in metric units (converted from Anderson 13 imperial values).
+
+    Args:
+        domain_id (str):
+        body (CreateFbfm13LookupRequest): Request to create a grid by looking up FBFM13 fuel
+            parameters.
+
+            Unlike entry-point grid creation requests, domain_id is not required
+            because derived grids carry the same domain reference as their source.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
+    """
+
+    kwargs = _get_kwargs(
+        domain_id=domain_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateFbfm13LookupRequest,
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
+    r"""Create a grid by looking up FBFM13 fuel parameters
+
+     # Create FBFM13 Lookup Grid
+
+    Converts Anderson 13 fuel model codes to fuel parameters using the
+    Anderson 13 lookup table.
+
+    Takes a source grid containing categorical FBFM13 codes (from
+    `/grids/fbfm13/landfire`) and produces a new grid with the requested
+    continuous fuel parameters.
+
+    ## Request Body
+
+    - **source_grid_id**: (required) Grid containing FBFM13 codes.
+    - **bands**: (required) Bands to look up. Valid values:
+      - `fuel_load.1hr`, `fuel_load.10hr`, `fuel_load.100hr` - Dead fuel loads (kg/m**2)
+      - `fuel_load.live_foliage` - Live foliage fuel loads (kg/m**2)
+      - `savr.1hr`, `savr.10hr`, `savr.100hr` - Dead fuel SAV ratios (1/m)
+      - `savr.live_foliage` - Live foliage fuel SAV ratios (1/m)
+      - `fuel_depth` - Fuel bed depth (m)
+    - **source_band**: (optional) Band in source grid containing FBFM13 codes. Defaults to `\"fbfm13\"`.
+    - **name**: (optional) Name for the grid.
+    - **description**: (optional) Description.
+    - **tags**: (optional) Tags for organizing grids.
+
+    ## Valid FBFM13 Codes
+
+    The source grid must contain only valid Anderson 13 fuel model codes.
+    The 18 valid codes are:
+
+    - **NB** (non-burnable): 91, 92, 93, 98, 99
+    - **Anderson 13 models**: 1–13
+
+    If any cell in the source grid contains a code not in this set (including 0
+    or nodata), the job will fail with an `INVALID_FBFM_CODES` error listing
+    the invalid codes found.
+
+    ## Response
+
+    Returns the created Grid with status \"pending\". The backend applies the
+    lookup transformation and updates status to \"completed\" when ready.
+
+    ## Notes
+
+    - Domain is propagated from the source grid (derived grids carry the
+      same domain reference as their source).
+    - The output grid inherits georeference from the source grid.
+    - Non-burnable codes (91-99) produce zero values for all bands.
+    - Fuel parameter values are from Anderson, Hal E. 1982. *Aids to
+      determining fuel models for estimating fire behavior.* USDA Forest
+      Service General Technical Report INT-122.
+    - All output values are in metric units (converted from Anderson 13 imperial values).
+
+    Args:
+        domain_id (str):
+        body (CreateFbfm13LookupRequest): Request to create a grid by looking up FBFM13 fuel
+            parameters.
+
+            Unlike entry-point grid creation requests, domain_id is not required
+            because derived grids carry the same domain reference as their source.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Grid | HTTPValidationError | QuotaExceededDetail
+    """
+
+    return (
+        await asyncio_detailed(
+            domain_id=domain_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/fastfuels_sdk/v2/client_library/api/grids/create_fbfm40_lookup.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_fbfm40_lookup.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_fbfm_40_lookup_request import CreateFbfm40LookupRequest
 from ...models.grid import Grid
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -36,7 +37,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Grid.from_dict(response.json())
 
@@ -47,6 +48,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,7 +61,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +75,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateFbfm40LookupRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid by looking up FBFM40 fuel parameters
 
      # Create FBFM40 Lookup Grid
@@ -138,7 +144,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -158,7 +164,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateFbfm40LookupRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid by looking up FBFM40 fuel parameters
 
      # Create FBFM40 Lookup Grid
@@ -227,7 +233,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -242,7 +248,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateFbfm40LookupRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid by looking up FBFM40 fuel parameters
 
      # Create FBFM40 Lookup Grid
@@ -311,7 +317,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -329,7 +335,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateFbfm40LookupRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid by looking up FBFM40 fuel parameters
 
      # Create FBFM40 Lookup Grid
@@ -398,7 +404,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/grids/create_fccs_lookup.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_fccs_lookup.py
@@ -1,0 +1,464 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.create_fccs_lookup_request import CreateFccsLookupRequest
+from ...models.grid import Grid
+from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
+from ...types import Response
+
+
+def _get_kwargs(
+    domain_id: str,
+    *,
+    body: CreateFccsLookupRequest,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/domains/{domain_id}/grids/lookup/fccs".format(
+            domain_id=quote(str(domain_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
+    if response.status_code == 201:
+        response_201 = Grid.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateFccsLookupRequest,
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
+    r"""Create a grid by looking up FCCS fuel parameters
+
+     # Create FCCS Lookup Grid
+
+    Converts FCCS fuelbed codes to fuel parameters using the FOFEM FCCS
+    fuelbed lookup table (see the
+    [FOFEM/SpatialFOFEM FCCS lookup table](https://www.landfire.gov/sites/default/files/CSV/SpatialFOFEM
+    _FCCS_Formatted_TS_06-27-24.csv),
+    the USDA Forest Service data source this endpoint converts).
+
+    Takes a source grid containing categorical FCCS codes (from
+    `/grids/fccs/landfire`) and produces a new grid with the requested
+    continuous fuel parameters.
+
+    ## Request Body
+
+    - **source_grid_id**: (required) Grid containing FCCS codes.
+    - **bands**: (required) Bands to look up. Valid values:
+      - `fuel_load.litter`, `fuel_load.duff` - Ground fuel loads (kg/m**2)
+      - `duff_depth` - Duff layer depth (m)
+      - `fuel_load.live_shrub`, `fuel_load.live_herb` - Live surface fuel loads (kg/m**2)
+      - `fuel_load.1hr`, `fuel_load.10hr`, `fuel_load.100hr` - Dead fuel loads (kg/m**2)
+      - `fuel_load.1000hr_sound`, `fuel_load.1000hr_rotten` - Dead fuel loads, >3in. diameter (kg/m**2)
+      - `fuel_load.live_foliage`, `fuel_load.live_branch` - Live crown fuel loads (kg/m**2)
+    - **source_band**: (optional) Band in source grid containing FCCS codes. Defaults to `\"fccs\"`.
+    - **name**: (optional) Name for the grid.
+    - **description**: (optional) Description.
+    - **tags**: (optional) Tags for organizing grids.
+
+    ## Band Coverage
+
+    These 12 bands are a starting subset of what FOFEM provides, not the
+    full table. `fuel_load.1000hr_sound` and `fuel_load.1000hr_rotten`
+    are each calculated by summing three FOFEM size-class columns
+    (3-9 in., 9-20 in., 20+ in.) rather than mapping to a single source
+    column. FOFEM also provides finer sound/rotten size-class
+    breakdowns, a cover-group code, and emission factors that aren't
+    exposed as bands here — additional bands can be added on request.
+
+    ## Valid FCCS Codes
+
+    Each `FCCS` code is a synthetic key: `base * 10_000 + suffix`, where
+    `base` is the `FCCSID` fuelbed number and the 3-digit `suffix`
+    encodes an FCCS Potential rating (Fire Behavior / Crown Fire /
+    Available Fuel Potential, each a 0-9 digit) per the [Fuel Characteristic
+    Classification System Version 3.0: Technical Documentation (PNW-
+    GTR-887)](https://www.fs.usda.gov/pnw/pubs/pnw_gtr887.pdf).
+
+    The source grid must contain FCCS codes whose base fuelbed number matches
+    a recognized `FCCSID`. A code with a valid base but no matching row in the
+    FOFEM lookup table is not an error. It's a fuelbed/fire-potential combination
+    the table doesn't cover, so its output is `NaN` for every band, and a
+    progress warning lists these codes.
+
+    ## Response
+
+    Returns the created Grid with status \"pending\". The backend applies the
+    lookup transformation and updates status to \"completed\" when ready.
+
+    ## Notes
+
+    - Domain is propagated from the source grid (derived grids carry the
+      same domain reference as their source).
+    - The output grid inherits georeference from the source grid.
+    - All output values are in metric units (converted from FOFEM imperial
+      values).
+
+    Args:
+        domain_id (str):
+        body (CreateFccsLookupRequest): Request to create a grid by looking up FCCS fuel
+            parameters.
+
+            Unlike entry-point grid creation requests, domain_id is not required
+            because derived grids carry the same domain reference as their source.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
+    """
+
+    kwargs = _get_kwargs(
+        domain_id=domain_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateFccsLookupRequest,
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
+    r"""Create a grid by looking up FCCS fuel parameters
+
+     # Create FCCS Lookup Grid
+
+    Converts FCCS fuelbed codes to fuel parameters using the FOFEM FCCS
+    fuelbed lookup table (see the
+    [FOFEM/SpatialFOFEM FCCS lookup table](https://www.landfire.gov/sites/default/files/CSV/SpatialFOFEM
+    _FCCS_Formatted_TS_06-27-24.csv),
+    the USDA Forest Service data source this endpoint converts).
+
+    Takes a source grid containing categorical FCCS codes (from
+    `/grids/fccs/landfire`) and produces a new grid with the requested
+    continuous fuel parameters.
+
+    ## Request Body
+
+    - **source_grid_id**: (required) Grid containing FCCS codes.
+    - **bands**: (required) Bands to look up. Valid values:
+      - `fuel_load.litter`, `fuel_load.duff` - Ground fuel loads (kg/m**2)
+      - `duff_depth` - Duff layer depth (m)
+      - `fuel_load.live_shrub`, `fuel_load.live_herb` - Live surface fuel loads (kg/m**2)
+      - `fuel_load.1hr`, `fuel_load.10hr`, `fuel_load.100hr` - Dead fuel loads (kg/m**2)
+      - `fuel_load.1000hr_sound`, `fuel_load.1000hr_rotten` - Dead fuel loads, >3in. diameter (kg/m**2)
+      - `fuel_load.live_foliage`, `fuel_load.live_branch` - Live crown fuel loads (kg/m**2)
+    - **source_band**: (optional) Band in source grid containing FCCS codes. Defaults to `\"fccs\"`.
+    - **name**: (optional) Name for the grid.
+    - **description**: (optional) Description.
+    - **tags**: (optional) Tags for organizing grids.
+
+    ## Band Coverage
+
+    These 12 bands are a starting subset of what FOFEM provides, not the
+    full table. `fuel_load.1000hr_sound` and `fuel_load.1000hr_rotten`
+    are each calculated by summing three FOFEM size-class columns
+    (3-9 in., 9-20 in., 20+ in.) rather than mapping to a single source
+    column. FOFEM also provides finer sound/rotten size-class
+    breakdowns, a cover-group code, and emission factors that aren't
+    exposed as bands here — additional bands can be added on request.
+
+    ## Valid FCCS Codes
+
+    Each `FCCS` code is a synthetic key: `base * 10_000 + suffix`, where
+    `base` is the `FCCSID` fuelbed number and the 3-digit `suffix`
+    encodes an FCCS Potential rating (Fire Behavior / Crown Fire /
+    Available Fuel Potential, each a 0-9 digit) per the [Fuel Characteristic
+    Classification System Version 3.0: Technical Documentation (PNW-
+    GTR-887)](https://www.fs.usda.gov/pnw/pubs/pnw_gtr887.pdf).
+
+    The source grid must contain FCCS codes whose base fuelbed number matches
+    a recognized `FCCSID`. A code with a valid base but no matching row in the
+    FOFEM lookup table is not an error. It's a fuelbed/fire-potential combination
+    the table doesn't cover, so its output is `NaN` for every band, and a
+    progress warning lists these codes.
+
+    ## Response
+
+    Returns the created Grid with status \"pending\". The backend applies the
+    lookup transformation and updates status to \"completed\" when ready.
+
+    ## Notes
+
+    - Domain is propagated from the source grid (derived grids carry the
+      same domain reference as their source).
+    - The output grid inherits georeference from the source grid.
+    - All output values are in metric units (converted from FOFEM imperial
+      values).
+
+    Args:
+        domain_id (str):
+        body (CreateFccsLookupRequest): Request to create a grid by looking up FCCS fuel
+            parameters.
+
+            Unlike entry-point grid creation requests, domain_id is not required
+            because derived grids carry the same domain reference as their source.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Grid | HTTPValidationError | QuotaExceededDetail
+    """
+
+    return sync_detailed(
+        domain_id=domain_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateFccsLookupRequest,
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
+    r"""Create a grid by looking up FCCS fuel parameters
+
+     # Create FCCS Lookup Grid
+
+    Converts FCCS fuelbed codes to fuel parameters using the FOFEM FCCS
+    fuelbed lookup table (see the
+    [FOFEM/SpatialFOFEM FCCS lookup table](https://www.landfire.gov/sites/default/files/CSV/SpatialFOFEM
+    _FCCS_Formatted_TS_06-27-24.csv),
+    the USDA Forest Service data source this endpoint converts).
+
+    Takes a source grid containing categorical FCCS codes (from
+    `/grids/fccs/landfire`) and produces a new grid with the requested
+    continuous fuel parameters.
+
+    ## Request Body
+
+    - **source_grid_id**: (required) Grid containing FCCS codes.
+    - **bands**: (required) Bands to look up. Valid values:
+      - `fuel_load.litter`, `fuel_load.duff` - Ground fuel loads (kg/m**2)
+      - `duff_depth` - Duff layer depth (m)
+      - `fuel_load.live_shrub`, `fuel_load.live_herb` - Live surface fuel loads (kg/m**2)
+      - `fuel_load.1hr`, `fuel_load.10hr`, `fuel_load.100hr` - Dead fuel loads (kg/m**2)
+      - `fuel_load.1000hr_sound`, `fuel_load.1000hr_rotten` - Dead fuel loads, >3in. diameter (kg/m**2)
+      - `fuel_load.live_foliage`, `fuel_load.live_branch` - Live crown fuel loads (kg/m**2)
+    - **source_band**: (optional) Band in source grid containing FCCS codes. Defaults to `\"fccs\"`.
+    - **name**: (optional) Name for the grid.
+    - **description**: (optional) Description.
+    - **tags**: (optional) Tags for organizing grids.
+
+    ## Band Coverage
+
+    These 12 bands are a starting subset of what FOFEM provides, not the
+    full table. `fuel_load.1000hr_sound` and `fuel_load.1000hr_rotten`
+    are each calculated by summing three FOFEM size-class columns
+    (3-9 in., 9-20 in., 20+ in.) rather than mapping to a single source
+    column. FOFEM also provides finer sound/rotten size-class
+    breakdowns, a cover-group code, and emission factors that aren't
+    exposed as bands here — additional bands can be added on request.
+
+    ## Valid FCCS Codes
+
+    Each `FCCS` code is a synthetic key: `base * 10_000 + suffix`, where
+    `base` is the `FCCSID` fuelbed number and the 3-digit `suffix`
+    encodes an FCCS Potential rating (Fire Behavior / Crown Fire /
+    Available Fuel Potential, each a 0-9 digit) per the [Fuel Characteristic
+    Classification System Version 3.0: Technical Documentation (PNW-
+    GTR-887)](https://www.fs.usda.gov/pnw/pubs/pnw_gtr887.pdf).
+
+    The source grid must contain FCCS codes whose base fuelbed number matches
+    a recognized `FCCSID`. A code with a valid base but no matching row in the
+    FOFEM lookup table is not an error. It's a fuelbed/fire-potential combination
+    the table doesn't cover, so its output is `NaN` for every band, and a
+    progress warning lists these codes.
+
+    ## Response
+
+    Returns the created Grid with status \"pending\". The backend applies the
+    lookup transformation and updates status to \"completed\" when ready.
+
+    ## Notes
+
+    - Domain is propagated from the source grid (derived grids carry the
+      same domain reference as their source).
+    - The output grid inherits georeference from the source grid.
+    - All output values are in metric units (converted from FOFEM imperial
+      values).
+
+    Args:
+        domain_id (str):
+        body (CreateFccsLookupRequest): Request to create a grid by looking up FCCS fuel
+            parameters.
+
+            Unlike entry-point grid creation requests, domain_id is not required
+            because derived grids carry the same domain reference as their source.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
+    """
+
+    kwargs = _get_kwargs(
+        domain_id=domain_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateFccsLookupRequest,
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
+    r"""Create a grid by looking up FCCS fuel parameters
+
+     # Create FCCS Lookup Grid
+
+    Converts FCCS fuelbed codes to fuel parameters using the FOFEM FCCS
+    fuelbed lookup table (see the
+    [FOFEM/SpatialFOFEM FCCS lookup table](https://www.landfire.gov/sites/default/files/CSV/SpatialFOFEM
+    _FCCS_Formatted_TS_06-27-24.csv),
+    the USDA Forest Service data source this endpoint converts).
+
+    Takes a source grid containing categorical FCCS codes (from
+    `/grids/fccs/landfire`) and produces a new grid with the requested
+    continuous fuel parameters.
+
+    ## Request Body
+
+    - **source_grid_id**: (required) Grid containing FCCS codes.
+    - **bands**: (required) Bands to look up. Valid values:
+      - `fuel_load.litter`, `fuel_load.duff` - Ground fuel loads (kg/m**2)
+      - `duff_depth` - Duff layer depth (m)
+      - `fuel_load.live_shrub`, `fuel_load.live_herb` - Live surface fuel loads (kg/m**2)
+      - `fuel_load.1hr`, `fuel_load.10hr`, `fuel_load.100hr` - Dead fuel loads (kg/m**2)
+      - `fuel_load.1000hr_sound`, `fuel_load.1000hr_rotten` - Dead fuel loads, >3in. diameter (kg/m**2)
+      - `fuel_load.live_foliage`, `fuel_load.live_branch` - Live crown fuel loads (kg/m**2)
+    - **source_band**: (optional) Band in source grid containing FCCS codes. Defaults to `\"fccs\"`.
+    - **name**: (optional) Name for the grid.
+    - **description**: (optional) Description.
+    - **tags**: (optional) Tags for organizing grids.
+
+    ## Band Coverage
+
+    These 12 bands are a starting subset of what FOFEM provides, not the
+    full table. `fuel_load.1000hr_sound` and `fuel_load.1000hr_rotten`
+    are each calculated by summing three FOFEM size-class columns
+    (3-9 in., 9-20 in., 20+ in.) rather than mapping to a single source
+    column. FOFEM also provides finer sound/rotten size-class
+    breakdowns, a cover-group code, and emission factors that aren't
+    exposed as bands here — additional bands can be added on request.
+
+    ## Valid FCCS Codes
+
+    Each `FCCS` code is a synthetic key: `base * 10_000 + suffix`, where
+    `base` is the `FCCSID` fuelbed number and the 3-digit `suffix`
+    encodes an FCCS Potential rating (Fire Behavior / Crown Fire /
+    Available Fuel Potential, each a 0-9 digit) per the [Fuel Characteristic
+    Classification System Version 3.0: Technical Documentation (PNW-
+    GTR-887)](https://www.fs.usda.gov/pnw/pubs/pnw_gtr887.pdf).
+
+    The source grid must contain FCCS codes whose base fuelbed number matches
+    a recognized `FCCSID`. A code with a valid base but no matching row in the
+    FOFEM lookup table is not an error. It's a fuelbed/fire-potential combination
+    the table doesn't cover, so its output is `NaN` for every band, and a
+    progress warning lists these codes.
+
+    ## Response
+
+    Returns the created Grid with status \"pending\". The backend applies the
+    lookup transformation and updates status to \"completed\" when ready.
+
+    ## Notes
+
+    - Domain is propagated from the source grid (derived grids carry the
+      same domain reference as their source).
+    - The output grid inherits georeference from the source grid.
+    - All output values are in metric units (converted from FOFEM imperial
+      values).
+
+    Args:
+        domain_id (str):
+        body (CreateFccsLookupRequest): Request to create a grid by looking up FCCS fuel
+            parameters.
+
+            Unlike entry-point grid creation requests, domain_id is not required
+            because derived grids carry the same domain reference as their source.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Grid | HTTPValidationError | QuotaExceededDetail
+    """
+
+    return (
+        await asyncio_detailed(
+            domain_id=domain_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/fastfuels_sdk/v2/client_library/api/grids/create_geotiff_upload.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_geotiff_upload.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_geo_tiff_upload_request import CreateGeoTIFFUploadRequest
 from ...models.grid_upload_created_response import GridUploadCreatedResponse
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -36,7 +37,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> GridUploadCreatedResponse | HTTPValidationError | None:
+) -> GridUploadCreatedResponse | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = GridUploadCreatedResponse.from_dict(response.json())
 
@@ -47,6 +48,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,7 +61,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[GridUploadCreatedResponse | HTTPValidationError]:
+) -> Response[GridUploadCreatedResponse | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +75,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateGeoTIFFUploadRequest,
-) -> Response[GridUploadCreatedResponse | HTTPValidationError]:
+) -> Response[GridUploadCreatedResponse | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid from a direct GeoTIFF upload
 
      # Create Upload Grid (GeoTIFF)
@@ -120,7 +126,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[GridUploadCreatedResponse | HTTPValidationError]
+        Response[GridUploadCreatedResponse | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -140,7 +146,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateGeoTIFFUploadRequest,
-) -> GridUploadCreatedResponse | HTTPValidationError | None:
+) -> GridUploadCreatedResponse | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid from a direct GeoTIFF upload
 
      # Create Upload Grid (GeoTIFF)
@@ -191,7 +197,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        GridUploadCreatedResponse | HTTPValidationError
+        GridUploadCreatedResponse | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -206,7 +212,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateGeoTIFFUploadRequest,
-) -> Response[GridUploadCreatedResponse | HTTPValidationError]:
+) -> Response[GridUploadCreatedResponse | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid from a direct GeoTIFF upload
 
      # Create Upload Grid (GeoTIFF)
@@ -257,7 +263,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[GridUploadCreatedResponse | HTTPValidationError]
+        Response[GridUploadCreatedResponse | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -275,7 +281,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateGeoTIFFUploadRequest,
-) -> GridUploadCreatedResponse | HTTPValidationError | None:
+) -> GridUploadCreatedResponse | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid from a direct GeoTIFF upload
 
      # Create Upload Grid (GeoTIFF)
@@ -326,7 +332,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        GridUploadCreatedResponse | HTTPValidationError
+        GridUploadCreatedResponse | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/grids/create_grid_export.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_grid_export.py
@@ -10,6 +10,7 @@ from ...models.export import Export
 from ...models.export_grid_request import ExportGridRequest
 from ...models.grid_export_format import GridExportFormat
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -41,7 +42,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Export | HTTPValidationError | None:
+) -> Export | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Export.from_dict(response.json())
 
@@ -52,6 +53,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -60,7 +66,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Export | HTTPValidationError]:
+) -> Response[Export | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -76,7 +82,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: ExportGridRequest,
-) -> Response[Export | HTTPValidationError]:
+) -> Response[Export | HTTPValidationError | QuotaExceededDetail]:
     """Export a grid
 
      Export a grid to the specified format.
@@ -106,7 +112,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Export | HTTPValidationError]
+        Response[Export | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -130,7 +136,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: ExportGridRequest,
-) -> Export | HTTPValidationError | None:
+) -> Export | HTTPValidationError | QuotaExceededDetail | None:
     """Export a grid
 
      Export a grid to the specified format.
@@ -160,7 +166,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Export | HTTPValidationError
+        Export | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -179,7 +185,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: ExportGridRequest,
-) -> Response[Export | HTTPValidationError]:
+) -> Response[Export | HTTPValidationError | QuotaExceededDetail]:
     """Export a grid
 
      Export a grid to the specified format.
@@ -209,7 +215,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Export | HTTPValidationError]
+        Response[Export | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -231,7 +237,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: ExportGridRequest,
-) -> Export | HTTPValidationError | None:
+) -> Export | HTTPValidationError | QuotaExceededDetail | None:
     """Export a grid
 
      Export a grid to the specified format.
@@ -261,7 +267,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Export | HTTPValidationError
+        Export | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/grids/create_landfire_canopy.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_landfire_canopy.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_landfire_canopy_request import CreateLandfireCanopyRequest
 from ...models.grid import Grid
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -36,7 +37,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Grid.from_dict(response.json())
 
@@ -47,6 +48,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,7 +61,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +75,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateLandfireCanopyRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid from LANDFIRE canopy data
 
      # Create LANDFIRE Canopy Grid
@@ -118,7 +124,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -138,7 +144,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateLandfireCanopyRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid from LANDFIRE canopy data
 
      # Create LANDFIRE Canopy Grid
@@ -187,7 +193,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -202,7 +208,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateLandfireCanopyRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid from LANDFIRE canopy data
 
      # Create LANDFIRE Canopy Grid
@@ -251,7 +257,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -269,7 +275,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateLandfireCanopyRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid from LANDFIRE canopy data
 
      # Create LANDFIRE Canopy Grid
@@ -318,7 +324,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/grids/create_landfire_fbfm13.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_landfire_fbfm13.py
@@ -1,0 +1,288 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.create_landfire_fbfm_13_request import CreateLandfireFbfm13Request
+from ...models.grid import Grid
+from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
+from ...types import Response
+
+
+def _get_kwargs(
+    domain_id: str,
+    *,
+    body: CreateLandfireFbfm13Request,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/domains/{domain_id}/grids/fbfm13/landfire".format(
+            domain_id=quote(str(domain_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
+    if response.status_code == 201:
+        response_201 = Grid.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateLandfireFbfm13Request,
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
+    r"""Create a grid from LANDFIRE FBFM13
+
+     # Create LANDFIRE FBFM13 Grid
+
+    Creates a grid with FBFM13 fuel model codes from LANDFIRE at 30m resolution.
+
+    The grid contains a single categorical band (`fbfm13`) with Anderson 13
+    fuel model codes (1-13).
+
+    To convert fuel model codes to fuel parameters (fuel loads, SAV,
+    depth), use the `/grids/lookup/fbfm13` endpoint.
+
+    ## Request Body
+
+    - **name**: (optional) Name for the grid.
+    - **description**: (optional) Description.
+    - **tags**: (optional) Tags for organizing grids.
+    - **version**: (optional) LANDFIRE version. Default: \"2024\".
+
+    ## Response
+
+    Returns the created Grid resource with status \"pending\". The backend will
+    fetch the data and update status to \"completed\" when ready.
+
+    Args:
+        domain_id (str):
+        body (CreateLandfireFbfm13Request): Request to create a grid from LANDFIRE FBFM13.
+
+            Returns a single-band grid with categorical fuel model codes.
+            To convert codes to fuel parameters, use /grids/lookup/fbfm13.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
+    """
+
+    kwargs = _get_kwargs(
+        domain_id=domain_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateLandfireFbfm13Request,
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
+    r"""Create a grid from LANDFIRE FBFM13
+
+     # Create LANDFIRE FBFM13 Grid
+
+    Creates a grid with FBFM13 fuel model codes from LANDFIRE at 30m resolution.
+
+    The grid contains a single categorical band (`fbfm13`) with Anderson 13
+    fuel model codes (1-13).
+
+    To convert fuel model codes to fuel parameters (fuel loads, SAV,
+    depth), use the `/grids/lookup/fbfm13` endpoint.
+
+    ## Request Body
+
+    - **name**: (optional) Name for the grid.
+    - **description**: (optional) Description.
+    - **tags**: (optional) Tags for organizing grids.
+    - **version**: (optional) LANDFIRE version. Default: \"2024\".
+
+    ## Response
+
+    Returns the created Grid resource with status \"pending\". The backend will
+    fetch the data and update status to \"completed\" when ready.
+
+    Args:
+        domain_id (str):
+        body (CreateLandfireFbfm13Request): Request to create a grid from LANDFIRE FBFM13.
+
+            Returns a single-band grid with categorical fuel model codes.
+            To convert codes to fuel parameters, use /grids/lookup/fbfm13.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Grid | HTTPValidationError | QuotaExceededDetail
+    """
+
+    return sync_detailed(
+        domain_id=domain_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateLandfireFbfm13Request,
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
+    r"""Create a grid from LANDFIRE FBFM13
+
+     # Create LANDFIRE FBFM13 Grid
+
+    Creates a grid with FBFM13 fuel model codes from LANDFIRE at 30m resolution.
+
+    The grid contains a single categorical band (`fbfm13`) with Anderson 13
+    fuel model codes (1-13).
+
+    To convert fuel model codes to fuel parameters (fuel loads, SAV,
+    depth), use the `/grids/lookup/fbfm13` endpoint.
+
+    ## Request Body
+
+    - **name**: (optional) Name for the grid.
+    - **description**: (optional) Description.
+    - **tags**: (optional) Tags for organizing grids.
+    - **version**: (optional) LANDFIRE version. Default: \"2024\".
+
+    ## Response
+
+    Returns the created Grid resource with status \"pending\". The backend will
+    fetch the data and update status to \"completed\" when ready.
+
+    Args:
+        domain_id (str):
+        body (CreateLandfireFbfm13Request): Request to create a grid from LANDFIRE FBFM13.
+
+            Returns a single-band grid with categorical fuel model codes.
+            To convert codes to fuel parameters, use /grids/lookup/fbfm13.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
+    """
+
+    kwargs = _get_kwargs(
+        domain_id=domain_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateLandfireFbfm13Request,
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
+    r"""Create a grid from LANDFIRE FBFM13
+
+     # Create LANDFIRE FBFM13 Grid
+
+    Creates a grid with FBFM13 fuel model codes from LANDFIRE at 30m resolution.
+
+    The grid contains a single categorical band (`fbfm13`) with Anderson 13
+    fuel model codes (1-13).
+
+    To convert fuel model codes to fuel parameters (fuel loads, SAV,
+    depth), use the `/grids/lookup/fbfm13` endpoint.
+
+    ## Request Body
+
+    - **name**: (optional) Name for the grid.
+    - **description**: (optional) Description.
+    - **tags**: (optional) Tags for organizing grids.
+    - **version**: (optional) LANDFIRE version. Default: \"2024\".
+
+    ## Response
+
+    Returns the created Grid resource with status \"pending\". The backend will
+    fetch the data and update status to \"completed\" when ready.
+
+    Args:
+        domain_id (str):
+        body (CreateLandfireFbfm13Request): Request to create a grid from LANDFIRE FBFM13.
+
+            Returns a single-band grid with categorical fuel model codes.
+            To convert codes to fuel parameters, use /grids/lookup/fbfm13.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Grid | HTTPValidationError | QuotaExceededDetail
+    """
+
+    return (
+        await asyncio_detailed(
+            domain_id=domain_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/fastfuels_sdk/v2/client_library/api/grids/create_landfire_fbfm40.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_landfire_fbfm40.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_landfire_fbfm_40_request import CreateLandfireFbfm40Request
 from ...models.grid import Grid
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -36,7 +37,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Grid.from_dict(response.json())
 
@@ -47,6 +48,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,7 +61,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +75,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateLandfireFbfm40Request,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid from LANDFIRE FBFM40
 
      # Create LANDFIRE FBFM40 Grid
@@ -106,7 +112,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -126,7 +132,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateLandfireFbfm40Request,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid from LANDFIRE FBFM40
 
      # Create LANDFIRE FBFM40 Grid
@@ -163,7 +169,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -178,7 +184,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateLandfireFbfm40Request,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid from LANDFIRE FBFM40
 
      # Create LANDFIRE FBFM40 Grid
@@ -215,7 +221,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -233,7 +239,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateLandfireFbfm40Request,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid from LANDFIRE FBFM40
 
      # Create LANDFIRE FBFM40 Grid
@@ -270,7 +276,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/grids/create_landfire_fccs.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_landfire_fccs.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_landfire_fccs_request import CreateLandfireFccsRequest
 from ...models.grid import Grid
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -36,7 +37,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Grid.from_dict(response.json())
 
@@ -47,6 +48,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,7 +61,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +75,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateLandfireFccsRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid from LANDFIRE FCCS
 
      # Create LANDFIRE FCCS Grid
@@ -108,7 +114,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -128,7 +134,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateLandfireFccsRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid from LANDFIRE FCCS
 
      # Create LANDFIRE FCCS Grid
@@ -167,7 +173,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -182,7 +188,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateLandfireFccsRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid from LANDFIRE FCCS
 
      # Create LANDFIRE FCCS Grid
@@ -221,7 +227,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -239,7 +245,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateLandfireFccsRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid from LANDFIRE FCCS
 
      # Create LANDFIRE FCCS Grid
@@ -278,7 +284,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/grids/create_landfire_topography.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_landfire_topography.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_landfire_topography_request import CreateLandfireTopographyRequest
 from ...models.grid import Grid
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -36,7 +37,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Grid.from_dict(response.json())
 
@@ -47,6 +48,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,7 +61,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +75,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateLandfireTopographyRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid from LANDFIRE topographic data
 
      # Create LANDFIRE Topography Grid
@@ -110,7 +116,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -130,7 +136,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateLandfireTopographyRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid from LANDFIRE topographic data
 
      # Create LANDFIRE Topography Grid
@@ -171,7 +177,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -186,7 +192,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateLandfireTopographyRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid from LANDFIRE topographic data
 
      # Create LANDFIRE Topography Grid
@@ -227,7 +233,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -245,7 +251,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateLandfireTopographyRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid from LANDFIRE topographic data
 
      # Create LANDFIRE Topography Grid
@@ -286,7 +292,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/grids/create_landscape_export.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_landscape_export.py
@@ -1,0 +1,296 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.export import Export
+from ...models.http_validation_error import HTTPValidationError
+from ...models.landscape_export_request import LandscapeExportRequest
+from ...models.quota_exceeded_detail import QuotaExceededDetail
+from ...types import Response
+
+
+def _get_kwargs(
+    domain_id: str,
+    *,
+    body: LandscapeExportRequest,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/domains/{domain_id}/grids/exports/landscape".format(
+            domain_id=quote(str(domain_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Export | HTTPValidationError | QuotaExceededDetail | None:
+    if response.status_code == 201:
+        response_201 = Export.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Export | HTTPValidationError | QuotaExceededDetail]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: LandscapeExportRequest,
+) -> Response[Export | HTTPValidationError | QuotaExceededDetail]:
+    """Export terrain + fuel + canopy grids to a landscape GeoTIFF
+
+     Assemble terrain, surface fuel model, and canopy grids into an
+    8-band LANDFIRE-style landscape GeoTIFF for operational fire behavior
+    tools (FlamMap, IFTDSS, WFDSS).
+
+    The output `landscape.tif` carries the standard LANDFIRE band order —
+    elevation, slope, aspect, fuel model, canopy cover, canopy height,
+    canopy base height, canopy bulk density — with LANDFIRE's int16 scaled
+    encodings, embedded CRS, and per-band name/unit metadata. This is the
+    format LANDFIRE distributes and IFTDSS accepts for upload.
+
+    Returns an Export resource with status `pending`. Poll
+    `GET /exports/{export_id}` until status is `completed` to retrieve the
+    signed download URL.
+
+    Args:
+        domain_id (str):
+        body (LandscapeExportRequest): Request body for creating a landscape export.
+
+            Eight required roles produce an 8-band landscape GeoTIFF in LANDFIRE band
+            order: elevation, slope, aspect, fuel model, canopy cover, canopy height,
+            canopy base height, canopy bulk density. This is the shape modern fire
+            behavior tools consume — IFTDSS requires all eight bands for upload.
+
+            The landscape lattice is defined by the `alignment` field — either the
+            Domain bounding box tiled at `resolution` (default 30 m, LANDFIRE-native),
+            or the lattice of an existing grid. Every role grid must be lattice-aligned
+            to the landscape and cover its full extent; otherwise the request is
+            rejected with 422. The exporter only crops oversized roles by integer
+            slicing — it never resamples or reprojects. To change a grid's resolution
+            or anchor, use `POST /v2/domains/{domain_id}/grids/{grid_id}/resample`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Export | HTTPValidationError | QuotaExceededDetail]
+    """
+
+    kwargs = _get_kwargs(
+        domain_id=domain_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: LandscapeExportRequest,
+) -> Export | HTTPValidationError | QuotaExceededDetail | None:
+    """Export terrain + fuel + canopy grids to a landscape GeoTIFF
+
+     Assemble terrain, surface fuel model, and canopy grids into an
+    8-band LANDFIRE-style landscape GeoTIFF for operational fire behavior
+    tools (FlamMap, IFTDSS, WFDSS).
+
+    The output `landscape.tif` carries the standard LANDFIRE band order —
+    elevation, slope, aspect, fuel model, canopy cover, canopy height,
+    canopy base height, canopy bulk density — with LANDFIRE's int16 scaled
+    encodings, embedded CRS, and per-band name/unit metadata. This is the
+    format LANDFIRE distributes and IFTDSS accepts for upload.
+
+    Returns an Export resource with status `pending`. Poll
+    `GET /exports/{export_id}` until status is `completed` to retrieve the
+    signed download URL.
+
+    Args:
+        domain_id (str):
+        body (LandscapeExportRequest): Request body for creating a landscape export.
+
+            Eight required roles produce an 8-band landscape GeoTIFF in LANDFIRE band
+            order: elevation, slope, aspect, fuel model, canopy cover, canopy height,
+            canopy base height, canopy bulk density. This is the shape modern fire
+            behavior tools consume — IFTDSS requires all eight bands for upload.
+
+            The landscape lattice is defined by the `alignment` field — either the
+            Domain bounding box tiled at `resolution` (default 30 m, LANDFIRE-native),
+            or the lattice of an existing grid. Every role grid must be lattice-aligned
+            to the landscape and cover its full extent; otherwise the request is
+            rejected with 422. The exporter only crops oversized roles by integer
+            slicing — it never resamples or reprojects. To change a grid's resolution
+            or anchor, use `POST /v2/domains/{domain_id}/grids/{grid_id}/resample`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Export | HTTPValidationError | QuotaExceededDetail
+    """
+
+    return sync_detailed(
+        domain_id=domain_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: LandscapeExportRequest,
+) -> Response[Export | HTTPValidationError | QuotaExceededDetail]:
+    """Export terrain + fuel + canopy grids to a landscape GeoTIFF
+
+     Assemble terrain, surface fuel model, and canopy grids into an
+    8-band LANDFIRE-style landscape GeoTIFF for operational fire behavior
+    tools (FlamMap, IFTDSS, WFDSS).
+
+    The output `landscape.tif` carries the standard LANDFIRE band order —
+    elevation, slope, aspect, fuel model, canopy cover, canopy height,
+    canopy base height, canopy bulk density — with LANDFIRE's int16 scaled
+    encodings, embedded CRS, and per-band name/unit metadata. This is the
+    format LANDFIRE distributes and IFTDSS accepts for upload.
+
+    Returns an Export resource with status `pending`. Poll
+    `GET /exports/{export_id}` until status is `completed` to retrieve the
+    signed download URL.
+
+    Args:
+        domain_id (str):
+        body (LandscapeExportRequest): Request body for creating a landscape export.
+
+            Eight required roles produce an 8-band landscape GeoTIFF in LANDFIRE band
+            order: elevation, slope, aspect, fuel model, canopy cover, canopy height,
+            canopy base height, canopy bulk density. This is the shape modern fire
+            behavior tools consume — IFTDSS requires all eight bands for upload.
+
+            The landscape lattice is defined by the `alignment` field — either the
+            Domain bounding box tiled at `resolution` (default 30 m, LANDFIRE-native),
+            or the lattice of an existing grid. Every role grid must be lattice-aligned
+            to the landscape and cover its full extent; otherwise the request is
+            rejected with 422. The exporter only crops oversized roles by integer
+            slicing — it never resamples or reprojects. To change a grid's resolution
+            or anchor, use `POST /v2/domains/{domain_id}/grids/{grid_id}/resample`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Export | HTTPValidationError | QuotaExceededDetail]
+    """
+
+    kwargs = _get_kwargs(
+        domain_id=domain_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: LandscapeExportRequest,
+) -> Export | HTTPValidationError | QuotaExceededDetail | None:
+    """Export terrain + fuel + canopy grids to a landscape GeoTIFF
+
+     Assemble terrain, surface fuel model, and canopy grids into an
+    8-band LANDFIRE-style landscape GeoTIFF for operational fire behavior
+    tools (FlamMap, IFTDSS, WFDSS).
+
+    The output `landscape.tif` carries the standard LANDFIRE band order —
+    elevation, slope, aspect, fuel model, canopy cover, canopy height,
+    canopy base height, canopy bulk density — with LANDFIRE's int16 scaled
+    encodings, embedded CRS, and per-band name/unit metadata. This is the
+    format LANDFIRE distributes and IFTDSS accepts for upload.
+
+    Returns an Export resource with status `pending`. Poll
+    `GET /exports/{export_id}` until status is `completed` to retrieve the
+    signed download URL.
+
+    Args:
+        domain_id (str):
+        body (LandscapeExportRequest): Request body for creating a landscape export.
+
+            Eight required roles produce an 8-band landscape GeoTIFF in LANDFIRE band
+            order: elevation, slope, aspect, fuel model, canopy cover, canopy height,
+            canopy base height, canopy bulk density. This is the shape modern fire
+            behavior tools consume — IFTDSS requires all eight bands for upload.
+
+            The landscape lattice is defined by the `alignment` field — either the
+            Domain bounding box tiled at `resolution` (default 30 m, LANDFIRE-native),
+            or the lattice of an existing grid. Every role grid must be lattice-aligned
+            to the landscape and cover its full extent; otherwise the request is
+            rejected with 422. The exporter only crops oversized roles by integer
+            slicing — it never resamples or reprojects. To change a grid's resolution
+            or anchor, use `POST /v2/domains/{domain_id}/grids/{grid_id}/resample`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Export | HTTPValidationError | QuotaExceededDetail
+    """
+
+    return (
+        await asyncio_detailed(
+            domain_id=domain_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/fastfuels_sdk/v2/client_library/api/grids/create_layerset_rasterize.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_layerset_rasterize.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_layerset_rasterize_request import CreateLayersetRasterizeRequest
 from ...models.grid import Grid
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -36,7 +37,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Grid.from_dict(response.json())
 
@@ -47,6 +48,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,7 +61,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +75,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateLayersetRasterizeRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     """Create a grid by rasterizing a layerset
 
      # Create Layerset-Rasterized Grid
@@ -114,7 +120,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -134,7 +140,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateLayersetRasterizeRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     """Create a grid by rasterizing a layerset
 
      # Create Layerset-Rasterized Grid
@@ -179,7 +185,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -194,7 +200,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateLayersetRasterizeRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     """Create a grid by rasterizing a layerset
 
      # Create Layerset-Rasterized Grid
@@ -239,7 +245,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -257,7 +263,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateLayersetRasterizeRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     """Create a grid by rasterizing a layerset
 
      # Create Layerset-Rasterized Grid
@@ -302,7 +308,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/grids/create_meta_chm.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_meta_chm.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_meta_chm_request import CreateMetaChmRequest
 from ...models.grid import Grid
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -36,7 +37,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Grid.from_dict(response.json())
 
@@ -47,6 +48,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,7 +61,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +75,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateMetaChmRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid from Meta CHM
 
      # Create Meta CHM Grid
@@ -104,7 +110,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -124,7 +130,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateMetaChmRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid from Meta CHM
 
      # Create Meta CHM Grid
@@ -159,7 +165,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -174,7 +180,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateMetaChmRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid from Meta CHM
 
      # Create Meta CHM Grid
@@ -209,7 +215,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -227,7 +233,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateMetaChmRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid from Meta CHM
 
      # Create Meta CHM Grid
@@ -262,7 +268,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/grids/create_naip_chm.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_naip_chm.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_naip_chm_request import CreateNaipChmRequest
 from ...models.grid import Grid
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -36,7 +37,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Grid.from_dict(response.json())
 
@@ -47,6 +48,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,7 +61,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +75,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateNaipChmRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid from NAIP CHM
 
      # Create NAIP CHM Grid
@@ -99,7 +105,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -119,7 +125,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateNaipChmRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid from NAIP CHM
 
      # Create NAIP CHM Grid
@@ -149,7 +155,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -164,7 +170,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateNaipChmRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid from NAIP CHM
 
      # Create NAIP CHM Grid
@@ -194,7 +200,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -212,7 +218,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateNaipChmRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid from NAIP CHM
 
      # Create NAIP CHM Grid
@@ -242,7 +248,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/grids/create_netcdf_upload.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_netcdf_upload.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_netcdf_upload_request import CreateNetcdfUploadRequest
 from ...models.grid_upload_created_response import GridUploadCreatedResponse
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -36,7 +37,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> GridUploadCreatedResponse | HTTPValidationError | None:
+) -> GridUploadCreatedResponse | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = GridUploadCreatedResponse.from_dict(response.json())
 
@@ -47,6 +48,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,7 +61,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[GridUploadCreatedResponse | HTTPValidationError]:
+) -> Response[GridUploadCreatedResponse | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +75,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateNetcdfUploadRequest,
-) -> Response[GridUploadCreatedResponse | HTTPValidationError]:
+) -> Response[GridUploadCreatedResponse | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid from a direct netCDF upload
 
      # Create Upload Grid (netCDF)
@@ -143,7 +149,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[GridUploadCreatedResponse | HTTPValidationError]
+        Response[GridUploadCreatedResponse | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -163,7 +169,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateNetcdfUploadRequest,
-) -> GridUploadCreatedResponse | HTTPValidationError | None:
+) -> GridUploadCreatedResponse | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid from a direct netCDF upload
 
      # Create Upload Grid (netCDF)
@@ -237,7 +243,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        GridUploadCreatedResponse | HTTPValidationError
+        GridUploadCreatedResponse | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -252,7 +258,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateNetcdfUploadRequest,
-) -> Response[GridUploadCreatedResponse | HTTPValidationError]:
+) -> Response[GridUploadCreatedResponse | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid from a direct netCDF upload
 
      # Create Upload Grid (netCDF)
@@ -326,7 +332,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[GridUploadCreatedResponse | HTTPValidationError]
+        Response[GridUploadCreatedResponse | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -344,7 +350,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateNetcdfUploadRequest,
-) -> GridUploadCreatedResponse | HTTPValidationError | None:
+) -> GridUploadCreatedResponse | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid from a direct netCDF upload
 
      # Create Upload Grid (netCDF)
@@ -418,7 +424,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        GridUploadCreatedResponse | HTTPValidationError
+        GridUploadCreatedResponse | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/grids/create_point_cloud_chm.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_point_cloud_chm.py
@@ -1,0 +1,400 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.create_point_cloud_chm_request import CreatePointCloudChmRequest
+from ...models.grid import Grid
+from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
+from ...types import Response
+
+
+def _get_kwargs(
+    domain_id: str,
+    *,
+    body: CreatePointCloudChmRequest,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/domains/{domain_id}/grids/canopy/point_cloud".format(
+            domain_id=quote(str(domain_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
+    if response.status_code == 201:
+        response_201 = Grid.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreatePointCloudChmRequest,
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
+    r"""Create a CHM grid from a point cloud
+
+     # Create a CHM Grid from a Point Cloud
+
+    Creates a grid with canopy height data rasterized from a point cloud. Each
+    cell holds the greatest height above ground of any return that falls in it.
+
+    The resulting grid carries the same `chm` band as the Meta, NAIP, and
+    LANDFIRE canopy sources, so it can be used anywhere they can — including as
+    the source for individual tree detection
+    (`POST /domains/{domain_id}/inventories/tree/chm`).
+
+    ## Ground
+
+    Canopy height is height above ground, so the ground surface underneath
+    matters. When the point cloud carries ASPRS ground classification
+    (class 2), those returns define the ground. When it does not — an upload
+    may carry no classification at all — the ground surface is derived from the
+    data.
+
+    Which path was taken, and how well the data constrained it, is recorded on
+    the completed grid under `source.ground`. Derived ground is accurate in
+    forested terrain and degrades over wide areas with no ground returns, such
+    as large building footprints or very dense canopy;
+    `source.ground.ground_coverage` and `source.ground.max_ground_distance_m`
+    are what reveal that.
+
+    ## Request Body
+
+    - **source_point_cloud_id**: The point cloud to rasterize. Must be airborne
+      (`type: als`), `completed`, and in this domain.
+    - **alignment**: (optional) Output lattice. Against the domain
+      (`target: \"domain\"`, the default) `resolution` defaults to 1 m — unlike
+      the raster-backed canopy sources there is no source pixel size to
+      inherit. Against another grid (`target: \"grid\"`) omitting `resolution`
+      matches that grid cell-for-cell, and the output covers the target's
+      extent rather than the domain's; giving one keeps the target's origin at
+      the new cell size. The target grid must be in this domain's CRS.
+      `target: \"native\"` is not supported — a point cloud has no pixel anchor
+      to preserve.
+    - **name**, **description**, **tags**: (optional) Metadata.
+
+    ## Response
+
+    Returns the created Grid resource with status \"pending\". The backend will
+    build the grid and update status to \"completed\" when ready.
+
+    Args:
+        domain_id (str):
+        body (CreatePointCloudChmRequest): Request to create a canopy height model grid from a
+            point cloud.
+
+            Returns a grid with a single continuous band:
+            - chm: Canopy height in meters
+
+            The point cloud must be airborne (`type: als`) and `completed`. Cell size
+            comes from `alignment.resolution`, defaulting to 1 m — unlike the
+            raster-backed canopy sources there is no source pixel size to inherit.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
+    """
+
+    kwargs = _get_kwargs(
+        domain_id=domain_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreatePointCloudChmRequest,
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
+    r"""Create a CHM grid from a point cloud
+
+     # Create a CHM Grid from a Point Cloud
+
+    Creates a grid with canopy height data rasterized from a point cloud. Each
+    cell holds the greatest height above ground of any return that falls in it.
+
+    The resulting grid carries the same `chm` band as the Meta, NAIP, and
+    LANDFIRE canopy sources, so it can be used anywhere they can — including as
+    the source for individual tree detection
+    (`POST /domains/{domain_id}/inventories/tree/chm`).
+
+    ## Ground
+
+    Canopy height is height above ground, so the ground surface underneath
+    matters. When the point cloud carries ASPRS ground classification
+    (class 2), those returns define the ground. When it does not — an upload
+    may carry no classification at all — the ground surface is derived from the
+    data.
+
+    Which path was taken, and how well the data constrained it, is recorded on
+    the completed grid under `source.ground`. Derived ground is accurate in
+    forested terrain and degrades over wide areas with no ground returns, such
+    as large building footprints or very dense canopy;
+    `source.ground.ground_coverage` and `source.ground.max_ground_distance_m`
+    are what reveal that.
+
+    ## Request Body
+
+    - **source_point_cloud_id**: The point cloud to rasterize. Must be airborne
+      (`type: als`), `completed`, and in this domain.
+    - **alignment**: (optional) Output lattice. Against the domain
+      (`target: \"domain\"`, the default) `resolution` defaults to 1 m — unlike
+      the raster-backed canopy sources there is no source pixel size to
+      inherit. Against another grid (`target: \"grid\"`) omitting `resolution`
+      matches that grid cell-for-cell, and the output covers the target's
+      extent rather than the domain's; giving one keeps the target's origin at
+      the new cell size. The target grid must be in this domain's CRS.
+      `target: \"native\"` is not supported — a point cloud has no pixel anchor
+      to preserve.
+    - **name**, **description**, **tags**: (optional) Metadata.
+
+    ## Response
+
+    Returns the created Grid resource with status \"pending\". The backend will
+    build the grid and update status to \"completed\" when ready.
+
+    Args:
+        domain_id (str):
+        body (CreatePointCloudChmRequest): Request to create a canopy height model grid from a
+            point cloud.
+
+            Returns a grid with a single continuous band:
+            - chm: Canopy height in meters
+
+            The point cloud must be airborne (`type: als`) and `completed`. Cell size
+            comes from `alignment.resolution`, defaulting to 1 m — unlike the
+            raster-backed canopy sources there is no source pixel size to inherit.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Grid | HTTPValidationError | QuotaExceededDetail
+    """
+
+    return sync_detailed(
+        domain_id=domain_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreatePointCloudChmRequest,
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
+    r"""Create a CHM grid from a point cloud
+
+     # Create a CHM Grid from a Point Cloud
+
+    Creates a grid with canopy height data rasterized from a point cloud. Each
+    cell holds the greatest height above ground of any return that falls in it.
+
+    The resulting grid carries the same `chm` band as the Meta, NAIP, and
+    LANDFIRE canopy sources, so it can be used anywhere they can — including as
+    the source for individual tree detection
+    (`POST /domains/{domain_id}/inventories/tree/chm`).
+
+    ## Ground
+
+    Canopy height is height above ground, so the ground surface underneath
+    matters. When the point cloud carries ASPRS ground classification
+    (class 2), those returns define the ground. When it does not — an upload
+    may carry no classification at all — the ground surface is derived from the
+    data.
+
+    Which path was taken, and how well the data constrained it, is recorded on
+    the completed grid under `source.ground`. Derived ground is accurate in
+    forested terrain and degrades over wide areas with no ground returns, such
+    as large building footprints or very dense canopy;
+    `source.ground.ground_coverage` and `source.ground.max_ground_distance_m`
+    are what reveal that.
+
+    ## Request Body
+
+    - **source_point_cloud_id**: The point cloud to rasterize. Must be airborne
+      (`type: als`), `completed`, and in this domain.
+    - **alignment**: (optional) Output lattice. Against the domain
+      (`target: \"domain\"`, the default) `resolution` defaults to 1 m — unlike
+      the raster-backed canopy sources there is no source pixel size to
+      inherit. Against another grid (`target: \"grid\"`) omitting `resolution`
+      matches that grid cell-for-cell, and the output covers the target's
+      extent rather than the domain's; giving one keeps the target's origin at
+      the new cell size. The target grid must be in this domain's CRS.
+      `target: \"native\"` is not supported — a point cloud has no pixel anchor
+      to preserve.
+    - **name**, **description**, **tags**: (optional) Metadata.
+
+    ## Response
+
+    Returns the created Grid resource with status \"pending\". The backend will
+    build the grid and update status to \"completed\" when ready.
+
+    Args:
+        domain_id (str):
+        body (CreatePointCloudChmRequest): Request to create a canopy height model grid from a
+            point cloud.
+
+            Returns a grid with a single continuous band:
+            - chm: Canopy height in meters
+
+            The point cloud must be airborne (`type: als`) and `completed`. Cell size
+            comes from `alignment.resolution`, defaulting to 1 m — unlike the
+            raster-backed canopy sources there is no source pixel size to inherit.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
+    """
+
+    kwargs = _get_kwargs(
+        domain_id=domain_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreatePointCloudChmRequest,
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
+    r"""Create a CHM grid from a point cloud
+
+     # Create a CHM Grid from a Point Cloud
+
+    Creates a grid with canopy height data rasterized from a point cloud. Each
+    cell holds the greatest height above ground of any return that falls in it.
+
+    The resulting grid carries the same `chm` band as the Meta, NAIP, and
+    LANDFIRE canopy sources, so it can be used anywhere they can — including as
+    the source for individual tree detection
+    (`POST /domains/{domain_id}/inventories/tree/chm`).
+
+    ## Ground
+
+    Canopy height is height above ground, so the ground surface underneath
+    matters. When the point cloud carries ASPRS ground classification
+    (class 2), those returns define the ground. When it does not — an upload
+    may carry no classification at all — the ground surface is derived from the
+    data.
+
+    Which path was taken, and how well the data constrained it, is recorded on
+    the completed grid under `source.ground`. Derived ground is accurate in
+    forested terrain and degrades over wide areas with no ground returns, such
+    as large building footprints or very dense canopy;
+    `source.ground.ground_coverage` and `source.ground.max_ground_distance_m`
+    are what reveal that.
+
+    ## Request Body
+
+    - **source_point_cloud_id**: The point cloud to rasterize. Must be airborne
+      (`type: als`), `completed`, and in this domain.
+    - **alignment**: (optional) Output lattice. Against the domain
+      (`target: \"domain\"`, the default) `resolution` defaults to 1 m — unlike
+      the raster-backed canopy sources there is no source pixel size to
+      inherit. Against another grid (`target: \"grid\"`) omitting `resolution`
+      matches that grid cell-for-cell, and the output covers the target's
+      extent rather than the domain's; giving one keeps the target's origin at
+      the new cell size. The target grid must be in this domain's CRS.
+      `target: \"native\"` is not supported — a point cloud has no pixel anchor
+      to preserve.
+    - **name**, **description**, **tags**: (optional) Metadata.
+
+    ## Response
+
+    Returns the created Grid resource with status \"pending\". The backend will
+    build the grid and update status to \"completed\" when ready.
+
+    Args:
+        domain_id (str):
+        body (CreatePointCloudChmRequest): Request to create a canopy height model grid from a
+            point cloud.
+
+            Returns a grid with a single continuous band:
+            - chm: Canopy height in meters
+
+            The point cloud must be airborne (`type: als`) and `completed`. Cell size
+            comes from `alignment.resolution`, defaulting to 1 m — unlike the
+            raster-backed canopy sources there is no source pixel size to inherit.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Grid | HTTPValidationError | QuotaExceededDetail
+    """
+
+    return (
+        await asyncio_detailed(
+            domain_id=domain_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/fastfuels_sdk/v2/client_library/api/grids/create_quicfire_export.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_quicfire_export.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.export import Export
 from ...models.http_validation_error import HTTPValidationError
 from ...models.quicfire_export_request import QuicfireExportRequest
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -36,7 +37,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Export | HTTPValidationError | None:
+) -> Export | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Export.from_dict(response.json())
 
@@ -47,6 +48,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,7 +61,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Export | HTTPValidationError]:
+) -> Response[Export | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +75,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: QuicfireExportRequest,
-) -> Response[Export | HTTPValidationError]:
+) -> Response[Export | HTTPValidationError | QuotaExceededDetail]:
     """Export combined fuel + topography grids to QUIC-Fire format
 
      Bundle surface fuel + canopy fuel + (optional) topography grids into a
@@ -99,12 +105,23 @@ def sync_detailed(
             The exporter only crops oversized roles by integer slicing — it never
             resamples or reprojects.
 
+            The output resolution is set here, on the export, via `alignment.dx`/`dy`
+            (default 2 m, QUIC-Fire's recommended value). It is a separate setting
+            from the resolution of each grid you built — changing your grids does not
+            change the export, and vice versa. Because the exporter never resamples,
+            every role grid must already be built at the fire-grid resolution. To
+            export at 1 m, for example, set `dx`/`dy` to 1 and build all role grids at
+            1 m (2D grids at 1 m via their `alignment.resolution`, and the 3D tree
+            grid at 1 m via `resolution.horizontal` — 3D grids cannot be resampled).
+            The same holds vertically: `alignment.dz` must equal the 3D tree grid's
+            `resolution.vertical`, or the request is rejected with 422.
+
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Export | HTTPValidationError]
+        Response[Export | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -124,7 +141,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: QuicfireExportRequest,
-) -> Export | HTTPValidationError | None:
+) -> Export | HTTPValidationError | QuotaExceededDetail | None:
     """Export combined fuel + topography grids to QUIC-Fire format
 
      Bundle surface fuel + canopy fuel + (optional) topography grids into a
@@ -154,12 +171,23 @@ def sync(
             The exporter only crops oversized roles by integer slicing — it never
             resamples or reprojects.
 
+            The output resolution is set here, on the export, via `alignment.dx`/`dy`
+            (default 2 m, QUIC-Fire's recommended value). It is a separate setting
+            from the resolution of each grid you built — changing your grids does not
+            change the export, and vice versa. Because the exporter never resamples,
+            every role grid must already be built at the fire-grid resolution. To
+            export at 1 m, for example, set `dx`/`dy` to 1 and build all role grids at
+            1 m (2D grids at 1 m via their `alignment.resolution`, and the 3D tree
+            grid at 1 m via `resolution.horizontal` — 3D grids cannot be resampled).
+            The same holds vertically: `alignment.dz` must equal the 3D tree grid's
+            `resolution.vertical`, or the request is rejected with 422.
+
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Export | HTTPValidationError
+        Export | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -174,7 +202,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: QuicfireExportRequest,
-) -> Response[Export | HTTPValidationError]:
+) -> Response[Export | HTTPValidationError | QuotaExceededDetail]:
     """Export combined fuel + topography grids to QUIC-Fire format
 
      Bundle surface fuel + canopy fuel + (optional) topography grids into a
@@ -204,12 +232,23 @@ async def asyncio_detailed(
             The exporter only crops oversized roles by integer slicing — it never
             resamples or reprojects.
 
+            The output resolution is set here, on the export, via `alignment.dx`/`dy`
+            (default 2 m, QUIC-Fire's recommended value). It is a separate setting
+            from the resolution of each grid you built — changing your grids does not
+            change the export, and vice versa. Because the exporter never resamples,
+            every role grid must already be built at the fire-grid resolution. To
+            export at 1 m, for example, set `dx`/`dy` to 1 and build all role grids at
+            1 m (2D grids at 1 m via their `alignment.resolution`, and the 3D tree
+            grid at 1 m via `resolution.horizontal` — 3D grids cannot be resampled).
+            The same holds vertically: `alignment.dz` must equal the 3D tree grid's
+            `resolution.vertical`, or the request is rejected with 422.
+
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Export | HTTPValidationError]
+        Response[Export | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -227,7 +266,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: QuicfireExportRequest,
-) -> Export | HTTPValidationError | None:
+) -> Export | HTTPValidationError | QuotaExceededDetail | None:
     """Export combined fuel + topography grids to QUIC-Fire format
 
      Bundle surface fuel + canopy fuel + (optional) topography grids into a
@@ -257,12 +296,23 @@ async def asyncio(
             The exporter only crops oversized roles by integer slicing — it never
             resamples or reprojects.
 
+            The output resolution is set here, on the export, via `alignment.dx`/`dy`
+            (default 2 m, QUIC-Fire's recommended value). It is a separate setting
+            from the resolution of each grid you built — changing your grids does not
+            change the export, and vice versa. Because the exporter never resamples,
+            every role grid must already be built at the fire-grid resolution. To
+            export at 1 m, for example, set `dx`/`dy` to 1 and build all role grids at
+            1 m (2D grids at 1 m via their `alignment.resolution`, and the 3D tree
+            grid at 1 m via `resolution.horizontal` — 3D grids cannot be resampled).
+            The same holds vertically: `alignment.dz` must equal the 3D tree grid's
+            `resolution.vertical`, or the request is rejected with 422.
+
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Export | HTTPValidationError
+        Export | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/grids/create_resample.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_resample.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_resample_request import CreateResampleRequest
 from ...models.grid import Grid
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -36,7 +37,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Grid.from_dict(response.json())
 
@@ -47,6 +48,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,7 +61,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +75,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateResampleRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid by resampling an existing grid
 
      # Create Resampled Grid
@@ -114,7 +120,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -134,7 +140,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateResampleRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid by resampling an existing grid
 
      # Create Resampled Grid
@@ -179,7 +185,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -194,7 +200,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateResampleRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid by resampling an existing grid
 
      # Create Resampled Grid
@@ -239,7 +245,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -257,7 +263,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateResampleRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid by resampling an existing grid
 
      # Create Resampled Grid
@@ -302,7 +308,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/grids/create_tree_inventory_grid.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_tree_inventory_grid.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_tree_inventory_request import CreateTreeInventoryRequest
 from ...models.grid import Grid
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -36,7 +37,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Grid.from_dict(response.json())
 
@@ -47,6 +48,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,7 +61,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +75,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateTreeInventoryRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a 3D tree fuel grid from a tree inventory
 
      # Create Tree Inventory Grid
@@ -131,7 +137,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -151,7 +157,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateTreeInventoryRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a 3D tree fuel grid from a tree inventory
 
      # Create Tree Inventory Grid
@@ -213,7 +219,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -228,7 +234,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateTreeInventoryRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a 3D tree fuel grid from a tree inventory
 
      # Create Tree Inventory Grid
@@ -290,7 +296,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -308,7 +314,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateTreeInventoryRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a 3D tree fuel grid from a tree inventory
 
      # Create Tree Inventory Grid
@@ -370,7 +376,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/grids/create_treemap.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_treemap.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_tree_map_request import CreateTreeMapRequest
 from ...models.grid import Grid
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -36,7 +37,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Grid.from_dict(response.json())
 
@@ -47,6 +48,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,7 +61,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +75,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateTreeMapRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid from TreeMap
 
      # Create TreeMap Grid
@@ -109,7 +115,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -129,7 +135,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateTreeMapRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid from TreeMap
 
      # Create TreeMap Grid
@@ -169,7 +175,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -184,7 +190,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateTreeMapRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a grid from TreeMap
 
      # Create TreeMap Grid
@@ -224,7 +230,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -242,7 +248,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateTreeMapRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a grid from TreeMap
 
      # Create TreeMap Grid
@@ -282,7 +288,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/grids/create_uniform_grid.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/create_uniform_grid.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_uniform_request import CreateUniformRequest
 from ...models.grid import Grid
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -36,7 +37,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Grid.from_dict(response.json())
 
@@ -47,6 +48,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,7 +61,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +75,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateUniformRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a uniform (constant-value) grid
 
      # Create Uniform Grid
@@ -118,7 +124,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -138,7 +144,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateUniformRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a uniform (constant-value) grid
 
      # Create Uniform Grid
@@ -187,7 +193,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -202,7 +208,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateUniformRequest,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Create a uniform (constant-value) grid
 
      # Create Uniform Grid
@@ -251,7 +257,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -269,7 +275,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateUniformRequest,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Create a uniform (constant-value) grid
 
      # Create Uniform Grid
@@ -318,7 +324,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/grids/duplicate_grid.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/duplicate_grid.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.duplicate_grid_request import DuplicateGridRequest
 from ...models.grid import Grid
 from ...models.http_validation_error import HTTPValidationError
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import UNSET, Response, Unset
 
 
@@ -41,7 +42,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Grid.from_dict(response.json())
 
@@ -52,6 +53,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -60,7 +66,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -75,7 +81,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: DuplicateGridRequest | None | Unset = UNSET,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Duplicate a grid
 
      # Duplicate a Grid
@@ -114,6 +120,10 @@ def sync_detailed(
       caller, or is not in this domain.
     - **422 Unprocessable Content**: The source grid exists but is not yet
       `completed`, so there is no finished artifact to copy.
+    - **429 Too Many Requests**: You have too many active grid jobs in progress
+      (your `max_active_grids` quota). Wait for jobs to complete or delete
+      unneeded grids, then retry. The response detail names the exact `quota`
+      and includes a `Retry-After` header.
 
     Args:
         domain_id (str):
@@ -125,7 +135,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -147,7 +157,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: DuplicateGridRequest | None | Unset = UNSET,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Duplicate a grid
 
      # Duplicate a Grid
@@ -186,6 +196,10 @@ def sync(
       caller, or is not in this domain.
     - **422 Unprocessable Content**: The source grid exists but is not yet
       `completed`, so there is no finished artifact to copy.
+    - **429 Too Many Requests**: You have too many active grid jobs in progress
+      (your `max_active_grids` quota). Wait for jobs to complete or delete
+      unneeded grids, then retry. The response detail names the exact `quota`
+      and includes a `Retry-After` header.
 
     Args:
         domain_id (str):
@@ -197,7 +211,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -214,7 +228,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: DuplicateGridRequest | None | Unset = UNSET,
-) -> Response[Grid | HTTPValidationError]:
+) -> Response[Grid | HTTPValidationError | QuotaExceededDetail]:
     r"""Duplicate a grid
 
      # Duplicate a Grid
@@ -253,6 +267,10 @@ async def asyncio_detailed(
       caller, or is not in this domain.
     - **422 Unprocessable Content**: The source grid exists but is not yet
       `completed`, so there is no finished artifact to copy.
+    - **429 Too Many Requests**: You have too many active grid jobs in progress
+      (your `max_active_grids` quota). Wait for jobs to complete or delete
+      unneeded grids, then retry. The response detail names the exact `quota`
+      and includes a `Retry-After` header.
 
     Args:
         domain_id (str):
@@ -264,7 +282,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Grid | HTTPValidationError]
+        Response[Grid | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -284,7 +302,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: DuplicateGridRequest | None | Unset = UNSET,
-) -> Grid | HTTPValidationError | None:
+) -> Grid | HTTPValidationError | QuotaExceededDetail | None:
     r"""Duplicate a grid
 
      # Duplicate a Grid
@@ -323,6 +341,10 @@ async def asyncio(
       caller, or is not in this domain.
     - **422 Unprocessable Content**: The source grid exists but is not yet
       `completed`, so there is no finished artifact to copy.
+    - **429 Too Many Requests**: You have too many active grid jobs in progress
+      (your `max_active_grids` quota). Wait for jobs to complete or delete
+      unneeded grids, then retry. The response detail names the exact `quota`
+      and includes a `Retry-After` header.
 
     Args:
         domain_id (str):
@@ -334,7 +356,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Grid | HTTPValidationError
+        Grid | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/grids/get_grid_data_binary.py
+++ b/fastfuels_sdk/v2/client_library/api/grids/get_grid_data_binary.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import httpx
@@ -54,9 +54,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Any | HTTPValidationError | None:
+) -> HTTPValidationError | str | None:
     if response.status_code == 200:
-        response_200 = response.json()
+        response_200 = cast(str, response.content)
         return response_200
 
     if response.status_code == 422:
@@ -72,7 +72,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Any | HTTPValidationError]:
+) -> Response[HTTPValidationError | str]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -90,7 +90,7 @@ def sync_detailed(
     client: AuthenticatedClient,
     array_format: GridDataArrayFormat | Unset = UNSET,
     order: GridDataOrder | Unset = UNSET,
-) -> Response[Any | HTTPValidationError]:
+) -> Response[HTTPValidationError | str]:
     """Get band data for a chunk (binary)
 
      # Get Grid Data (binary)
@@ -173,7 +173,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any | HTTPValidationError]
+        Response[HTTPValidationError | str]
     """
 
     kwargs = _get_kwargs(
@@ -201,7 +201,7 @@ def sync(
     client: AuthenticatedClient,
     array_format: GridDataArrayFormat | Unset = UNSET,
     order: GridDataOrder | Unset = UNSET,
-) -> Any | HTTPValidationError | None:
+) -> HTTPValidationError | str | None:
     """Get band data for a chunk (binary)
 
      # Get Grid Data (binary)
@@ -284,7 +284,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Any | HTTPValidationError
+        HTTPValidationError | str
     """
 
     return sync_detailed(
@@ -307,7 +307,7 @@ async def asyncio_detailed(
     client: AuthenticatedClient,
     array_format: GridDataArrayFormat | Unset = UNSET,
     order: GridDataOrder | Unset = UNSET,
-) -> Response[Any | HTTPValidationError]:
+) -> Response[HTTPValidationError | str]:
     """Get band data for a chunk (binary)
 
      # Get Grid Data (binary)
@@ -390,7 +390,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any | HTTPValidationError]
+        Response[HTTPValidationError | str]
     """
 
     kwargs = _get_kwargs(
@@ -416,7 +416,7 @@ async def asyncio(
     client: AuthenticatedClient,
     array_format: GridDataArrayFormat | Unset = UNSET,
     order: GridDataOrder | Unset = UNSET,
-) -> Any | HTTPValidationError | None:
+) -> HTTPValidationError | str | None:
     """Get band data for a chunk (binary)
 
      # Get Grid Data (binary)
@@ -499,7 +499,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Any | HTTPValidationError
+        HTTPValidationError | str
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/inventories/apply_modifications.py
+++ b/fastfuels_sdk/v2/client_library/api/inventories/apply_modifications.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.apply_modifications_request import ApplyModificationsRequest
 from ...models.http_validation_error import HTTPValidationError
 from ...models.inventory import Inventory
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -38,7 +39,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | Inventory | None:
+) -> HTTPValidationError | Inventory | QuotaExceededDetail | None:
     if response.status_code == 200:
         response_200 = Inventory.from_dict(response.json())
 
@@ -49,6 +50,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -57,7 +63,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | Inventory]:
+) -> Response[HTTPValidationError | Inventory | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -72,7 +78,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: ApplyModificationsRequest,
-) -> Response[HTTPValidationError | Inventory]:
+) -> Response[HTTPValidationError | Inventory | QuotaExceededDetail]:
     r"""Apply modifications to an inventory in place
 
      # Apply Modifications to an Inventory (in place)
@@ -135,10 +141,28 @@ def sync_detailed(
 
     ## Response
 
-    Returns this inventory (same ID) with status `\"pending\"` and the submitted
-    rules appended to `modifications`. Its `checksum` changes, so any resource
-    derived from it can detect that the source has changed. Poll the inventory
-    until status returns to `\"completed\"`.
+    Returns this inventory (same ID) with status `\"pending\"`. Its `checksum`
+    changes immediately, so any resource derived from it can detect that the
+    source has changed. The submitted rules appear in the inventory's
+    `modifications` list once processing completes — poll the inventory until
+    status returns to `\"completed\"`.
+
+    If processing fails, the inventory's status becomes `\"failed\"` with error
+    details, the stored data is unchanged, and the queued rules are retained —
+    submit another POST to retry (the new rules are applied together with the
+    retained ones).
+
+    ## Error Responses
+
+    - **404 Not Found**: The inventory does not exist, is not owned by the
+      caller, or is not in this domain.
+    - **422 Unprocessable Content**: The inventory is not in `completed` status
+      (and is not a retryable failed modification); or a referenced `feature_id`
+      is missing, cross-domain, or not completed.
+    - **429 Too Many Requests**: You have too many active inventory jobs in
+      progress (your `max_active_inventories` quota). Wait for jobs to complete
+      or delete unneeded inventories, then retry. The response detail names the
+      exact `quota` and includes a `Retry-After` header.
 
     Args:
         domain_id (str):
@@ -154,7 +178,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | Inventory]
+        Response[HTTPValidationError | Inventory | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -176,7 +200,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: ApplyModificationsRequest,
-) -> HTTPValidationError | Inventory | None:
+) -> HTTPValidationError | Inventory | QuotaExceededDetail | None:
     r"""Apply modifications to an inventory in place
 
      # Apply Modifications to an Inventory (in place)
@@ -239,10 +263,28 @@ def sync(
 
     ## Response
 
-    Returns this inventory (same ID) with status `\"pending\"` and the submitted
-    rules appended to `modifications`. Its `checksum` changes, so any resource
-    derived from it can detect that the source has changed. Poll the inventory
-    until status returns to `\"completed\"`.
+    Returns this inventory (same ID) with status `\"pending\"`. Its `checksum`
+    changes immediately, so any resource derived from it can detect that the
+    source has changed. The submitted rules appear in the inventory's
+    `modifications` list once processing completes — poll the inventory until
+    status returns to `\"completed\"`.
+
+    If processing fails, the inventory's status becomes `\"failed\"` with error
+    details, the stored data is unchanged, and the queued rules are retained —
+    submit another POST to retry (the new rules are applied together with the
+    retained ones).
+
+    ## Error Responses
+
+    - **404 Not Found**: The inventory does not exist, is not owned by the
+      caller, or is not in this domain.
+    - **422 Unprocessable Content**: The inventory is not in `completed` status
+      (and is not a retryable failed modification); or a referenced `feature_id`
+      is missing, cross-domain, or not completed.
+    - **429 Too Many Requests**: You have too many active inventory jobs in
+      progress (your `max_active_inventories` quota). Wait for jobs to complete
+      or delete unneeded inventories, then retry. The response detail names the
+      exact `quota` and includes a `Retry-After` header.
 
     Args:
         domain_id (str):
@@ -258,7 +300,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | Inventory
+        HTTPValidationError | Inventory | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -275,7 +317,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: ApplyModificationsRequest,
-) -> Response[HTTPValidationError | Inventory]:
+) -> Response[HTTPValidationError | Inventory | QuotaExceededDetail]:
     r"""Apply modifications to an inventory in place
 
      # Apply Modifications to an Inventory (in place)
@@ -338,10 +380,28 @@ async def asyncio_detailed(
 
     ## Response
 
-    Returns this inventory (same ID) with status `\"pending\"` and the submitted
-    rules appended to `modifications`. Its `checksum` changes, so any resource
-    derived from it can detect that the source has changed. Poll the inventory
-    until status returns to `\"completed\"`.
+    Returns this inventory (same ID) with status `\"pending\"`. Its `checksum`
+    changes immediately, so any resource derived from it can detect that the
+    source has changed. The submitted rules appear in the inventory's
+    `modifications` list once processing completes — poll the inventory until
+    status returns to `\"completed\"`.
+
+    If processing fails, the inventory's status becomes `\"failed\"` with error
+    details, the stored data is unchanged, and the queued rules are retained —
+    submit another POST to retry (the new rules are applied together with the
+    retained ones).
+
+    ## Error Responses
+
+    - **404 Not Found**: The inventory does not exist, is not owned by the
+      caller, or is not in this domain.
+    - **422 Unprocessable Content**: The inventory is not in `completed` status
+      (and is not a retryable failed modification); or a referenced `feature_id`
+      is missing, cross-domain, or not completed.
+    - **429 Too Many Requests**: You have too many active inventory jobs in
+      progress (your `max_active_inventories` quota). Wait for jobs to complete
+      or delete unneeded inventories, then retry. The response detail names the
+      exact `quota` and includes a `Retry-After` header.
 
     Args:
         domain_id (str):
@@ -357,7 +417,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | Inventory]
+        Response[HTTPValidationError | Inventory | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -377,7 +437,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: ApplyModificationsRequest,
-) -> HTTPValidationError | Inventory | None:
+) -> HTTPValidationError | Inventory | QuotaExceededDetail | None:
     r"""Apply modifications to an inventory in place
 
      # Apply Modifications to an Inventory (in place)
@@ -440,10 +500,28 @@ async def asyncio(
 
     ## Response
 
-    Returns this inventory (same ID) with status `\"pending\"` and the submitted
-    rules appended to `modifications`. Its `checksum` changes, so any resource
-    derived from it can detect that the source has changed. Poll the inventory
-    until status returns to `\"completed\"`.
+    Returns this inventory (same ID) with status `\"pending\"`. Its `checksum`
+    changes immediately, so any resource derived from it can detect that the
+    source has changed. The submitted rules appear in the inventory's
+    `modifications` list once processing completes — poll the inventory until
+    status returns to `\"completed\"`.
+
+    If processing fails, the inventory's status becomes `\"failed\"` with error
+    details, the stored data is unchanged, and the queued rules are retained —
+    submit another POST to retry (the new rules are applied together with the
+    retained ones).
+
+    ## Error Responses
+
+    - **404 Not Found**: The inventory does not exist, is not owned by the
+      caller, or is not in this domain.
+    - **422 Unprocessable Content**: The inventory is not in `completed` status
+      (and is not a retryable failed modification); or a referenced `feature_id`
+      is missing, cross-domain, or not completed.
+    - **429 Too Many Requests**: You have too many active inventory jobs in
+      progress (your `max_active_inventories` quota). Wait for jobs to complete
+      or delete unneeded inventories, then retry. The response detail names the
+      exact `quota` and includes a `Retry-After` header.
 
     Args:
         domain_id (str):
@@ -459,7 +537,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | Inventory
+        HTTPValidationError | Inventory | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/inventories/apply_treatments.py
+++ b/fastfuels_sdk/v2/client_library/api/inventories/apply_treatments.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.apply_treatments_request import ApplyTreatmentsRequest
 from ...models.http_validation_error import HTTPValidationError
 from ...models.inventory import Inventory
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -38,7 +39,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | Inventory | None:
+) -> HTTPValidationError | Inventory | QuotaExceededDetail | None:
     if response.status_code == 200:
         response_200 = Inventory.from_dict(response.json())
 
@@ -49,6 +50,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -57,7 +63,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | Inventory]:
+) -> Response[HTTPValidationError | Inventory | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -72,7 +78,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: ApplyTreatmentsRequest,
-) -> Response[HTTPValidationError | Inventory]:
+) -> Response[HTTPValidationError | Inventory | QuotaExceededDetail]:
     r"""Apply treatments to an inventory in place
 
      # Apply Treatments to an Inventory (in place)
@@ -129,10 +135,30 @@ def sync_detailed(
 
     ## Response
 
-    Returns this inventory (same ID) with status `\"pending\"` and the submitted
-    treatments appended to `treatments`. Its `checksum` changes, so any resource
-    derived from it can detect that the source has changed. Poll the inventory
-    until status returns to `\"completed\"`.
+    Returns this inventory (same ID) with status `\"pending\"`. Its `checksum`
+    changes immediately, so any resource derived from it can detect that the
+    source has changed. The submitted treatments appear in the inventory's
+    `treatments` list once processing completes — poll the inventory until
+    status returns to `\"completed\"`.
+
+    If processing fails, the inventory's status becomes `\"failed\"` with error
+    details, the stored data is unchanged, and the queued treatments are
+    retained — submit another POST to retry (the new treatments are applied
+    together with the retained ones).
+
+    ## Error Responses
+
+    - **404 Not Found**: The inventory does not exist, is not owned by the
+      caller, or is not in this domain.
+    - **422 Unprocessable Content**: The inventory is not in `completed` status
+      (and is not a retryable failed treatment); the inventory has no `dbh`
+      column to thin against (e.g. CHM-derived); an inventory-wide basal-area
+      treatment over a very large domain; or a referenced `feature_id` is
+      missing, cross-domain, or not completed.
+    - **429 Too Many Requests**: You have too many active inventory jobs in
+      progress (your `max_active_inventories` quota). Wait for jobs to complete
+      or delete unneeded inventories, then retry. The response detail names the
+      exact `quota` and includes a `Retry-After` header.
 
     Args:
         domain_id (str):
@@ -148,7 +174,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | Inventory]
+        Response[HTTPValidationError | Inventory | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -170,7 +196,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: ApplyTreatmentsRequest,
-) -> HTTPValidationError | Inventory | None:
+) -> HTTPValidationError | Inventory | QuotaExceededDetail | None:
     r"""Apply treatments to an inventory in place
 
      # Apply Treatments to an Inventory (in place)
@@ -227,10 +253,30 @@ def sync(
 
     ## Response
 
-    Returns this inventory (same ID) with status `\"pending\"` and the submitted
-    treatments appended to `treatments`. Its `checksum` changes, so any resource
-    derived from it can detect that the source has changed. Poll the inventory
-    until status returns to `\"completed\"`.
+    Returns this inventory (same ID) with status `\"pending\"`. Its `checksum`
+    changes immediately, so any resource derived from it can detect that the
+    source has changed. The submitted treatments appear in the inventory's
+    `treatments` list once processing completes — poll the inventory until
+    status returns to `\"completed\"`.
+
+    If processing fails, the inventory's status becomes `\"failed\"` with error
+    details, the stored data is unchanged, and the queued treatments are
+    retained — submit another POST to retry (the new treatments are applied
+    together with the retained ones).
+
+    ## Error Responses
+
+    - **404 Not Found**: The inventory does not exist, is not owned by the
+      caller, or is not in this domain.
+    - **422 Unprocessable Content**: The inventory is not in `completed` status
+      (and is not a retryable failed treatment); the inventory has no `dbh`
+      column to thin against (e.g. CHM-derived); an inventory-wide basal-area
+      treatment over a very large domain; or a referenced `feature_id` is
+      missing, cross-domain, or not completed.
+    - **429 Too Many Requests**: You have too many active inventory jobs in
+      progress (your `max_active_inventories` quota). Wait for jobs to complete
+      or delete unneeded inventories, then retry. The response detail names the
+      exact `quota` and includes a `Retry-After` header.
 
     Args:
         domain_id (str):
@@ -246,7 +292,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | Inventory
+        HTTPValidationError | Inventory | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -263,7 +309,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: ApplyTreatmentsRequest,
-) -> Response[HTTPValidationError | Inventory]:
+) -> Response[HTTPValidationError | Inventory | QuotaExceededDetail]:
     r"""Apply treatments to an inventory in place
 
      # Apply Treatments to an Inventory (in place)
@@ -320,10 +366,30 @@ async def asyncio_detailed(
 
     ## Response
 
-    Returns this inventory (same ID) with status `\"pending\"` and the submitted
-    treatments appended to `treatments`. Its `checksum` changes, so any resource
-    derived from it can detect that the source has changed. Poll the inventory
-    until status returns to `\"completed\"`.
+    Returns this inventory (same ID) with status `\"pending\"`. Its `checksum`
+    changes immediately, so any resource derived from it can detect that the
+    source has changed. The submitted treatments appear in the inventory's
+    `treatments` list once processing completes — poll the inventory until
+    status returns to `\"completed\"`.
+
+    If processing fails, the inventory's status becomes `\"failed\"` with error
+    details, the stored data is unchanged, and the queued treatments are
+    retained — submit another POST to retry (the new treatments are applied
+    together with the retained ones).
+
+    ## Error Responses
+
+    - **404 Not Found**: The inventory does not exist, is not owned by the
+      caller, or is not in this domain.
+    - **422 Unprocessable Content**: The inventory is not in `completed` status
+      (and is not a retryable failed treatment); the inventory has no `dbh`
+      column to thin against (e.g. CHM-derived); an inventory-wide basal-area
+      treatment over a very large domain; or a referenced `feature_id` is
+      missing, cross-domain, or not completed.
+    - **429 Too Many Requests**: You have too many active inventory jobs in
+      progress (your `max_active_inventories` quota). Wait for jobs to complete
+      or delete unneeded inventories, then retry. The response detail names the
+      exact `quota` and includes a `Retry-After` header.
 
     Args:
         domain_id (str):
@@ -339,7 +405,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | Inventory]
+        Response[HTTPValidationError | Inventory | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -359,7 +425,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: ApplyTreatmentsRequest,
-) -> HTTPValidationError | Inventory | None:
+) -> HTTPValidationError | Inventory | QuotaExceededDetail | None:
     r"""Apply treatments to an inventory in place
 
      # Apply Treatments to an Inventory (in place)
@@ -416,10 +482,30 @@ async def asyncio(
 
     ## Response
 
-    Returns this inventory (same ID) with status `\"pending\"` and the submitted
-    treatments appended to `treatments`. Its `checksum` changes, so any resource
-    derived from it can detect that the source has changed. Poll the inventory
-    until status returns to `\"completed\"`.
+    Returns this inventory (same ID) with status `\"pending\"`. Its `checksum`
+    changes immediately, so any resource derived from it can detect that the
+    source has changed. The submitted treatments appear in the inventory's
+    `treatments` list once processing completes — poll the inventory until
+    status returns to `\"completed\"`.
+
+    If processing fails, the inventory's status becomes `\"failed\"` with error
+    details, the stored data is unchanged, and the queued treatments are
+    retained — submit another POST to retry (the new treatments are applied
+    together with the retained ones).
+
+    ## Error Responses
+
+    - **404 Not Found**: The inventory does not exist, is not owned by the
+      caller, or is not in this domain.
+    - **422 Unprocessable Content**: The inventory is not in `completed` status
+      (and is not a retryable failed treatment); the inventory has no `dbh`
+      column to thin against (e.g. CHM-derived); an inventory-wide basal-area
+      treatment over a very large domain; or a referenced `feature_id` is
+      missing, cross-domain, or not completed.
+    - **429 Too Many Requests**: You have too many active inventory jobs in
+      progress (your `max_active_inventories` quota). Wait for jobs to complete
+      or delete unneeded inventories, then retry. The response detail names the
+      exact `quota` and includes a `Retry-After` header.
 
     Args:
         domain_id (str):
@@ -435,7 +521,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | Inventory
+        HTTPValidationError | Inventory | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/inventories/create_chm_inventory.py
+++ b/fastfuels_sdk/v2/client_library/api/inventories/create_chm_inventory.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_chm_inventory_request import CreateChmInventoryRequest
 from ...models.http_validation_error import HTTPValidationError
 from ...models.inventory import Inventory
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -36,7 +37,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | Inventory | None:
+) -> HTTPValidationError | Inventory | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Inventory.from_dict(response.json())
 
@@ -47,6 +48,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,7 +61,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | Inventory]:
+) -> Response[HTTPValidationError | Inventory | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +75,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateChmInventoryRequest,
-) -> Response[HTTPValidationError | Inventory]:
+) -> Response[HTTPValidationError | Inventory | QuotaExceededDetail]:
     r"""Create an inventory from a Canopy Height Model (CHM)
 
      # Create CHM Extraction Inventory
@@ -108,7 +114,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | Inventory]
+        Response[HTTPValidationError | Inventory | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -128,7 +134,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateChmInventoryRequest,
-) -> HTTPValidationError | Inventory | None:
+) -> HTTPValidationError | Inventory | QuotaExceededDetail | None:
     r"""Create an inventory from a Canopy Height Model (CHM)
 
      # Create CHM Extraction Inventory
@@ -167,7 +173,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | Inventory
+        HTTPValidationError | Inventory | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -182,7 +188,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateChmInventoryRequest,
-) -> Response[HTTPValidationError | Inventory]:
+) -> Response[HTTPValidationError | Inventory | QuotaExceededDetail]:
     r"""Create an inventory from a Canopy Height Model (CHM)
 
      # Create CHM Extraction Inventory
@@ -221,7 +227,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | Inventory]
+        Response[HTTPValidationError | Inventory | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -239,7 +245,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateChmInventoryRequest,
-) -> HTTPValidationError | Inventory | None:
+) -> HTTPValidationError | Inventory | QuotaExceededDetail | None:
     r"""Create an inventory from a Canopy Height Model (CHM)
 
      # Create CHM Extraction Inventory
@@ -278,7 +284,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | Inventory
+        HTTPValidationError | Inventory | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/inventories/create_gdam_inventory.py
+++ b/fastfuels_sdk/v2/client_library/api/inventories/create_gdam_inventory.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_gdam_inventory_request import CreateGdamInventoryRequest
 from ...models.http_validation_error import HTTPValidationError
 from ...models.inventory import Inventory
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -36,7 +37,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | Inventory | None:
+) -> HTTPValidationError | Inventory | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Inventory.from_dict(response.json())
 
@@ -47,6 +48,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,7 +61,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | Inventory]:
+) -> Response[HTTPValidationError | Inventory | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +75,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateGdamInventoryRequest,
-) -> Response[HTTPValidationError | Inventory]:
+) -> Response[HTTPValidationError | Inventory | QuotaExceededDetail]:
     r"""Create an inventory by filling in another via GDAM
 
      # Create GDAM Allometry Inventory
@@ -132,7 +138,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | Inventory]
+        Response[HTTPValidationError | Inventory | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -152,7 +158,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateGdamInventoryRequest,
-) -> HTTPValidationError | Inventory | None:
+) -> HTTPValidationError | Inventory | QuotaExceededDetail | None:
     r"""Create an inventory by filling in another via GDAM
 
      # Create GDAM Allometry Inventory
@@ -215,7 +221,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | Inventory
+        HTTPValidationError | Inventory | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -230,7 +236,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateGdamInventoryRequest,
-) -> Response[HTTPValidationError | Inventory]:
+) -> Response[HTTPValidationError | Inventory | QuotaExceededDetail]:
     r"""Create an inventory by filling in another via GDAM
 
      # Create GDAM Allometry Inventory
@@ -293,7 +299,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | Inventory]
+        Response[HTTPValidationError | Inventory | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -311,7 +317,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateGdamInventoryRequest,
-) -> HTTPValidationError | Inventory | None:
+) -> HTTPValidationError | Inventory | QuotaExceededDetail | None:
     r"""Create an inventory by filling in another via GDAM
 
      # Create GDAM Allometry Inventory
@@ -374,7 +380,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | Inventory
+        HTTPValidationError | Inventory | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/inventories/create_inventory_export.py
+++ b/fastfuels_sdk/v2/client_library/api/inventories/create_inventory_export.py
@@ -10,6 +10,7 @@ from ...models.export import Export
 from ...models.export_inventory_request import ExportInventoryRequest
 from ...models.http_validation_error import HTTPValidationError
 from ...models.inventory_export_format import InventoryExportFormat
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -41,7 +42,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Export | HTTPValidationError | None:
+) -> Export | HTTPValidationError | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Export.from_dict(response.json())
 
@@ -52,6 +53,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -60,7 +66,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[Export | HTTPValidationError]:
+) -> Response[Export | HTTPValidationError | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -76,7 +82,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: ExportInventoryRequest,
-) -> Response[Export | HTTPValidationError]:
+) -> Response[Export | HTTPValidationError | QuotaExceededDetail]:
     """Export an inventory
 
      Export an inventory to the specified format.
@@ -104,7 +110,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Export | HTTPValidationError]
+        Response[Export | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -128,7 +134,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: ExportInventoryRequest,
-) -> Export | HTTPValidationError | None:
+) -> Export | HTTPValidationError | QuotaExceededDetail | None:
     """Export an inventory
 
      Export an inventory to the specified format.
@@ -156,7 +162,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Export | HTTPValidationError
+        Export | HTTPValidationError | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -175,7 +181,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: ExportInventoryRequest,
-) -> Response[Export | HTTPValidationError]:
+) -> Response[Export | HTTPValidationError | QuotaExceededDetail]:
     """Export an inventory
 
      Export an inventory to the specified format.
@@ -203,7 +209,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Export | HTTPValidationError]
+        Response[Export | HTTPValidationError | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -225,7 +231,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: ExportInventoryRequest,
-) -> Export | HTTPValidationError | None:
+) -> Export | HTTPValidationError | QuotaExceededDetail | None:
     """Export an inventory
 
      Export an inventory to the specified format.
@@ -253,7 +259,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Export | HTTPValidationError
+        Export | HTTPValidationError | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/inventories/create_inventory_upload.py
+++ b/fastfuels_sdk/v2/client_library/api/inventories/create_inventory_upload.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_inventory_upload_request import CreateInventoryUploadRequest
 from ...models.http_validation_error import HTTPValidationError
 from ...models.inventory_upload_created_response import InventoryUploadCreatedResponse
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -36,7 +37,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | InventoryUploadCreatedResponse | None:
+) -> HTTPValidationError | InventoryUploadCreatedResponse | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = InventoryUploadCreatedResponse.from_dict(response.json())
 
@@ -47,6 +48,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,7 +61,9 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | InventoryUploadCreatedResponse]:
+) -> Response[
+    HTTPValidationError | InventoryUploadCreatedResponse | QuotaExceededDetail
+]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +77,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateInventoryUploadRequest,
-) -> Response[HTTPValidationError | InventoryUploadCreatedResponse]:
+) -> Response[
+    HTTPValidationError | InventoryUploadCreatedResponse | QuotaExceededDetail
+]:
     r"""Create an inventory from a direct file upload
 
      # Create Upload Inventory
@@ -112,7 +122,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | InventoryUploadCreatedResponse]
+        Response[HTTPValidationError | InventoryUploadCreatedResponse | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -132,7 +142,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreateInventoryUploadRequest,
-) -> HTTPValidationError | InventoryUploadCreatedResponse | None:
+) -> HTTPValidationError | InventoryUploadCreatedResponse | QuotaExceededDetail | None:
     r"""Create an inventory from a direct file upload
 
      # Create Upload Inventory
@@ -175,7 +185,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | InventoryUploadCreatedResponse
+        HTTPValidationError | InventoryUploadCreatedResponse | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -190,7 +200,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreateInventoryUploadRequest,
-) -> Response[HTTPValidationError | InventoryUploadCreatedResponse]:
+) -> Response[
+    HTTPValidationError | InventoryUploadCreatedResponse | QuotaExceededDetail
+]:
     r"""Create an inventory from a direct file upload
 
      # Create Upload Inventory
@@ -233,7 +245,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | InventoryUploadCreatedResponse]
+        Response[HTTPValidationError | InventoryUploadCreatedResponse | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -251,7 +263,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreateInventoryUploadRequest,
-) -> HTTPValidationError | InventoryUploadCreatedResponse | None:
+) -> HTTPValidationError | InventoryUploadCreatedResponse | QuotaExceededDetail | None:
     r"""Create an inventory from a direct file upload
 
      # Create Upload Inventory
@@ -294,7 +306,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | InventoryUploadCreatedResponse
+        HTTPValidationError | InventoryUploadCreatedResponse | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/inventories/create_pim_inventory.py
+++ b/fastfuels_sdk/v2/client_library/api/inventories/create_pim_inventory.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_pim_inventory_request import CreatePimInventoryRequest
 from ...models.http_validation_error import HTTPValidationError
 from ...models.inventory import Inventory
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -36,7 +37,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | Inventory | None:
+) -> HTTPValidationError | Inventory | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Inventory.from_dict(response.json())
 
@@ -47,6 +48,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,7 +61,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | Inventory]:
+) -> Response[HTTPValidationError | Inventory | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -69,7 +75,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreatePimInventoryRequest,
-) -> Response[HTTPValidationError | Inventory]:
+) -> Response[HTTPValidationError | Inventory | QuotaExceededDetail]:
     r"""Create an inventory from PIM expansion
 
      # Create PIM Expansion Inventory
@@ -127,7 +133,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | Inventory]
+        Response[HTTPValidationError | Inventory | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -147,7 +153,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreatePimInventoryRequest,
-) -> HTTPValidationError | Inventory | None:
+) -> HTTPValidationError | Inventory | QuotaExceededDetail | None:
     r"""Create an inventory from PIM expansion
 
      # Create PIM Expansion Inventory
@@ -205,7 +211,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | Inventory
+        HTTPValidationError | Inventory | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -220,7 +226,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreatePimInventoryRequest,
-) -> Response[HTTPValidationError | Inventory]:
+) -> Response[HTTPValidationError | Inventory | QuotaExceededDetail]:
     r"""Create an inventory from PIM expansion
 
      # Create PIM Expansion Inventory
@@ -278,7 +284,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | Inventory]
+        Response[HTTPValidationError | Inventory | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -296,7 +302,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreatePimInventoryRequest,
-) -> HTTPValidationError | Inventory | None:
+) -> HTTPValidationError | Inventory | QuotaExceededDetail | None:
     r"""Create an inventory from PIM expansion
 
      # Create PIM Expansion Inventory
@@ -354,7 +360,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | Inventory
+        HTTPValidationError | Inventory | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/inventories/duplicate_inventory.py
+++ b/fastfuels_sdk/v2/client_library/api/inventories/duplicate_inventory.py
@@ -9,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.duplicate_inventory_request import DuplicateInventoryRequest
 from ...models.http_validation_error import HTTPValidationError
 from ...models.inventory import Inventory
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import UNSET, Response, Unset
 
 
@@ -41,7 +42,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | Inventory | None:
+) -> HTTPValidationError | Inventory | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = Inventory.from_dict(response.json())
 
@@ -52,6 +53,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -60,7 +66,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | Inventory]:
+) -> Response[HTTPValidationError | Inventory | QuotaExceededDetail]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -75,7 +81,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: DuplicateInventoryRequest | None | Unset = UNSET,
-) -> Response[HTTPValidationError | Inventory]:
+) -> Response[HTTPValidationError | Inventory | QuotaExceededDetail]:
     r"""Duplicate an inventory
 
      # Duplicate an Inventory
@@ -112,6 +118,10 @@ def sync_detailed(
       caller, or is not in this domain.
     - **422 Unprocessable Content**: The source inventory exists but is not yet
       `completed`, so there is no finished artifact to copy.
+    - **429 Too Many Requests**: You have too many active inventory jobs in
+      progress (your `max_active_inventories` quota). Wait for jobs to complete
+      or delete unneeded inventories, then retry. The response detail names the
+      exact `quota` and includes a `Retry-After` header.
 
     Args:
         domain_id (str):
@@ -123,7 +133,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | Inventory]
+        Response[HTTPValidationError | Inventory | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -145,7 +155,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: DuplicateInventoryRequest | None | Unset = UNSET,
-) -> HTTPValidationError | Inventory | None:
+) -> HTTPValidationError | Inventory | QuotaExceededDetail | None:
     r"""Duplicate an inventory
 
      # Duplicate an Inventory
@@ -182,6 +192,10 @@ def sync(
       caller, or is not in this domain.
     - **422 Unprocessable Content**: The source inventory exists but is not yet
       `completed`, so there is no finished artifact to copy.
+    - **429 Too Many Requests**: You have too many active inventory jobs in
+      progress (your `max_active_inventories` quota). Wait for jobs to complete
+      or delete unneeded inventories, then retry. The response detail names the
+      exact `quota` and includes a `Retry-After` header.
 
     Args:
         domain_id (str):
@@ -193,7 +207,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | Inventory
+        HTTPValidationError | Inventory | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -210,7 +224,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: DuplicateInventoryRequest | None | Unset = UNSET,
-) -> Response[HTTPValidationError | Inventory]:
+) -> Response[HTTPValidationError | Inventory | QuotaExceededDetail]:
     r"""Duplicate an inventory
 
      # Duplicate an Inventory
@@ -247,6 +261,10 @@ async def asyncio_detailed(
       caller, or is not in this domain.
     - **422 Unprocessable Content**: The source inventory exists but is not yet
       `completed`, so there is no finished artifact to copy.
+    - **429 Too Many Requests**: You have too many active inventory jobs in
+      progress (your `max_active_inventories` quota). Wait for jobs to complete
+      or delete unneeded inventories, then retry. The response detail names the
+      exact `quota` and includes a `Retry-After` header.
 
     Args:
         domain_id (str):
@@ -258,7 +276,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | Inventory]
+        Response[HTTPValidationError | Inventory | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -278,7 +296,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: DuplicateInventoryRequest | None | Unset = UNSET,
-) -> HTTPValidationError | Inventory | None:
+) -> HTTPValidationError | Inventory | QuotaExceededDetail | None:
     r"""Duplicate an inventory
 
      # Duplicate an Inventory
@@ -315,6 +333,10 @@ async def asyncio(
       caller, or is not in this domain.
     - **422 Unprocessable Content**: The source inventory exists but is not yet
       `completed`, so there is no finished artifact to copy.
+    - **429 Too Many Requests**: You have too many active inventory jobs in
+      progress (your `max_active_inventories` quota). Wait for jobs to complete
+      or delete unneeded inventories, then retry. The response detail names the
+      exact `quota` and includes a `Retry-After` header.
 
     Args:
         domain_id (str):
@@ -326,7 +348,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | Inventory
+        HTTPValidationError | Inventory | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/inventories/get_inventory_data_csv.py
+++ b/fastfuels_sdk/v2/client_library/api/inventories/get_inventory_data_csv.py
@@ -7,9 +7,6 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
-from ...models.inventory_data_format import InventoryDataFormat
-from ...models.inventory_data_response import InventoryDataResponse
-from ...models.inventory_json_orientation import InventoryJsonOrientation
 from ...types import UNSET, Response, Unset
 
 
@@ -18,24 +15,10 @@ def _get_kwargs(
     inventory_id: str,
     partition_index: int,
     *,
-    format_: InventoryDataFormat | Unset = UNSET,
-    json_orientation: InventoryJsonOrientation | Unset = UNSET,
     columns: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
 
     params: dict[str, Any] = {}
-
-    json_format_: str | Unset = UNSET
-    if not isinstance(format_, Unset):
-        json_format_ = format_.value
-
-    params["format"] = json_format_
-
-    json_json_orientation: str | Unset = UNSET
-    if not isinstance(json_orientation, Unset):
-        json_json_orientation = json_orientation.value
-
-    params["json_orientation"] = json_json_orientation
 
     json_columns: None | str | Unset
     if isinstance(columns, Unset):
@@ -48,7 +31,7 @@ def _get_kwargs(
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/domains/{domain_id}/inventories/{inventory_id}/data/{partition_index}".format(
+        "url": "/domains/{domain_id}/inventories/{inventory_id}/data/{partition_index}/csv".format(
             domain_id=quote(str(domain_id), safe=""),
             inventory_id=quote(str(inventory_id), safe=""),
             partition_index=quote(str(partition_index), safe=""),
@@ -61,10 +44,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | InventoryDataResponse | None:
+) -> HTTPValidationError | str | None:
     if response.status_code == 200:
-        response_200 = InventoryDataResponse.from_dict(response.json())
-
+        response_200 = response.text
         return response_200
 
     if response.status_code == 422:
@@ -80,7 +62,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | InventoryDataResponse]:
+) -> Response[HTTPValidationError | str]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -95,16 +77,18 @@ def sync_detailed(
     partition_index: int,
     *,
     client: AuthenticatedClient,
-    format_: InventoryDataFormat | Unset = UNSET,
-    json_orientation: InventoryJsonOrientation | Unset = UNSET,
     columns: None | str | Unset = UNSET,
-) -> Response[HTTPValidationError | InventoryDataResponse]:
-    """Get inventory data for a partition
+) -> Response[HTTPValidationError | str]:
+    """Get inventory data for a partition (CSV)
 
-     # Get Inventory Data
+     # Get Inventory Data (CSV)
 
-    Reads a single partition of a completed inventory's Parquet data on GCS.
-    Returns the tree records as JSON (split or records orientation) or CSV.
+    Reads a single partition of a completed inventory's Parquet data on GCS and
+    returns the tree records as a `text/csv` body with a header row. Use this
+    when you want to hand the response straight to a CSV reader.
+
+    For a structured JSON payload, use the JSON variant of this endpoint (drop
+    the trailing `/csv`).
 
     ## Path Parameters
 
@@ -114,19 +98,16 @@ def sync_detailed(
 
     ## Query Parameters
 
-    - **format**: Response format: `json` (default) or `csv`.
-    - **json_orientation**: JSON layout: `split` (default, compact) or
-      `records` (self-describing). Ignored for CSV.
     - **columns**: Comma-separated column subset (default: all).
 
     ## Response
 
-    **JSON split** (default): column names + 2D array of values.
+    A `text/csv` body, with partition metadata in these response headers:
 
-    **JSON records**: list of row objects.
-
-    **CSV**: `text/csv` body with metadata in response headers
-    `X-Partition-Index`, `X-Row-Count`, `X-Total-Rows`, `X-Num-Partitions`.
+    - `X-Partition-Index`: the partition this body came from.
+    - `X-Row-Count`: rows in this partition.
+    - `X-Total-Rows`: rows across all partitions of the inventory.
+    - `X-Num-Partitions`: total number of partitions.
 
     ## Error Responses
 
@@ -138,8 +119,6 @@ def sync_detailed(
         domain_id (str):
         inventory_id (str):
         partition_index (int): Zero-based partition index.
-        format_ (InventoryDataFormat | Unset):
-        json_orientation (InventoryJsonOrientation | Unset):
         columns (None | str | Unset): Comma-separated column subset.
 
     Raises:
@@ -147,15 +126,13 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | InventoryDataResponse]
+        Response[HTTPValidationError | str]
     """
 
     kwargs = _get_kwargs(
         domain_id=domain_id,
         inventory_id=inventory_id,
         partition_index=partition_index,
-        format_=format_,
-        json_orientation=json_orientation,
         columns=columns,
     )
 
@@ -172,16 +149,18 @@ def sync(
     partition_index: int,
     *,
     client: AuthenticatedClient,
-    format_: InventoryDataFormat | Unset = UNSET,
-    json_orientation: InventoryJsonOrientation | Unset = UNSET,
     columns: None | str | Unset = UNSET,
-) -> HTTPValidationError | InventoryDataResponse | None:
-    """Get inventory data for a partition
+) -> HTTPValidationError | str | None:
+    """Get inventory data for a partition (CSV)
 
-     # Get Inventory Data
+     # Get Inventory Data (CSV)
 
-    Reads a single partition of a completed inventory's Parquet data on GCS.
-    Returns the tree records as JSON (split or records orientation) or CSV.
+    Reads a single partition of a completed inventory's Parquet data on GCS and
+    returns the tree records as a `text/csv` body with a header row. Use this
+    when you want to hand the response straight to a CSV reader.
+
+    For a structured JSON payload, use the JSON variant of this endpoint (drop
+    the trailing `/csv`).
 
     ## Path Parameters
 
@@ -191,19 +170,16 @@ def sync(
 
     ## Query Parameters
 
-    - **format**: Response format: `json` (default) or `csv`.
-    - **json_orientation**: JSON layout: `split` (default, compact) or
-      `records` (self-describing). Ignored for CSV.
     - **columns**: Comma-separated column subset (default: all).
 
     ## Response
 
-    **JSON split** (default): column names + 2D array of values.
+    A `text/csv` body, with partition metadata in these response headers:
 
-    **JSON records**: list of row objects.
-
-    **CSV**: `text/csv` body with metadata in response headers
-    `X-Partition-Index`, `X-Row-Count`, `X-Total-Rows`, `X-Num-Partitions`.
+    - `X-Partition-Index`: the partition this body came from.
+    - `X-Row-Count`: rows in this partition.
+    - `X-Total-Rows`: rows across all partitions of the inventory.
+    - `X-Num-Partitions`: total number of partitions.
 
     ## Error Responses
 
@@ -215,8 +191,6 @@ def sync(
         domain_id (str):
         inventory_id (str):
         partition_index (int): Zero-based partition index.
-        format_ (InventoryDataFormat | Unset):
-        json_orientation (InventoryJsonOrientation | Unset):
         columns (None | str | Unset): Comma-separated column subset.
 
     Raises:
@@ -224,7 +198,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | InventoryDataResponse
+        HTTPValidationError | str
     """
 
     return sync_detailed(
@@ -232,8 +206,6 @@ def sync(
         inventory_id=inventory_id,
         partition_index=partition_index,
         client=client,
-        format_=format_,
-        json_orientation=json_orientation,
         columns=columns,
     ).parsed
 
@@ -244,16 +216,18 @@ async def asyncio_detailed(
     partition_index: int,
     *,
     client: AuthenticatedClient,
-    format_: InventoryDataFormat | Unset = UNSET,
-    json_orientation: InventoryJsonOrientation | Unset = UNSET,
     columns: None | str | Unset = UNSET,
-) -> Response[HTTPValidationError | InventoryDataResponse]:
-    """Get inventory data for a partition
+) -> Response[HTTPValidationError | str]:
+    """Get inventory data for a partition (CSV)
 
-     # Get Inventory Data
+     # Get Inventory Data (CSV)
 
-    Reads a single partition of a completed inventory's Parquet data on GCS.
-    Returns the tree records as JSON (split or records orientation) or CSV.
+    Reads a single partition of a completed inventory's Parquet data on GCS and
+    returns the tree records as a `text/csv` body with a header row. Use this
+    when you want to hand the response straight to a CSV reader.
+
+    For a structured JSON payload, use the JSON variant of this endpoint (drop
+    the trailing `/csv`).
 
     ## Path Parameters
 
@@ -263,19 +237,16 @@ async def asyncio_detailed(
 
     ## Query Parameters
 
-    - **format**: Response format: `json` (default) or `csv`.
-    - **json_orientation**: JSON layout: `split` (default, compact) or
-      `records` (self-describing). Ignored for CSV.
     - **columns**: Comma-separated column subset (default: all).
 
     ## Response
 
-    **JSON split** (default): column names + 2D array of values.
+    A `text/csv` body, with partition metadata in these response headers:
 
-    **JSON records**: list of row objects.
-
-    **CSV**: `text/csv` body with metadata in response headers
-    `X-Partition-Index`, `X-Row-Count`, `X-Total-Rows`, `X-Num-Partitions`.
+    - `X-Partition-Index`: the partition this body came from.
+    - `X-Row-Count`: rows in this partition.
+    - `X-Total-Rows`: rows across all partitions of the inventory.
+    - `X-Num-Partitions`: total number of partitions.
 
     ## Error Responses
 
@@ -287,8 +258,6 @@ async def asyncio_detailed(
         domain_id (str):
         inventory_id (str):
         partition_index (int): Zero-based partition index.
-        format_ (InventoryDataFormat | Unset):
-        json_orientation (InventoryJsonOrientation | Unset):
         columns (None | str | Unset): Comma-separated column subset.
 
     Raises:
@@ -296,15 +265,13 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | InventoryDataResponse]
+        Response[HTTPValidationError | str]
     """
 
     kwargs = _get_kwargs(
         domain_id=domain_id,
         inventory_id=inventory_id,
         partition_index=partition_index,
-        format_=format_,
-        json_orientation=json_orientation,
         columns=columns,
     )
 
@@ -319,16 +286,18 @@ async def asyncio(
     partition_index: int,
     *,
     client: AuthenticatedClient,
-    format_: InventoryDataFormat | Unset = UNSET,
-    json_orientation: InventoryJsonOrientation | Unset = UNSET,
     columns: None | str | Unset = UNSET,
-) -> HTTPValidationError | InventoryDataResponse | None:
-    """Get inventory data for a partition
+) -> HTTPValidationError | str | None:
+    """Get inventory data for a partition (CSV)
 
-     # Get Inventory Data
+     # Get Inventory Data (CSV)
 
-    Reads a single partition of a completed inventory's Parquet data on GCS.
-    Returns the tree records as JSON (split or records orientation) or CSV.
+    Reads a single partition of a completed inventory's Parquet data on GCS and
+    returns the tree records as a `text/csv` body with a header row. Use this
+    when you want to hand the response straight to a CSV reader.
+
+    For a structured JSON payload, use the JSON variant of this endpoint (drop
+    the trailing `/csv`).
 
     ## Path Parameters
 
@@ -338,19 +307,16 @@ async def asyncio(
 
     ## Query Parameters
 
-    - **format**: Response format: `json` (default) or `csv`.
-    - **json_orientation**: JSON layout: `split` (default, compact) or
-      `records` (self-describing). Ignored for CSV.
     - **columns**: Comma-separated column subset (default: all).
 
     ## Response
 
-    **JSON split** (default): column names + 2D array of values.
+    A `text/csv` body, with partition metadata in these response headers:
 
-    **JSON records**: list of row objects.
-
-    **CSV**: `text/csv` body with metadata in response headers
-    `X-Partition-Index`, `X-Row-Count`, `X-Total-Rows`, `X-Num-Partitions`.
+    - `X-Partition-Index`: the partition this body came from.
+    - `X-Row-Count`: rows in this partition.
+    - `X-Total-Rows`: rows across all partitions of the inventory.
+    - `X-Num-Partitions`: total number of partitions.
 
     ## Error Responses
 
@@ -362,8 +328,6 @@ async def asyncio(
         domain_id (str):
         inventory_id (str):
         partition_index (int): Zero-based partition index.
-        format_ (InventoryDataFormat | Unset):
-        json_orientation (InventoryJsonOrientation | Unset):
         columns (None | str | Unset): Comma-separated column subset.
 
     Raises:
@@ -371,7 +335,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | InventoryDataResponse
+        HTTPValidationError | str
     """
 
     return (
@@ -380,8 +344,6 @@ async def asyncio(
             inventory_id=inventory_id,
             partition_index=partition_index,
             client=client,
-            format_=format_,
-            json_orientation=json_orientation,
             columns=columns,
         )
     ).parsed

--- a/fastfuels_sdk/v2/client_library/api/inventories/get_inventory_data_json.py
+++ b/fastfuels_sdk/v2/client_library/api/inventories/get_inventory_data_json.py
@@ -1,0 +1,363 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.inventory_data_response import InventoryDataResponse
+from ...models.inventory_json_orientation import InventoryJsonOrientation
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    domain_id: str,
+    inventory_id: str,
+    partition_index: int,
+    *,
+    json_orientation: InventoryJsonOrientation | Unset = UNSET,
+    columns: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    json_json_orientation: str | Unset = UNSET
+    if not isinstance(json_orientation, Unset):
+        json_json_orientation = json_orientation.value
+
+    params["json_orientation"] = json_json_orientation
+
+    json_columns: None | str | Unset
+    if isinstance(columns, Unset):
+        json_columns = UNSET
+    else:
+        json_columns = columns
+    params["columns"] = json_columns
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/domains/{domain_id}/inventories/{inventory_id}/data/{partition_index}".format(
+            domain_id=quote(str(domain_id), safe=""),
+            inventory_id=quote(str(inventory_id), safe=""),
+            partition_index=quote(str(partition_index), safe=""),
+        ),
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | InventoryDataResponse | None:
+    if response.status_code == 200:
+        response_200 = InventoryDataResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | InventoryDataResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    domain_id: str,
+    inventory_id: str,
+    partition_index: int,
+    *,
+    client: AuthenticatedClient,
+    json_orientation: InventoryJsonOrientation | Unset = UNSET,
+    columns: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | InventoryDataResponse]:
+    """Get inventory data for a partition (JSON)
+
+     # Get Inventory Data (JSON)
+
+    Reads a single partition of a completed inventory's Parquet data on GCS and
+    returns the tree records as a JSON payload — either a compact columnar
+    layout or self-describing row objects, selected via `json_orientation`.
+
+    For a CSV body, use the CSV variant of this endpoint (append `/csv`).
+
+    ## Path Parameters
+
+    - **domain_id**: The domain the inventory belongs to.
+    - **inventory_id**: The unique identifier of the inventory.
+    - **partition_index**: Zero-based partition index.
+
+    ## Query Parameters
+
+    - **json_orientation**: JSON layout: `split` (default, compact) or
+      `records` (self-describing).
+    - **columns**: Comma-separated column subset (default: all).
+
+    ## Response
+
+    **split** (default): column names + 2D array of values.
+
+    **records**: list of row objects.
+
+    ## Error Responses
+
+    - **404 Not Found**: Inventory does not exist or user does not have access.
+    - **422 Unprocessable Entity**: Inventory not completed, partition index
+      out of range, invalid column names, or metadata not available.
+
+    Args:
+        domain_id (str):
+        inventory_id (str):
+        partition_index (int): Zero-based partition index.
+        json_orientation (InventoryJsonOrientation | Unset):
+        columns (None | str | Unset): Comma-separated column subset.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | InventoryDataResponse]
+    """
+
+    kwargs = _get_kwargs(
+        domain_id=domain_id,
+        inventory_id=inventory_id,
+        partition_index=partition_index,
+        json_orientation=json_orientation,
+        columns=columns,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    domain_id: str,
+    inventory_id: str,
+    partition_index: int,
+    *,
+    client: AuthenticatedClient,
+    json_orientation: InventoryJsonOrientation | Unset = UNSET,
+    columns: None | str | Unset = UNSET,
+) -> HTTPValidationError | InventoryDataResponse | None:
+    """Get inventory data for a partition (JSON)
+
+     # Get Inventory Data (JSON)
+
+    Reads a single partition of a completed inventory's Parquet data on GCS and
+    returns the tree records as a JSON payload — either a compact columnar
+    layout or self-describing row objects, selected via `json_orientation`.
+
+    For a CSV body, use the CSV variant of this endpoint (append `/csv`).
+
+    ## Path Parameters
+
+    - **domain_id**: The domain the inventory belongs to.
+    - **inventory_id**: The unique identifier of the inventory.
+    - **partition_index**: Zero-based partition index.
+
+    ## Query Parameters
+
+    - **json_orientation**: JSON layout: `split` (default, compact) or
+      `records` (self-describing).
+    - **columns**: Comma-separated column subset (default: all).
+
+    ## Response
+
+    **split** (default): column names + 2D array of values.
+
+    **records**: list of row objects.
+
+    ## Error Responses
+
+    - **404 Not Found**: Inventory does not exist or user does not have access.
+    - **422 Unprocessable Entity**: Inventory not completed, partition index
+      out of range, invalid column names, or metadata not available.
+
+    Args:
+        domain_id (str):
+        inventory_id (str):
+        partition_index (int): Zero-based partition index.
+        json_orientation (InventoryJsonOrientation | Unset):
+        columns (None | str | Unset): Comma-separated column subset.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | InventoryDataResponse
+    """
+
+    return sync_detailed(
+        domain_id=domain_id,
+        inventory_id=inventory_id,
+        partition_index=partition_index,
+        client=client,
+        json_orientation=json_orientation,
+        columns=columns,
+    ).parsed
+
+
+async def asyncio_detailed(
+    domain_id: str,
+    inventory_id: str,
+    partition_index: int,
+    *,
+    client: AuthenticatedClient,
+    json_orientation: InventoryJsonOrientation | Unset = UNSET,
+    columns: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | InventoryDataResponse]:
+    """Get inventory data for a partition (JSON)
+
+     # Get Inventory Data (JSON)
+
+    Reads a single partition of a completed inventory's Parquet data on GCS and
+    returns the tree records as a JSON payload — either a compact columnar
+    layout or self-describing row objects, selected via `json_orientation`.
+
+    For a CSV body, use the CSV variant of this endpoint (append `/csv`).
+
+    ## Path Parameters
+
+    - **domain_id**: The domain the inventory belongs to.
+    - **inventory_id**: The unique identifier of the inventory.
+    - **partition_index**: Zero-based partition index.
+
+    ## Query Parameters
+
+    - **json_orientation**: JSON layout: `split` (default, compact) or
+      `records` (self-describing).
+    - **columns**: Comma-separated column subset (default: all).
+
+    ## Response
+
+    **split** (default): column names + 2D array of values.
+
+    **records**: list of row objects.
+
+    ## Error Responses
+
+    - **404 Not Found**: Inventory does not exist or user does not have access.
+    - **422 Unprocessable Entity**: Inventory not completed, partition index
+      out of range, invalid column names, or metadata not available.
+
+    Args:
+        domain_id (str):
+        inventory_id (str):
+        partition_index (int): Zero-based partition index.
+        json_orientation (InventoryJsonOrientation | Unset):
+        columns (None | str | Unset): Comma-separated column subset.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | InventoryDataResponse]
+    """
+
+    kwargs = _get_kwargs(
+        domain_id=domain_id,
+        inventory_id=inventory_id,
+        partition_index=partition_index,
+        json_orientation=json_orientation,
+        columns=columns,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    domain_id: str,
+    inventory_id: str,
+    partition_index: int,
+    *,
+    client: AuthenticatedClient,
+    json_orientation: InventoryJsonOrientation | Unset = UNSET,
+    columns: None | str | Unset = UNSET,
+) -> HTTPValidationError | InventoryDataResponse | None:
+    """Get inventory data for a partition (JSON)
+
+     # Get Inventory Data (JSON)
+
+    Reads a single partition of a completed inventory's Parquet data on GCS and
+    returns the tree records as a JSON payload — either a compact columnar
+    layout or self-describing row objects, selected via `json_orientation`.
+
+    For a CSV body, use the CSV variant of this endpoint (append `/csv`).
+
+    ## Path Parameters
+
+    - **domain_id**: The domain the inventory belongs to.
+    - **inventory_id**: The unique identifier of the inventory.
+    - **partition_index**: Zero-based partition index.
+
+    ## Query Parameters
+
+    - **json_orientation**: JSON layout: `split` (default, compact) or
+      `records` (self-describing).
+    - **columns**: Comma-separated column subset (default: all).
+
+    ## Response
+
+    **split** (default): column names + 2D array of values.
+
+    **records**: list of row objects.
+
+    ## Error Responses
+
+    - **404 Not Found**: Inventory does not exist or user does not have access.
+    - **422 Unprocessable Entity**: Inventory not completed, partition index
+      out of range, invalid column names, or metadata not available.
+
+    Args:
+        domain_id (str):
+        inventory_id (str):
+        partition_index (int): Zero-based partition index.
+        json_orientation (InventoryJsonOrientation | Unset):
+        columns (None | str | Unset): Comma-separated column subset.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | InventoryDataResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            domain_id=domain_id,
+            inventory_id=inventory_id,
+            partition_index=partition_index,
+            client=client,
+            json_orientation=json_orientation,
+            columns=columns,
+        )
+    ).parsed

--- a/fastfuels_sdk/v2/client_library/api/point_clouds/check_3dep_point_cloud_coverage.py
+++ b/fastfuels_sdk/v2/client_library/api/point_clouds/check_3dep_point_cloud_coverage.py
@@ -1,0 +1,259 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.point_cloud_three_dep_coverage_response import (
+    PointCloudThreeDepCoverageResponse,
+)
+from ...types import Response
+
+
+def _get_kwargs(
+    domain_id: str,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/domains/{domain_id}/pointclouds/3dep/coverage".format(
+            domain_id=quote(str(domain_id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | PointCloudThreeDepCoverageResponse | None:
+    if response.status_code == 200:
+        response_200 = PointCloudThreeDepCoverageResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | PointCloudThreeDepCoverageResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[HTTPValidationError | PointCloudThreeDepCoverageResponse]:
+    """Check 3DEP lidar coverage for a domain
+
+     # Check 3DEP Lidar Coverage
+
+    Immediate pre-flight check reporting which USGS 3DEP lidar surveys are
+    available for this domain, how much of it they cover, and roughly how many
+    points a fetch would return. Use it before creating a 3DEP point cloud to
+    avoid waiting on a background job only to find a coverage gap — 3DEP is
+    regional, and survey boundaries are irregular.
+
+    This checks lidar point clouds. Elevation raster coverage is a separate
+    product with its own check at
+    `GET /domains/{domain_id}/grids/topography/3dep/coverage`.
+
+    ## Response
+
+    Reports whether any lidar is available, the fraction of the domain covered,
+    the surveys that would be read with what each contributes, and the
+    estimated point count against the per-fetch budget. `datasets[].name`
+    values can be passed as `datasets` when creating the point cloud to pin the
+    fetch.
+
+    ## Error Responses
+
+    - **503**: The USGS 3DEP catalog is temporarily unreachable.
+
+    Args:
+        domain_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | PointCloudThreeDepCoverageResponse]
+    """
+
+    kwargs = _get_kwargs(
+        domain_id=domain_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> HTTPValidationError | PointCloudThreeDepCoverageResponse | None:
+    """Check 3DEP lidar coverage for a domain
+
+     # Check 3DEP Lidar Coverage
+
+    Immediate pre-flight check reporting which USGS 3DEP lidar surveys are
+    available for this domain, how much of it they cover, and roughly how many
+    points a fetch would return. Use it before creating a 3DEP point cloud to
+    avoid waiting on a background job only to find a coverage gap — 3DEP is
+    regional, and survey boundaries are irregular.
+
+    This checks lidar point clouds. Elevation raster coverage is a separate
+    product with its own check at
+    `GET /domains/{domain_id}/grids/topography/3dep/coverage`.
+
+    ## Response
+
+    Reports whether any lidar is available, the fraction of the domain covered,
+    the surveys that would be read with what each contributes, and the
+    estimated point count against the per-fetch budget. `datasets[].name`
+    values can be passed as `datasets` when creating the point cloud to pin the
+    fetch.
+
+    ## Error Responses
+
+    - **503**: The USGS 3DEP catalog is temporarily unreachable.
+
+    Args:
+        domain_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | PointCloudThreeDepCoverageResponse
+    """
+
+    return sync_detailed(
+        domain_id=domain_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[HTTPValidationError | PointCloudThreeDepCoverageResponse]:
+    """Check 3DEP lidar coverage for a domain
+
+     # Check 3DEP Lidar Coverage
+
+    Immediate pre-flight check reporting which USGS 3DEP lidar surveys are
+    available for this domain, how much of it they cover, and roughly how many
+    points a fetch would return. Use it before creating a 3DEP point cloud to
+    avoid waiting on a background job only to find a coverage gap — 3DEP is
+    regional, and survey boundaries are irregular.
+
+    This checks lidar point clouds. Elevation raster coverage is a separate
+    product with its own check at
+    `GET /domains/{domain_id}/grids/topography/3dep/coverage`.
+
+    ## Response
+
+    Reports whether any lidar is available, the fraction of the domain covered,
+    the surveys that would be read with what each contributes, and the
+    estimated point count against the per-fetch budget. `datasets[].name`
+    values can be passed as `datasets` when creating the point cloud to pin the
+    fetch.
+
+    ## Error Responses
+
+    - **503**: The USGS 3DEP catalog is temporarily unreachable.
+
+    Args:
+        domain_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | PointCloudThreeDepCoverageResponse]
+    """
+
+    kwargs = _get_kwargs(
+        domain_id=domain_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+) -> HTTPValidationError | PointCloudThreeDepCoverageResponse | None:
+    """Check 3DEP lidar coverage for a domain
+
+     # Check 3DEP Lidar Coverage
+
+    Immediate pre-flight check reporting which USGS 3DEP lidar surveys are
+    available for this domain, how much of it they cover, and roughly how many
+    points a fetch would return. Use it before creating a 3DEP point cloud to
+    avoid waiting on a background job only to find a coverage gap — 3DEP is
+    regional, and survey boundaries are irregular.
+
+    This checks lidar point clouds. Elevation raster coverage is a separate
+    product with its own check at
+    `GET /domains/{domain_id}/grids/topography/3dep/coverage`.
+
+    ## Response
+
+    Reports whether any lidar is available, the fraction of the domain covered,
+    the surveys that would be read with what each contributes, and the
+    estimated point count against the per-fetch budget. `datasets[].name`
+    values can be passed as `datasets` when creating the point cloud to pin the
+    fetch.
+
+    ## Error Responses
+
+    - **503**: The USGS 3DEP catalog is temporarily unreachable.
+
+    Args:
+        domain_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | PointCloudThreeDepCoverageResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            domain_id=domain_id,
+            client=client,
+        )
+    ).parsed

--- a/fastfuels_sdk/v2/client_library/api/point_clouds/create_3dep_point_cloud.py
+++ b/fastfuels_sdk/v2/client_library/api/point_clouds/create_3dep_point_cloud.py
@@ -1,0 +1,418 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.create_three_dep_point_cloud_request import (
+    CreateThreeDepPointCloudRequest,
+)
+from ...models.http_validation_error import HTTPValidationError
+from ...models.point_cloud import PointCloud
+from ...models.quota_exceeded_detail import QuotaExceededDetail
+from ...types import Response
+
+
+def _get_kwargs(
+    domain_id: str,
+    *,
+    body: CreateThreeDepPointCloudRequest,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/domains/{domain_id}/pointclouds/3dep".format(
+            domain_id=quote(str(domain_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | PointCloud | QuotaExceededDetail | None:
+    if response.status_code == 201:
+        response_201 = PointCloud.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | PointCloud | QuotaExceededDetail]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateThreeDepPointCloudRequest,
+) -> Response[HTTPValidationError | PointCloud | QuotaExceededDetail]:
+    """Create a point cloud from USGS 3DEP
+
+     # Create a Point Cloud from USGS 3DEP
+
+    Fetches public airborne lidar from the USGS 3D Elevation Program for this
+    domain. The points are clipped to the domain, reprojected to the domain's
+    coordinate reference system, and stored as a point cloud you can build on —
+    most directly as a canopy height model, which in turn feeds a tree
+    inventory.
+
+    The point cloud is returned immediately with `status` = `pending` and is
+    fetched in the background: `status` becomes `running`, then `completed` once
+    the points are stored and `georeference` and `summary` are filled in — or
+    `failed` if the fetch cannot be completed. Poll
+    `GET /domains/{domain_id}/pointclouds/{id}` to follow progress.
+
+    3DEP is airborne, so the resulting point cloud is always type `als`. There
+    is no acquisition type to choose.
+
+    ## Choosing acquisitions
+
+    3DEP is published as separate surveys, which overlap and differ in age and
+    point density. By default the backend prefers a single survey that covers
+    the whole domain, and otherwise combines the fewest surveys that fill it —
+    each additional survey introduces a seam between flights of different dates
+    and densities. Pass `datasets` to pin the fetch to specific surveys
+    instead; check the coverage endpoint first to see what is available.
+
+    Survey boundaries are irregular, so a domain is often covered to
+    99-point-something percent rather than exactly 100. Any coverage above zero
+    produces a point cloud, and the fraction actually covered is recorded on the
+    result as `source.coverage_fraction` — check it if a gap would matter, since
+    `summary.density` is measured over the points that exist and looks healthy
+    either way. Use the coverage endpoint to see the shortfall before creating
+    anything.
+
+    ## Request Body
+
+    - **name**: (optional) Human-readable name.
+    - **description**: (optional) Longer free-text description.
+    - **tags**: (optional) Tags for organizing and filtering.
+    - **datasets**: (optional) Acquisition names to read, in priority order.
+      Omit to choose automatically.
+
+    ## Coordinate reference system
+
+    Points are reprojected to the domain's CRS. Only horizontal coordinates are
+    transformed — elevations are stored exactly as USGS published them, never
+    converted between reference surfaces.
+
+    ## Error Responses
+
+    - **422**: No 3DEP lidar covers this domain, a pinned acquisition is
+      unknown or does not overlap the domain, or the fetch would exceed the
+      point budget.
+    - **429**: A quota was exceeded.
+    - **503**: The USGS 3DEP catalog is temporarily unreachable.
+
+    Args:
+        domain_id (str):
+        body (CreateThreeDepPointCloudRequest): Request body for fetching a point cloud from USGS
+            3DEP.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | PointCloud | QuotaExceededDetail]
+    """
+
+    kwargs = _get_kwargs(
+        domain_id=domain_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateThreeDepPointCloudRequest,
+) -> HTTPValidationError | PointCloud | QuotaExceededDetail | None:
+    """Create a point cloud from USGS 3DEP
+
+     # Create a Point Cloud from USGS 3DEP
+
+    Fetches public airborne lidar from the USGS 3D Elevation Program for this
+    domain. The points are clipped to the domain, reprojected to the domain's
+    coordinate reference system, and stored as a point cloud you can build on —
+    most directly as a canopy height model, which in turn feeds a tree
+    inventory.
+
+    The point cloud is returned immediately with `status` = `pending` and is
+    fetched in the background: `status` becomes `running`, then `completed` once
+    the points are stored and `georeference` and `summary` are filled in — or
+    `failed` if the fetch cannot be completed. Poll
+    `GET /domains/{domain_id}/pointclouds/{id}` to follow progress.
+
+    3DEP is airborne, so the resulting point cloud is always type `als`. There
+    is no acquisition type to choose.
+
+    ## Choosing acquisitions
+
+    3DEP is published as separate surveys, which overlap and differ in age and
+    point density. By default the backend prefers a single survey that covers
+    the whole domain, and otherwise combines the fewest surveys that fill it —
+    each additional survey introduces a seam between flights of different dates
+    and densities. Pass `datasets` to pin the fetch to specific surveys
+    instead; check the coverage endpoint first to see what is available.
+
+    Survey boundaries are irregular, so a domain is often covered to
+    99-point-something percent rather than exactly 100. Any coverage above zero
+    produces a point cloud, and the fraction actually covered is recorded on the
+    result as `source.coverage_fraction` — check it if a gap would matter, since
+    `summary.density` is measured over the points that exist and looks healthy
+    either way. Use the coverage endpoint to see the shortfall before creating
+    anything.
+
+    ## Request Body
+
+    - **name**: (optional) Human-readable name.
+    - **description**: (optional) Longer free-text description.
+    - **tags**: (optional) Tags for organizing and filtering.
+    - **datasets**: (optional) Acquisition names to read, in priority order.
+      Omit to choose automatically.
+
+    ## Coordinate reference system
+
+    Points are reprojected to the domain's CRS. Only horizontal coordinates are
+    transformed — elevations are stored exactly as USGS published them, never
+    converted between reference surfaces.
+
+    ## Error Responses
+
+    - **422**: No 3DEP lidar covers this domain, a pinned acquisition is
+      unknown or does not overlap the domain, or the fetch would exceed the
+      point budget.
+    - **429**: A quota was exceeded.
+    - **503**: The USGS 3DEP catalog is temporarily unreachable.
+
+    Args:
+        domain_id (str):
+        body (CreateThreeDepPointCloudRequest): Request body for fetching a point cloud from USGS
+            3DEP.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | PointCloud | QuotaExceededDetail
+    """
+
+    return sync_detailed(
+        domain_id=domain_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateThreeDepPointCloudRequest,
+) -> Response[HTTPValidationError | PointCloud | QuotaExceededDetail]:
+    """Create a point cloud from USGS 3DEP
+
+     # Create a Point Cloud from USGS 3DEP
+
+    Fetches public airborne lidar from the USGS 3D Elevation Program for this
+    domain. The points are clipped to the domain, reprojected to the domain's
+    coordinate reference system, and stored as a point cloud you can build on —
+    most directly as a canopy height model, which in turn feeds a tree
+    inventory.
+
+    The point cloud is returned immediately with `status` = `pending` and is
+    fetched in the background: `status` becomes `running`, then `completed` once
+    the points are stored and `georeference` and `summary` are filled in — or
+    `failed` if the fetch cannot be completed. Poll
+    `GET /domains/{domain_id}/pointclouds/{id}` to follow progress.
+
+    3DEP is airborne, so the resulting point cloud is always type `als`. There
+    is no acquisition type to choose.
+
+    ## Choosing acquisitions
+
+    3DEP is published as separate surveys, which overlap and differ in age and
+    point density. By default the backend prefers a single survey that covers
+    the whole domain, and otherwise combines the fewest surveys that fill it —
+    each additional survey introduces a seam between flights of different dates
+    and densities. Pass `datasets` to pin the fetch to specific surveys
+    instead; check the coverage endpoint first to see what is available.
+
+    Survey boundaries are irregular, so a domain is often covered to
+    99-point-something percent rather than exactly 100. Any coverage above zero
+    produces a point cloud, and the fraction actually covered is recorded on the
+    result as `source.coverage_fraction` — check it if a gap would matter, since
+    `summary.density` is measured over the points that exist and looks healthy
+    either way. Use the coverage endpoint to see the shortfall before creating
+    anything.
+
+    ## Request Body
+
+    - **name**: (optional) Human-readable name.
+    - **description**: (optional) Longer free-text description.
+    - **tags**: (optional) Tags for organizing and filtering.
+    - **datasets**: (optional) Acquisition names to read, in priority order.
+      Omit to choose automatically.
+
+    ## Coordinate reference system
+
+    Points are reprojected to the domain's CRS. Only horizontal coordinates are
+    transformed — elevations are stored exactly as USGS published them, never
+    converted between reference surfaces.
+
+    ## Error Responses
+
+    - **422**: No 3DEP lidar covers this domain, a pinned acquisition is
+      unknown or does not overlap the domain, or the fetch would exceed the
+      point budget.
+    - **429**: A quota was exceeded.
+    - **503**: The USGS 3DEP catalog is temporarily unreachable.
+
+    Args:
+        domain_id (str):
+        body (CreateThreeDepPointCloudRequest): Request body for fetching a point cloud from USGS
+            3DEP.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | PointCloud | QuotaExceededDetail]
+    """
+
+    kwargs = _get_kwargs(
+        domain_id=domain_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    domain_id: str,
+    *,
+    client: AuthenticatedClient,
+    body: CreateThreeDepPointCloudRequest,
+) -> HTTPValidationError | PointCloud | QuotaExceededDetail | None:
+    """Create a point cloud from USGS 3DEP
+
+     # Create a Point Cloud from USGS 3DEP
+
+    Fetches public airborne lidar from the USGS 3D Elevation Program for this
+    domain. The points are clipped to the domain, reprojected to the domain's
+    coordinate reference system, and stored as a point cloud you can build on —
+    most directly as a canopy height model, which in turn feeds a tree
+    inventory.
+
+    The point cloud is returned immediately with `status` = `pending` and is
+    fetched in the background: `status` becomes `running`, then `completed` once
+    the points are stored and `georeference` and `summary` are filled in — or
+    `failed` if the fetch cannot be completed. Poll
+    `GET /domains/{domain_id}/pointclouds/{id}` to follow progress.
+
+    3DEP is airborne, so the resulting point cloud is always type `als`. There
+    is no acquisition type to choose.
+
+    ## Choosing acquisitions
+
+    3DEP is published as separate surveys, which overlap and differ in age and
+    point density. By default the backend prefers a single survey that covers
+    the whole domain, and otherwise combines the fewest surveys that fill it —
+    each additional survey introduces a seam between flights of different dates
+    and densities. Pass `datasets` to pin the fetch to specific surveys
+    instead; check the coverage endpoint first to see what is available.
+
+    Survey boundaries are irregular, so a domain is often covered to
+    99-point-something percent rather than exactly 100. Any coverage above zero
+    produces a point cloud, and the fraction actually covered is recorded on the
+    result as `source.coverage_fraction` — check it if a gap would matter, since
+    `summary.density` is measured over the points that exist and looks healthy
+    either way. Use the coverage endpoint to see the shortfall before creating
+    anything.
+
+    ## Request Body
+
+    - **name**: (optional) Human-readable name.
+    - **description**: (optional) Longer free-text description.
+    - **tags**: (optional) Tags for organizing and filtering.
+    - **datasets**: (optional) Acquisition names to read, in priority order.
+      Omit to choose automatically.
+
+    ## Coordinate reference system
+
+    Points are reprojected to the domain's CRS. Only horizontal coordinates are
+    transformed — elevations are stored exactly as USGS published them, never
+    converted between reference surfaces.
+
+    ## Error Responses
+
+    - **422**: No 3DEP lidar covers this domain, a pinned acquisition is
+      unknown or does not overlap the domain, or the fetch would exceed the
+      point budget.
+    - **429**: A quota was exceeded.
+    - **503**: The USGS 3DEP catalog is temporarily unreachable.
+
+    Args:
+        domain_id (str):
+        body (CreateThreeDepPointCloudRequest): Request body for fetching a point cloud from USGS
+            3DEP.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | PointCloud | QuotaExceededDetail
+    """
+
+    return (
+        await asyncio_detailed(
+            domain_id=domain_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/fastfuels_sdk/v2/client_library/api/point_clouds/create_point_cloud_upload.py
+++ b/fastfuels_sdk/v2/client_library/api/point_clouds/create_point_cloud_upload.py
@@ -11,6 +11,7 @@ from ...models.http_validation_error import HTTPValidationError
 from ...models.point_cloud_upload_created_response import (
     PointCloudUploadCreatedResponse,
 )
+from ...models.quota_exceeded_detail import QuotaExceededDetail
 from ...types import Response
 
 
@@ -38,7 +39,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | PointCloudUploadCreatedResponse | None:
+) -> HTTPValidationError | PointCloudUploadCreatedResponse | QuotaExceededDetail | None:
     if response.status_code == 201:
         response_201 = PointCloudUploadCreatedResponse.from_dict(response.json())
 
@@ -49,6 +50,11 @@ def _parse_response(
 
         return response_422
 
+    if response.status_code == 429:
+        response_429 = QuotaExceededDetail.from_dict(response.json())
+
+        return response_429
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -57,7 +63,9 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | PointCloudUploadCreatedResponse]:
+) -> Response[
+    HTTPValidationError | PointCloudUploadCreatedResponse | QuotaExceededDetail
+]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -71,7 +79,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     body: CreatePointCloudUploadRequest,
-) -> Response[HTTPValidationError | PointCloudUploadCreatedResponse]:
+) -> Response[
+    HTTPValidationError | PointCloudUploadCreatedResponse | QuotaExceededDetail
+]:
     r"""Create a point cloud from a direct file upload
 
      # Upload a Point Cloud
@@ -123,7 +133,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | PointCloudUploadCreatedResponse]
+        Response[HTTPValidationError | PointCloudUploadCreatedResponse | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -143,7 +153,7 @@ def sync(
     *,
     client: AuthenticatedClient,
     body: CreatePointCloudUploadRequest,
-) -> HTTPValidationError | PointCloudUploadCreatedResponse | None:
+) -> HTTPValidationError | PointCloudUploadCreatedResponse | QuotaExceededDetail | None:
     r"""Create a point cloud from a direct file upload
 
      # Upload a Point Cloud
@@ -195,7 +205,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | PointCloudUploadCreatedResponse
+        HTTPValidationError | PointCloudUploadCreatedResponse | QuotaExceededDetail
     """
 
     return sync_detailed(
@@ -210,7 +220,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     body: CreatePointCloudUploadRequest,
-) -> Response[HTTPValidationError | PointCloudUploadCreatedResponse]:
+) -> Response[
+    HTTPValidationError | PointCloudUploadCreatedResponse | QuotaExceededDetail
+]:
     r"""Create a point cloud from a direct file upload
 
      # Upload a Point Cloud
@@ -262,7 +274,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | PointCloudUploadCreatedResponse]
+        Response[HTTPValidationError | PointCloudUploadCreatedResponse | QuotaExceededDetail]
     """
 
     kwargs = _get_kwargs(
@@ -280,7 +292,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     body: CreatePointCloudUploadRequest,
-) -> HTTPValidationError | PointCloudUploadCreatedResponse | None:
+) -> HTTPValidationError | PointCloudUploadCreatedResponse | QuotaExceededDetail | None:
     r"""Create a point cloud from a direct file upload
 
      # Upload a Point Cloud
@@ -332,7 +344,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | PointCloudUploadCreatedResponse
+        HTTPValidationError | PointCloudUploadCreatedResponse | QuotaExceededDetail
     """
 
     return (

--- a/fastfuels_sdk/v2/client_library/api/users/__init__.py
+++ b/fastfuels_sdk/v2/client_library/api/users/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/fastfuels_sdk/v2/client_library/api/users/get_me.py
+++ b/fastfuels_sdk/v2/client_library/api/users/get_me.py
@@ -1,0 +1,136 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.user_me_response import UserMeResponse
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/users/me",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> UserMeResponse | None:
+    if response.status_code == 200:
+        response_200 = UserMeResponse.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[UserMeResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[UserMeResponse]:
+    """Get the authenticated owner
+
+     Return the authenticated owner's identity, tier, and resolved quotas.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[UserMeResponse]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+) -> UserMeResponse | None:
+    """Get the authenticated owner
+
+     Return the authenticated owner's identity, tier, and resolved quotas.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        UserMeResponse
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[UserMeResponse]:
+    """Get the authenticated owner
+
+     Return the authenticated owner's identity, tier, and resolved quotas.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[UserMeResponse]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+) -> UserMeResponse | None:
+    """Get the authenticated owner
+
+     Return the authenticated owner's identity, tier, and resolved quotas.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        UserMeResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/fastfuels_sdk/v2/client_library/api/users/get_me_usage.py
+++ b/fastfuels_sdk/v2/client_library/api/users/get_me_usage.py
@@ -1,0 +1,136 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.usage import Usage
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/users/me/usage",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Usage | None:
+    if response.status_code == 200:
+        response_200 = Usage.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Usage]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[Usage]:
+    """Get the authenticated owner's usage
+
+     Return current usage against the owner's resolved limits, per resource type.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Usage]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+) -> Usage | None:
+    """Get the authenticated owner's usage
+
+     Return current usage against the owner's resolved limits, per resource type.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Usage
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[Usage]:
+    """Get the authenticated owner's usage
+
+     Return current usage against the owner's resolved limits, per resource type.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Usage]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+) -> Usage | None:
+    """Get the authenticated owner's usage
+
+     Return current usage against the owner's resolved limits, per resource type.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Usage
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/fastfuels_sdk/v2/client_library/client.py
+++ b/fastfuels_sdk/v2/client_library/client.py
@@ -100,7 +100,7 @@ class Client:
         self.get_httpx_client().__enter__()
         return self
 
-    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+    def __exit__(self, *args: object, **kwargs: Any) -> None:
         """Exit a context manager for internal httpx.Client (see httpx docs)"""
         self.get_httpx_client().__exit__(*args, **kwargs)
 
@@ -131,7 +131,7 @@ class Client:
         await self.get_async_httpx_client().__aenter__()
         return self
 
-    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+    async def __aexit__(self, *args: object, **kwargs: Any) -> None:
         """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
         await self.get_async_httpx_client().__aexit__(*args, **kwargs)
 
@@ -241,7 +241,7 @@ class AuthenticatedClient:
         self.get_httpx_client().__enter__()
         return self
 
-    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+    def __exit__(self, *args: object, **kwargs: Any) -> None:
         """Exit a context manager for internal httpx.Client (see httpx docs)"""
         self.get_httpx_client().__exit__(*args, **kwargs)
 
@@ -277,6 +277,6 @@ class AuthenticatedClient:
         await self.get_async_httpx_client().__aenter__()
         return self
 
-    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+    async def __aexit__(self, *args: object, **kwargs: Any) -> None:
         """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
         await self.get_async_httpx_client().__aexit__(*args, **kwargs)

--- a/fastfuels_sdk/v2/client_library/models/__init__.py
+++ b/fastfuels_sdk/v2/client_library/models/__init__.py
@@ -7,6 +7,7 @@ from .allometry_biomass_source_component_states import (
 )
 from .allometry_max_crown_radius_source import AllometryMaxCrownRadiusSource
 from .application import Application
+from .application_quota_overrides_type_0 import ApplicationQuotaOverridesType0
 from .apply_grid_modifications_request import ApplyGridModificationsRequest
 from .apply_modifications_request import ApplyModificationsRequest
 from .apply_treatments_request import ApplyTreatmentsRequest
@@ -18,15 +19,29 @@ from .biomass_component_state import BiomassComponentState
 from .biomass_equations import BiomassEquations
 from .biomass_unit import BiomassUnit
 from .categorical_band_summary import CategoricalBandSummary
+from .categorical_column_summary import CategoricalColumnSummary
 from .chunks import Chunks
 from .chunks_count_by_axis_type_0 import ChunksCountByAxisType0
 from .column import Column
 from .column_type import ColumnType
+from .compose_attribute_condition import ComposeAttributeCondition
+from .compose_comparison_operator import ComposeComparisonOperator
+from .compose_compute import ComposeCompute
+from .compose_input import ComposeInput
+from .compose_literal import ComposeLiteral
+from .compose_operator import ComposeOperator
+from .compose_select import ComposeSelect
 from .continuous_band_summary import ContinuousBandSummary
+from .continuous_column_summary import ContinuousColumnSummary
+from .count_usage import CountUsage
 from .create_application_request import CreateApplicationRequest
 from .create_chm_inventory_request import CreateChmInventoryRequest
+from .create_compose_request import CreateComposeRequest
 from .create_domain_request_body import CreateDomainRequestBody
+from .create_duet_request import CreateDuetRequest
+from .create_fbfm_13_lookup_request import CreateFbfm13LookupRequest
 from .create_fbfm_40_lookup_request import CreateFbfm40LookupRequest
+from .create_fccs_lookup_request import CreateFccsLookupRequest
 from .create_gdam_inventory_request import CreateGdamInventoryRequest
 from .create_gdam_inventory_request_impute_columns_item import (
     CreateGdamInventoryRequestImputeColumnsItem,
@@ -36,6 +51,7 @@ from .create_inventory_upload_request import CreateInventoryUploadRequest
 from .create_key_request import CreateKeyRequest
 from .create_key_response import CreateKeyResponse
 from .create_landfire_canopy_request import CreateLandfireCanopyRequest
+from .create_landfire_fbfm_13_request import CreateLandfireFbfm13Request
 from .create_landfire_fbfm_40_request import CreateLandfireFbfm40Request
 from .create_landfire_fccs_request import CreateLandfireFccsRequest
 from .create_landfire_topography_request import CreateLandfireTopographyRequest
@@ -47,11 +63,13 @@ from .create_netcdf_upload_request import CreateNetcdfUploadRequest
 from .create_osm_road_feature_request import CreateOsmRoadFeatureRequest
 from .create_osm_water_feature_request import CreateOsmWaterFeatureRequest
 from .create_pim_inventory_request import CreatePimInventoryRequest
+from .create_point_cloud_chm_request import CreatePointCloudChmRequest
 from .create_point_cloud_upload_request import CreatePointCloudUploadRequest
 from .create_resample_request import CreateResampleRequest
 from .create_resample_request_method_overrides import (
     CreateResampleRequestMethodOverrides,
 )
+from .create_three_dep_point_cloud_request import CreateThreeDepPointCloudRequest
 from .create_three_dep_topography_request import CreateThreeDepTopographyRequest
 from .create_tree_inventory_request import CreateTreeInventoryRequest
 from .create_tree_map_request import CreateTreeMapRequest
@@ -64,6 +82,12 @@ from .domain_lattice import DomainLattice
 from .domain_sort_field import DomainSortField
 from .domain_sort_order import DomainSortOrder
 from .domain_style import DomainStyle
+from .duet_band import DuetBand
+from .duet_calibration import DuetCalibration
+from .duet_constant_calibration_target import DuetConstantCalibrationTarget
+from .duet_max_min_calibration_target import DuetMaxMinCalibrationTarget
+from .duet_mean_sd_calibration_target import DuetMeanSdCalibrationTarget
+from .duet_parameter_calibration import DuetParameterCalibration
 from .duplicate_grid_request import DuplicateGridRequest
 from .duplicate_inventory_request import DuplicateInventoryRequest
 from .export import Export
@@ -71,7 +95,9 @@ from .export_grid_request import ExportGridRequest
 from .export_inventory_request import ExportInventoryRequest
 from .export_sort_field import ExportSortField
 from .export_source import ExportSource
+from .fbfm_13_lookup_band import Fbfm13LookupBand
 from .fbfm_40_lookup_band import Fbfm40LookupBand
+from .fccs_lookup_band import FccsLookupBand
 from .feature import Feature
 from .feature_data_metadata import FeatureDataMetadata
 from .feature_georeference import FeatureGeoreference
@@ -79,6 +105,7 @@ from .feature_partition_info import FeaturePartitionInfo
 from .feature_sort_field import FeatureSortField
 from .feature_source import FeatureSource
 from .feature_type import FeatureType
+from .fia_species_group_share import FIASpeciesGroupShare
 from .field_source import FieldSource
 from .fine_biomass_config import FineBiomassConfig
 from .geo_json_crs import GeoJsonCRS
@@ -116,6 +143,7 @@ from .grid_upload_created_response import GridUploadCreatedResponse
 from .grid_upload_spec import GridUploadSpec
 from .grid_upload_spec_headers import GridUploadSpecHeaders
 from .http_validation_error import HTTPValidationError
+from .inline_compute import InlineCompute
 from .inventory import Inventory
 from .inventory_attribute import InventoryAttribute
 from .inventory_basal_area_treatment import InventoryBasalAreaTreatment
@@ -131,7 +159,6 @@ from .inventory_columns_biomass_source_columns import (
 from .inventory_columns_biomass_source_component_states import (
     InventoryColumnsBiomassSourceComponentStates,
 )
-from .inventory_data_format import InventoryDataFormat
 from .inventory_data_metadata import InventoryDataMetadata
 from .inventory_data_response import InventoryDataResponse
 from .inventory_data_response_data_type_1_item import InventoryDataResponseDataType1Item
@@ -163,13 +190,24 @@ from .inventory_upload_spec import InventoryUploadSpec
 from .inventory_upload_spec_headers import InventoryUploadSpecHeaders
 from .job_error import JobError
 from .job_progress import JobProgress
+from .job_resource_usage import JobResourceUsage
 from .job_status import JobStatus
 from .key import Key
 from .landfire_canopy_fuel_band import LandfireCanopyFuelBand
 from .landfire_canopy_version import LandfireCanopyVersion
+from .landfire_fbfm_13_version import LandfireFbfm13Version
 from .landfire_fbfm_40_version import LandfireFbfm40Version
 from .landfire_fccs_version import LandfireFccsVersion
 from .landfire_topography_version import LandfireTopographyVersion
+from .landscape_export_alignment_domain_target import (
+    LandscapeExportAlignmentDomainTarget,
+)
+from .landscape_export_alignment_grid_target import LandscapeExportAlignmentGridTarget
+from .landscape_export_request import LandscapeExportRequest
+from .landscape_export_request_fire_behavior_fuel_model import (
+    LandscapeExportRequestFireBehaviorFuelModel,
+)
+from .landscape_field_source import LandscapeFieldSource
 from .layerset_crs import LayersetCrs
 from .layerset_crs_properties import LayersetCrsProperties
 from .layerset_feature import LayersetFeature
@@ -199,6 +237,7 @@ from .point_cloud_georeference import PointCloudGeoreference
 from .point_cloud_sort_field import PointCloudSortField
 from .point_cloud_source import PointCloudSource
 from .point_cloud_summary import PointCloudSummary
+from .point_cloud_three_dep_coverage_response import PointCloudThreeDepCoverageResponse
 from .point_cloud_type import PointCloudType
 from .point_cloud_upload_created_response import PointCloudUploadCreatedResponse
 from .point_cloud_upload_spec import PointCloudUploadSpec
@@ -211,6 +250,8 @@ from .quic_fire_export_alignment_domain_target import (
 from .quic_fire_export_alignment_grid_target import QUICFireExportAlignmentGridTarget
 from .quicfire_export_request import QuicfireExportRequest
 from .quicfire_export_request_moist_merge import QuicfireExportRequestMoistMerge
+from .quota_exceeded_detail import QuotaExceededDetail
+from .quotas import Quotas
 from .remove_action import RemoveAction
 from .resampling_method import ResamplingMethod
 from .resolution_3d import Resolution3D
@@ -221,9 +262,11 @@ from .spatial_operator import SpatialOperator
 from .stem_isolation_lmf import StemIsolationLmf
 from .stem_isolation_vwf import StemIsolationVwf
 from .three_dep_coverage_response import ThreeDepCoverageResponse
+from .three_dep_dataset_coverage import ThreeDepDatasetCoverage
 from .three_dep_resolution import ThreeDepResolution
 from .topography_band import TopographyBand
 from .tree_band import TreeBand
+from .tree_forestry_metrics import TreeForestryMetrics
 from .tree_map_band import TreeMapBand
 from .tree_map_version import TreeMapVersion
 from .uniform_band import UniformBand
@@ -237,6 +280,12 @@ from .update_grid_request_body import UpdateGridRequestBody
 from .update_inventory_request_body import UpdateInventoryRequestBody
 from .update_point_cloud_request_body import UpdatePointCloudRequestBody
 from .upload_band_definition import UploadBandDefinition
+from .usage import Usage
+from .usage_count import UsageCount
+from .usage_lifecycle import UsageLifecycle
+from .usage_storage import UsageStorage
+from .user_me_response import UserMeResponse
+from .user_me_response_kind import UserMeResponseKind
 from .validation_error import ValidationError
 
 __all__ = (
@@ -245,6 +294,7 @@ __all__ = (
     "AllometryBiomassSourceComponentStates",
     "AllometryMaxCrownRadiusSource",
     "Application",
+    "ApplicationQuotaOverridesType0",
     "ApplyGridModificationsRequest",
     "ApplyModificationsRequest",
     "ApplyTreatmentsRequest",
@@ -256,15 +306,29 @@ __all__ = (
     "BiomassEquations",
     "BiomassUnit",
     "CategoricalBandSummary",
+    "CategoricalColumnSummary",
     "Chunks",
     "ChunksCountByAxisType0",
     "Column",
     "ColumnType",
+    "ComposeAttributeCondition",
+    "ComposeComparisonOperator",
+    "ComposeCompute",
+    "ComposeInput",
+    "ComposeLiteral",
+    "ComposeOperator",
+    "ComposeSelect",
     "ContinuousBandSummary",
+    "ContinuousColumnSummary",
+    "CountUsage",
     "CreateApplicationRequest",
     "CreateChmInventoryRequest",
+    "CreateComposeRequest",
     "CreateDomainRequestBody",
+    "CreateDuetRequest",
+    "CreateFbfm13LookupRequest",
     "CreateFbfm40LookupRequest",
+    "CreateFccsLookupRequest",
     "CreateGdamInventoryRequest",
     "CreateGdamInventoryRequestImputeColumnsItem",
     "CreateGeoTIFFUploadRequest",
@@ -272,6 +336,7 @@ __all__ = (
     "CreateKeyRequest",
     "CreateKeyResponse",
     "CreateLandfireCanopyRequest",
+    "CreateLandfireFbfm13Request",
     "CreateLandfireFbfm40Request",
     "CreateLandfireFccsRequest",
     "CreateLandfireTopographyRequest",
@@ -283,9 +348,11 @@ __all__ = (
     "CreateOsmRoadFeatureRequest",
     "CreateOsmWaterFeatureRequest",
     "CreatePimInventoryRequest",
+    "CreatePointCloudChmRequest",
     "CreatePointCloudUploadRequest",
     "CreateResampleRequest",
     "CreateResampleRequestMethodOverrides",
+    "CreateThreeDepPointCloudRequest",
     "CreateThreeDepTopographyRequest",
     "CreateTreeInventoryRequest",
     "CreateTreeMapRequest",
@@ -298,6 +365,12 @@ __all__ = (
     "DomainSortField",
     "DomainSortOrder",
     "DomainStyle",
+    "DuetBand",
+    "DuetCalibration",
+    "DuetConstantCalibrationTarget",
+    "DuetMaxMinCalibrationTarget",
+    "DuetMeanSdCalibrationTarget",
+    "DuetParameterCalibration",
     "DuplicateGridRequest",
     "DuplicateInventoryRequest",
     "Export",
@@ -305,7 +378,10 @@ __all__ = (
     "ExportInventoryRequest",
     "ExportSortField",
     "ExportSource",
+    "FIASpeciesGroupShare",
+    "Fbfm13LookupBand",
     "Fbfm40LookupBand",
+    "FccsLookupBand",
     "Feature",
     "FeatureDataMetadata",
     "FeatureGeoreference",
@@ -346,6 +422,7 @@ __all__ = (
     "GridUploadSpec",
     "GridUploadSpecHeaders",
     "HTTPValidationError",
+    "InlineCompute",
     "Inventory",
     "InventoryAttribute",
     "InventoryBasalAreaTreatment",
@@ -355,7 +432,6 @@ __all__ = (
     "InventoryColumnsBiomassSource",
     "InventoryColumnsBiomassSourceColumns",
     "InventoryColumnsBiomassSourceComponentStates",
-    "InventoryDataFormat",
     "InventoryDataMetadata",
     "InventoryDataResponse",
     "InventoryDataResponseDataType1Item",
@@ -383,13 +459,20 @@ __all__ = (
     "InventoryUploadSpecHeaders",
     "JobError",
     "JobProgress",
+    "JobResourceUsage",
     "JobStatus",
     "Key",
     "LandfireCanopyFuelBand",
     "LandfireCanopyVersion",
+    "LandfireFbfm13Version",
     "LandfireFbfm40Version",
     "LandfireFccsVersion",
     "LandfireTopographyVersion",
+    "LandscapeExportAlignmentDomainTarget",
+    "LandscapeExportAlignmentGridTarget",
+    "LandscapeExportRequest",
+    "LandscapeExportRequestFireBehaviorFuelModel",
+    "LandscapeFieldSource",
     "LayersetCrs",
     "LayersetCrsProperties",
     "LayersetFeature",
@@ -419,6 +502,7 @@ __all__ = (
     "PointCloudSortField",
     "PointCloudSource",
     "PointCloudSummary",
+    "PointCloudThreeDepCoverageResponse",
     "PointCloudType",
     "PointCloudUploadCreatedResponse",
     "PointCloudUploadSpec",
@@ -429,6 +513,8 @@ __all__ = (
     "QUICFireExportAlignmentGridTarget",
     "QuicfireExportRequest",
     "QuicfireExportRequestMoistMerge",
+    "QuotaExceededDetail",
+    "Quotas",
     "RemoveAction",
     "ResamplingMethod",
     "Resolution3D",
@@ -439,9 +525,11 @@ __all__ = (
     "StemIsolationLmf",
     "StemIsolationVwf",
     "ThreeDepCoverageResponse",
+    "ThreeDepDatasetCoverage",
     "ThreeDepResolution",
     "TopographyBand",
     "TreeBand",
+    "TreeForestryMetrics",
     "TreeMapBand",
     "TreeMapVersion",
     "UniformBand",
@@ -455,5 +543,11 @@ __all__ = (
     "UpdateInventoryRequestBody",
     "UpdatePointCloudRequestBody",
     "UploadBandDefinition",
+    "Usage",
+    "UsageCount",
+    "UsageLifecycle",
+    "UsageStorage",
+    "UserMeResponse",
+    "UserMeResponseKind",
     "ValidationError",
 )

--- a/fastfuels_sdk/v2/client_library/models/__init__.py
+++ b/fastfuels_sdk/v2/client_library/models/__init__.py
@@ -37,7 +37,6 @@ from .count_usage import CountUsage
 from .create_application_request import CreateApplicationRequest
 from .create_chm_inventory_request import CreateChmInventoryRequest
 from .create_compose_request import CreateComposeRequest
-from .create_domain_request_body import CreateDomainRequestBody
 from .create_duet_request import CreateDuetRequest
 from .create_fbfm_13_lookup_request import CreateFbfm13LookupRequest
 from .create_fbfm_40_lookup_request import CreateFbfm40LookupRequest
@@ -111,6 +110,7 @@ from .fine_biomass_config import FineBiomassConfig
 from .geo_json_crs import GeoJsonCRS
 from .geo_json_crs_properties import GeoJsonCRSProperties
 from .geo_json_feature import GeoJsonFeature
+from .geo_json_feature_collection import GeoJsonFeatureCollection
 from .geo_json_feature_properties_type_0 import GeoJsonFeaturePropertiesType0
 from .geometry_collection import GeometryCollection
 from .georeference import Georeference
@@ -261,10 +261,10 @@ from .sparse_grid_data import SparseGridData
 from .spatial_operator import SpatialOperator
 from .stem_isolation_lmf import StemIsolationLmf
 from .stem_isolation_vwf import StemIsolationVwf
-from .three_dep_coverage_response import ThreeDepCoverageResponse
 from .three_dep_dataset_coverage import ThreeDepDatasetCoverage
 from .three_dep_resolution import ThreeDepResolution
 from .topography_band import TopographyBand
+from .topography_three_dep_coverage_response import TopographyThreeDepCoverageResponse
 from .tree_band import TreeBand
 from .tree_forestry_metrics import TreeForestryMetrics
 from .tree_map_band import TreeMapBand
@@ -324,7 +324,6 @@ __all__ = (
     "CreateApplicationRequest",
     "CreateChmInventoryRequest",
     "CreateComposeRequest",
-    "CreateDomainRequestBody",
     "CreateDuetRequest",
     "CreateFbfm13LookupRequest",
     "CreateFbfm40LookupRequest",
@@ -394,6 +393,7 @@ __all__ = (
     "GeoJsonCRS",
     "GeoJsonCRSProperties",
     "GeoJsonFeature",
+    "GeoJsonFeatureCollection",
     "GeoJsonFeaturePropertiesType0",
     "GeometryCollection",
     "Georeference",
@@ -524,10 +524,10 @@ __all__ = (
     "SpatialOperator",
     "StemIsolationLmf",
     "StemIsolationVwf",
-    "ThreeDepCoverageResponse",
     "ThreeDepDatasetCoverage",
     "ThreeDepResolution",
     "TopographyBand",
+    "TopographyThreeDepCoverageResponse",
     "TreeBand",
     "TreeForestryMetrics",
     "TreeMapBand",

--- a/fastfuels_sdk/v2/client_library/models/allometry_biomass_source.py
+++ b/fastfuels_sdk/v2/client_library/models/allometry_biomass_source.py
@@ -5,6 +5,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -89,7 +90,7 @@ class AllometryBiomassSource:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.allometry_biomass_source_component_states import (
             AllometryBiomassSourceComponentStates,
         )

--- a/fastfuels_sdk/v2/client_library/models/allometry_biomass_source_component_states.py
+++ b/fastfuels_sdk/v2/client_library/models/allometry_biomass_source_component_states.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -30,7 +30,7 @@ class AllometryBiomassSourceComponentStates:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.biomass_component_state import BiomassComponentState
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/allometry_max_crown_radius_source.py
+++ b/fastfuels_sdk/v2/client_library/models/allometry_max_crown_radius_source.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -37,7 +38,7 @@ class AllometryMaxCrownRadiusSource:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         type_ = cast(Literal["allometry"] | Unset, d.pop("type", UNSET))
         if type_ != "allometry" and not isinstance(type_, Unset):

--- a/fastfuels_sdk/v2/client_library/models/application.py
+++ b/fastfuels_sdk/v2/client_library/models/application.py
@@ -2,12 +2,18 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.application_quota_overrides_type_0 import (
+        ApplicationQuotaOverridesType0,
+    )
+
 
 T = TypeVar("T", bound="Application")
 
@@ -23,6 +29,9 @@ class Application:
         description (None | str | Unset): Description of the application.
         created_on (datetime.datetime | Unset): When the application was created.
         modified_on (datetime.datetime | Unset): When the application was last modified.
+        tier (None | str | Unset): Quota tier for the application. Set by the FastFuels team.
+        quota_overrides (ApplicationQuotaOverridesType0 | None | Unset): Per-application quota overrides. Set by the
+            FastFuels team.
     """
 
     id: str
@@ -31,9 +40,15 @@ class Application:
     description: None | str | Unset = UNSET
     created_on: datetime.datetime | Unset = UNSET
     modified_on: datetime.datetime | Unset = UNSET
+    tier: None | str | Unset = UNSET
+    quota_overrides: ApplicationQuotaOverridesType0 | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.application_quota_overrides_type_0 import (
+            ApplicationQuotaOverridesType0,
+        )
+
         id = self.id
 
         owner_id = self.owner_id
@@ -54,6 +69,20 @@ class Application:
         if not isinstance(self.modified_on, Unset):
             modified_on = self.modified_on.isoformat()
 
+        tier: None | str | Unset
+        if isinstance(self.tier, Unset):
+            tier = UNSET
+        else:
+            tier = self.tier
+
+        quota_overrides: dict[str, Any] | None | Unset
+        if isinstance(self.quota_overrides, Unset):
+            quota_overrides = UNSET
+        elif isinstance(self.quota_overrides, ApplicationQuotaOverridesType0):
+            quota_overrides = self.quota_overrides.to_dict()
+        else:
+            quota_overrides = self.quota_overrides
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -69,11 +98,19 @@ class Application:
             field_dict["created_on"] = created_on
         if modified_on is not UNSET:
             field_dict["modified_on"] = modified_on
+        if tier is not UNSET:
+            field_dict["tier"] = tier
+        if quota_overrides is not UNSET:
+            field_dict["quota_overrides"] = quota_overrides
 
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        from ..models.application_quota_overrides_type_0 import (
+            ApplicationQuotaOverridesType0,
+        )
+
         d = dict(src_dict)
         id = d.pop("id")
 
@@ -104,6 +141,34 @@ class Application:
         else:
             modified_on = datetime.datetime.fromisoformat(_modified_on)
 
+        def _parse_tier(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        tier = _parse_tier(d.pop("tier", UNSET))
+
+        def _parse_quota_overrides(
+            data: object,
+        ) -> ApplicationQuotaOverridesType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                quota_overrides_type_0 = ApplicationQuotaOverridesType0.from_dict(data)
+
+                return quota_overrides_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(ApplicationQuotaOverridesType0 | None | Unset, data)
+
+        quota_overrides = _parse_quota_overrides(d.pop("quota_overrides", UNSET))
+
         application = cls(
             id=id,
             owner_id=owner_id,
@@ -111,6 +176,8 @@ class Application:
             description=description,
             created_on=created_on,
             modified_on=modified_on,
+            tier=tier,
+            quota_overrides=quota_overrides,
         )
 
         application.additional_properties = d

--- a/fastfuels_sdk/v2/client_library/models/application_quota_overrides_type_0.py
+++ b/fastfuels_sdk/v2/client_library/models/application_quota_overrides_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Self, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ApplicationQuotaOverridesType0")
+
+
+@_attrs_define
+class ApplicationQuotaOverridesType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        d = dict(src_dict)
+        application_quota_overrides_type_0 = cls()
+
+        application_quota_overrides_type_0.additional_properties = d
+        return application_quota_overrides_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/apply_grid_modifications_request.py
+++ b/fastfuels_sdk/v2/client_library/models/apply_grid_modifications_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -44,7 +44,7 @@ class ApplyGridModificationsRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.grid_modification import GridModification
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/apply_modifications_request.py
+++ b/fastfuels_sdk/v2/client_library/models/apply_modifications_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -44,7 +44,7 @@ class ApplyModificationsRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.inventory_modification import InventoryModification
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/apply_treatments_request.py
+++ b/fastfuels_sdk/v2/client_library/models/apply_treatments_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -53,7 +53,7 @@ class ApplyTreatmentsRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.inventory_basal_area_treatment import InventoryBasalAreaTreatment
         from ..models.inventory_diameter_treatment import InventoryDiameterTreatment
 

--- a/fastfuels_sdk/v2/client_library/models/band.py
+++ b/fastfuels_sdk/v2/client_library/models/band.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -83,9 +83,9 @@ class Band:
         summary: dict[str, Any] | None | Unset
         if isinstance(self.summary, Unset):
             summary = UNSET
-        elif isinstance(self.summary, ContinuousBandSummary):
-            summary = self.summary.to_dict()
-        elif isinstance(self.summary, CategoricalBandSummary):
+        elif isinstance(self.summary, ContinuousBandSummary) or isinstance(
+            self.summary, CategoricalBandSummary
+        ):
             summary = self.summary.to_dict()
         else:
             summary = self.summary
@@ -113,7 +113,7 @@ class Band:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.categorical_band_summary import CategoricalBandSummary
         from ..models.continuous_band_summary import ContinuousBandSummary
 

--- a/fastfuels_sdk/v2/client_library/models/base_model.py
+++ b/fastfuels_sdk/v2/client_library/models/base_model.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -23,7 +23,7 @@ class BaseModel:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         base_model = cls()
 

--- a/fastfuels_sdk/v2/client_library/models/biomass_component_state.py
+++ b/fastfuels_sdk/v2/client_library/models/biomass_component_state.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 
@@ -38,7 +38,7 @@ class BiomassComponentState:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         live = d.pop("live", UNSET)
 

--- a/fastfuels_sdk/v2/client_library/models/categorical_band_summary.py
+++ b/fastfuels_sdk/v2/client_library/models/categorical_band_summary.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -53,7 +54,7 @@ class CategoricalBandSummary:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         type_ = cast(Literal["categorical"], d.pop("type"))
         if type_ != "categorical":

--- a/fastfuels_sdk/v2/client_library/models/categorical_column_summary.py
+++ b/fastfuels_sdk/v2/client_library/models/categorical_column_summary.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    Self,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="CategoricalColumnSummary")
+
+
+@_attrs_define
+class CategoricalColumnSummary:
+    """
+    Attributes:
+        type_ (Literal['categorical']):
+        count (int):
+        null_count (int):
+        unique_count (int):
+    """
+
+    type_: Literal["categorical"]
+    count: int
+    null_count: int
+    unique_count: int
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
+        count = self.count
+
+        null_count = self.null_count
+
+        unique_count = self.unique_count
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "type": type_,
+                "count": count,
+                "null_count": null_count,
+                "unique_count": unique_count,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        d = dict(src_dict)
+        type_ = cast(Literal["categorical"], d.pop("type"))
+        if type_ != "categorical":
+            raise ValueError(f"type must match const 'categorical', got '{type_}'")
+
+        count = d.pop("count")
+
+        null_count = d.pop("null_count")
+
+        unique_count = d.pop("unique_count")
+
+        categorical_column_summary = cls(
+            type_=type_,
+            count=count,
+            null_count=null_count,
+            unique_count=unique_count,
+        )
+
+        categorical_column_summary.additional_properties = d
+        return categorical_column_summary
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/chunks.py
+++ b/fastfuels_sdk/v2/client_library/models/chunks.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -71,7 +71,7 @@ class Chunks:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.chunks_count_by_axis_type_0 import ChunksCountByAxisType0
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/chunks_count_by_axis_type_0.py
+++ b/fastfuels_sdk/v2/client_library/models/chunks_count_by_axis_type_0.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -23,7 +23,7 @@ class ChunksCountByAxisType0:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         chunks_count_by_axis_type_0 = cls()
 

--- a/fastfuels_sdk/v2/client_library/models/column.py
+++ b/fastfuels_sdk/v2/client_library/models/column.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..models.column_type import ColumnType
 from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.categorical_column_summary import CategoricalColumnSummary
+    from ..models.continuous_column_summary import ContinuousColumnSummary
+
 
 T = TypeVar("T", bound="Column")
 
@@ -20,14 +25,19 @@ class Column:
         key (str): Column name (e.g., 'dbh', 'fia_species_code')
         type_ (ColumnType): Type of column data.
         unit (None | str | Unset):
+        summary (CategoricalColumnSummary | ContinuousColumnSummary | None | Unset):
     """
 
     key: str
     type_: ColumnType
     unit: None | str | Unset = UNSET
+    summary: CategoricalColumnSummary | ContinuousColumnSummary | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.categorical_column_summary import CategoricalColumnSummary
+        from ..models.continuous_column_summary import ContinuousColumnSummary
+
         key = self.key
 
         type_ = self.type_.value
@@ -37,6 +47,16 @@ class Column:
             unit = UNSET
         else:
             unit = self.unit
+
+        summary: dict[str, Any] | None | Unset
+        if isinstance(self.summary, Unset):
+            summary = UNSET
+        elif isinstance(self.summary, ContinuousColumnSummary) or isinstance(
+            self.summary, CategoricalColumnSummary
+        ):
+            summary = self.summary.to_dict()
+        else:
+            summary = self.summary
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -48,11 +68,16 @@ class Column:
         )
         if unit is not UNSET:
             field_dict["unit"] = unit
+        if summary is not UNSET:
+            field_dict["summary"] = summary
 
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        from ..models.categorical_column_summary import CategoricalColumnSummary
+        from ..models.continuous_column_summary import ContinuousColumnSummary
+
         d = dict(src_dict)
         key = d.pop("key")
 
@@ -67,10 +92,40 @@ class Column:
 
         unit = _parse_unit(d.pop("unit", UNSET))
 
+        def _parse_summary(
+            data: object,
+        ) -> CategoricalColumnSummary | ContinuousColumnSummary | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                summary_type_0_type_0 = ContinuousColumnSummary.from_dict(data)
+
+                return summary_type_0_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                summary_type_0_type_1 = CategoricalColumnSummary.from_dict(data)
+
+                return summary_type_0_type_1
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(
+                CategoricalColumnSummary | ContinuousColumnSummary | None | Unset, data
+            )
+
+        summary = _parse_summary(d.pop("summary", UNSET))
+
         column = cls(
             key=key,
             type_=type_,
             unit=unit,
+            summary=summary,
         )
 
         column.additional_properties = d

--- a/fastfuels_sdk/v2/client_library/models/compose_attribute_condition.py
+++ b/fastfuels_sdk/v2/client_library/models/compose_attribute_condition.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Self, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.compose_comparison_operator import ComposeComparisonOperator
+
+T = TypeVar("T", bound="ComposeAttributeCondition")
+
+
+@_attrs_define
+class ComposeAttributeCondition:
+    """Attribute condition using an alias-qualified input band reference.
+
+    Attributes:
+        band (str): Alias-qualified band ref, e.g. `a.fbfm`.
+        operator (ComposeComparisonOperator): Comparison operators for compose attribute conditions.
+        value (float | int | list[float | int | str] | str):
+    """
+
+    band: str
+    operator: ComposeComparisonOperator
+    value: float | int | list[float | int | str] | str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        band = self.band
+
+        operator = self.operator.value
+
+        value: float | int | list[float | int | str] | str
+        if isinstance(self.value, list):
+            value = []
+            for value_type_3_item_data in self.value:
+                value_type_3_item: float | int | str
+                value_type_3_item = value_type_3_item_data
+                value.append(value_type_3_item)
+
+        else:
+            value = self.value
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "band": band,
+                "operator": operator,
+                "value": value,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        d = dict(src_dict)
+        band = d.pop("band")
+
+        operator = ComposeComparisonOperator(d.pop("operator"))
+
+        def _parse_value(data: object) -> float | int | list[float | int | str] | str:
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                value_type_3 = []
+                _value_type_3 = data
+                for value_type_3_item_data in _value_type_3:
+
+                    def _parse_value_type_3_item(data: object) -> float | int | str:
+                        return cast(float | int | str, data)
+
+                    value_type_3_item = _parse_value_type_3_item(value_type_3_item_data)
+
+                    value_type_3.append(value_type_3_item)
+
+                return value_type_3
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(float | int | list[float | int | str] | str, data)
+
+        value = _parse_value(d.pop("value"))
+
+        compose_attribute_condition = cls(
+            band=band,
+            operator=operator,
+            value=value,
+        )
+
+        compose_attribute_condition.additional_properties = d
+        return compose_attribute_condition
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/compose_comparison_operator.py
+++ b/fastfuels_sdk/v2/client_library/models/compose_comparison_operator.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+
+class ComposeComparisonOperator(str, Enum):
+    EQ = "eq"
+    GE = "ge"
+    GT = "gt"
+    IN = "in"
+    LE = "le"
+    LT = "lt"
+    NE = "ne"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/fastfuels_sdk/v2/client_library/models/compose_compute.py
+++ b/fastfuels_sdk/v2/client_library/models/compose_compute.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.compose_operator import ComposeOperator
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.compose_attribute_condition import ComposeAttributeCondition
+    from ..models.compose_literal import ComposeLiteral
+    from ..models.grid_feature_spatial_condition import GridFeatureSpatialCondition
+    from ..models.grid_geometry_spatial_condition import GridGeometrySpatialCondition
+    from ..models.inline_compute import InlineCompute
+
+
+T = TypeVar("T", bound="ComposeCompute")
+
+
+@_attrs_define
+class ComposeCompute:
+    """Compute an output band from one or more operands.
+
+    The output band is always continuous and its unit is derived from the
+    operands (the product/quotient for `multiply`/`divide`, the operand unit
+    otherwise). Supply `unit` only to express the result in a different but
+    dimensionally compatible unit; the worker converts to it.
+
+        Attributes:
+            operator (ComposeOperator): Operators available for compose computations.
+            operands (list[ComposeLiteral | float | int | str]):
+            output (str): Output band key, e.g. `fuel_load.1hr`.
+            name (None | str | Unset): Optional display name for the output band.
+            description (None | str | Unset): Optional description for the output band.
+            unit (None | str | Unset): Optional canonical output unit. Defaults to the unit derived from the operands; if
+                given it must be dimensionally compatible.
+            conditions (list[ComposeAttributeCondition | GridFeatureSpatialCondition | GridGeometrySpatialCondition] | None
+                | Unset):
+            else_ (ComposeLiteral | float | InlineCompute | int | None | str | Unset):
+    """
+
+    operator: ComposeOperator
+    operands: list[ComposeLiteral | float | int | str]
+    output: str
+    name: None | str | Unset = UNSET
+    description: None | str | Unset = UNSET
+    unit: None | str | Unset = UNSET
+    conditions: (
+        list[
+            ComposeAttributeCondition
+            | GridFeatureSpatialCondition
+            | GridGeometrySpatialCondition
+        ]
+        | None
+        | Unset
+    ) = UNSET
+    else_: ComposeLiteral | float | InlineCompute | int | None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.compose_attribute_condition import ComposeAttributeCondition
+        from ..models.compose_literal import ComposeLiteral
+        from ..models.grid_geometry_spatial_condition import (
+            GridGeometrySpatialCondition,
+        )
+        from ..models.inline_compute import InlineCompute
+
+        operator = self.operator.value
+
+        operands = []
+        for operands_item_data in self.operands:
+            operands_item: dict[str, Any] | float | int | str
+            if isinstance(operands_item_data, ComposeLiteral):
+                operands_item = operands_item_data.to_dict()
+            else:
+                operands_item = operands_item_data
+            operands.append(operands_item)
+
+        output = self.output
+
+        name: None | str | Unset
+        if isinstance(self.name, Unset):
+            name = UNSET
+        else:
+            name = self.name
+
+        description: None | str | Unset
+        if isinstance(self.description, Unset):
+            description = UNSET
+        else:
+            description = self.description
+
+        unit: None | str | Unset
+        if isinstance(self.unit, Unset):
+            unit = UNSET
+        else:
+            unit = self.unit
+
+        conditions: list[dict[str, Any]] | None | Unset
+        if isinstance(self.conditions, Unset):
+            conditions = UNSET
+        elif isinstance(self.conditions, list):
+            conditions = []
+            for conditions_type_0_item_data in self.conditions:
+                conditions_type_0_item: dict[str, Any]
+                if isinstance(
+                    conditions_type_0_item_data, ComposeAttributeCondition
+                ) or isinstance(
+                    conditions_type_0_item_data, GridGeometrySpatialCondition
+                ):
+                    conditions_type_0_item = conditions_type_0_item_data.to_dict()
+                else:
+                    conditions_type_0_item = conditions_type_0_item_data.to_dict()
+
+                conditions.append(conditions_type_0_item)
+
+        else:
+            conditions = self.conditions
+
+        else_: dict[str, Any] | float | int | None | str | Unset
+        if isinstance(self.else_, Unset):
+            else_ = UNSET
+        elif isinstance(self.else_, ComposeLiteral) or isinstance(
+            self.else_, InlineCompute
+        ):
+            else_ = self.else_.to_dict()
+        else:
+            else_ = self.else_
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "operator": operator,
+                "operands": operands,
+                "output": output,
+            }
+        )
+        if name is not UNSET:
+            field_dict["name"] = name
+        if description is not UNSET:
+            field_dict["description"] = description
+        if unit is not UNSET:
+            field_dict["unit"] = unit
+        if conditions is not UNSET:
+            field_dict["conditions"] = conditions
+        if else_ is not UNSET:
+            field_dict["else"] = else_
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        from ..models.compose_attribute_condition import ComposeAttributeCondition
+        from ..models.compose_literal import ComposeLiteral
+        from ..models.grid_feature_spatial_condition import GridFeatureSpatialCondition
+        from ..models.grid_geometry_spatial_condition import (
+            GridGeometrySpatialCondition,
+        )
+        from ..models.inline_compute import InlineCompute
+
+        d = dict(src_dict)
+        operator = ComposeOperator(d.pop("operator"))
+
+        operands = []
+        _operands = d.pop("operands")
+        for operands_item_data in _operands:
+
+            def _parse_operands_item(
+                data: object,
+            ) -> ComposeLiteral | float | int | str:
+                try:
+                    if not isinstance(data, dict):
+                        raise TypeError()
+                    operands_item_type_3 = ComposeLiteral.from_dict(data)
+
+                    return operands_item_type_3
+                except (TypeError, ValueError, AttributeError, KeyError):
+                    pass
+                return cast(ComposeLiteral | float | int | str, data)
+
+            operands_item = _parse_operands_item(operands_item_data)
+
+            operands.append(operands_item)
+
+        output = d.pop("output")
+
+        def _parse_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        name = _parse_name(d.pop("name", UNSET))
+
+        def _parse_description(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        description = _parse_description(d.pop("description", UNSET))
+
+        def _parse_unit(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        unit = _parse_unit(d.pop("unit", UNSET))
+
+        def _parse_conditions(
+            data: object,
+        ) -> (
+            list[
+                ComposeAttributeCondition
+                | GridFeatureSpatialCondition
+                | GridGeometrySpatialCondition
+            ]
+            | None
+            | Unset
+        ):
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                conditions_type_0 = []
+                _conditions_type_0 = data
+                for conditions_type_0_item_data in _conditions_type_0:
+
+                    def _parse_conditions_type_0_item(
+                        data: object,
+                    ) -> (
+                        ComposeAttributeCondition
+                        | GridFeatureSpatialCondition
+                        | GridGeometrySpatialCondition
+                    ):
+                        try:
+                            if not isinstance(data, dict):
+                                raise TypeError()
+                            conditions_type_0_item_type_0 = (
+                                ComposeAttributeCondition.from_dict(data)
+                            )
+
+                            return conditions_type_0_item_type_0
+                        except (TypeError, ValueError, AttributeError, KeyError):
+                            pass
+                        try:
+                            if not isinstance(data, dict):
+                                raise TypeError()
+                            conditions_type_0_item_type_1 = (
+                                GridGeometrySpatialCondition.from_dict(data)
+                            )
+
+                            return conditions_type_0_item_type_1
+                        except (TypeError, ValueError, AttributeError, KeyError):
+                            pass
+                        if not isinstance(data, dict):
+                            raise TypeError()
+                        conditions_type_0_item_type_2 = (
+                            GridFeatureSpatialCondition.from_dict(data)
+                        )
+
+                        return conditions_type_0_item_type_2
+
+                    conditions_type_0_item = _parse_conditions_type_0_item(
+                        conditions_type_0_item_data
+                    )
+
+                    conditions_type_0.append(conditions_type_0_item)
+
+                return conditions_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(
+                list[
+                    ComposeAttributeCondition
+                    | GridFeatureSpatialCondition
+                    | GridGeometrySpatialCondition
+                ]
+                | None
+                | Unset,
+                data,
+            )
+
+        conditions = _parse_conditions(d.pop("conditions", UNSET))
+
+        def _parse_else_(
+            data: object,
+        ) -> ComposeLiteral | float | InlineCompute | int | None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                else_type_3 = ComposeLiteral.from_dict(data)
+
+                return else_type_3
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                else_type_4 = InlineCompute.from_dict(data)
+
+                return else_type_4
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(
+                ComposeLiteral | float | InlineCompute | int | None | str | Unset, data
+            )
+
+        else_ = _parse_else_(d.pop("else", UNSET))
+
+        compose_compute = cls(
+            operator=operator,
+            operands=operands,
+            output=output,
+            name=name,
+            description=description,
+            unit=unit,
+            conditions=conditions,
+            else_=else_,
+        )
+
+        compose_compute.additional_properties = d
+        return compose_compute
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/compose_input.py
+++ b/fastfuels_sdk/v2/client_library/models/compose_input.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Self, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ComposeInput")
+
+
+@_attrs_define
+class ComposeInput:
+    """A source grid participating in a compose request.
+
+    Attributes:
+        grid_id (str):
+        alias (str): Short alias used to reference bands, e.g. `a.fuel_load.1hr`.
+    """
+
+    grid_id: str
+    alias: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        grid_id = self.grid_id
+
+        alias = self.alias
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "grid_id": grid_id,
+                "alias": alias,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        d = dict(src_dict)
+        grid_id = d.pop("grid_id")
+
+        alias = d.pop("alias")
+
+        compose_input = cls(
+            grid_id=grid_id,
+            alias=alias,
+        )
+
+        compose_input.additional_properties = d
+        return compose_input
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/compose_literal.py
+++ b/fastfuels_sdk/v2/client_library/models/compose_literal.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    Self,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ComposeLiteral")
+
+
+@_attrs_define
+class ComposeLiteral:
+    """Typed literal value for compose operands and fallback values.
+
+    Attributes:
+        value (float | int | str):
+        type_ (Literal['literal'] | Unset):  Default: 'literal'.
+        unit (None | str | Unset): Canonical unit for numeric values. Must be null for string literals.
+    """
+
+    value: float | int | str
+    type_: Literal["literal"] | Unset = "literal"
+    unit: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        value: float | int | str
+        value = self.value
+
+        type_ = self.type_
+
+        unit: None | str | Unset
+        if isinstance(self.unit, Unset):
+            unit = UNSET
+        else:
+            unit = self.unit
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "value": value,
+            }
+        )
+        if type_ is not UNSET:
+            field_dict["type"] = type_
+        if unit is not UNSET:
+            field_dict["unit"] = unit
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        d = dict(src_dict)
+
+        def _parse_value(data: object) -> float | int | str:
+            return cast(float | int | str, data)
+
+        value = _parse_value(d.pop("value"))
+
+        type_ = cast(Literal["literal"] | Unset, d.pop("type", UNSET))
+        if type_ != "literal" and not isinstance(type_, Unset):
+            raise ValueError(f"type must match const 'literal', got '{type_}'")
+
+        def _parse_unit(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        unit = _parse_unit(d.pop("unit", UNSET))
+
+        compose_literal = cls(
+            value=value,
+            type_=type_,
+            unit=unit,
+        )
+
+        compose_literal.additional_properties = d
+        return compose_literal
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/compose_operator.py
+++ b/fastfuels_sdk/v2/client_library/models/compose_operator.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+
+class ComposeOperator(str, Enum):
+    ADD = "add"
+    AVERAGE = "average"
+    DIVIDE = "divide"
+    MAX = "max"
+    MIN = "min"
+    MULTIPLY = "multiply"
+    SUBTRACT = "subtract"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/fastfuels_sdk/v2/client_library/models/compose_select.py
+++ b/fastfuels_sdk/v2/client_library/models/compose_select.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.compose_attribute_condition import ComposeAttributeCondition
+    from ..models.compose_literal import ComposeLiteral
+    from ..models.grid_feature_spatial_condition import GridFeatureSpatialCondition
+    from ..models.grid_geometry_spatial_condition import GridGeometrySpatialCondition
+    from ..models.inline_compute import InlineCompute
+
+
+T = TypeVar("T", bound="ComposeSelect")
+
+
+@_attrs_define
+class ComposeSelect:
+    """Select one input band into an output band, optionally conditionally.
+
+    The output band's type and unit are inherited from the selected source
+    band; only the human-readable `name`/`description` are optional overrides.
+
+        Attributes:
+            output (str): Output band key, e.g. `fuel_load.1hr`.
+            from_ (str): Alias-qualified source band ref.
+            name (None | str | Unset): Optional display name for the output band.
+            description (None | str | Unset): Optional description for the output band.
+            conditions (list[ComposeAttributeCondition | GridFeatureSpatialCondition | GridGeometrySpatialCondition] | None
+                | Unset):
+            else_ (ComposeLiteral | float | InlineCompute | int | None | str | Unset):
+    """
+
+    output: str
+    from_: str
+    name: None | str | Unset = UNSET
+    description: None | str | Unset = UNSET
+    conditions: (
+        list[
+            ComposeAttributeCondition
+            | GridFeatureSpatialCondition
+            | GridGeometrySpatialCondition
+        ]
+        | None
+        | Unset
+    ) = UNSET
+    else_: ComposeLiteral | float | InlineCompute | int | None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.compose_attribute_condition import ComposeAttributeCondition
+        from ..models.compose_literal import ComposeLiteral
+        from ..models.grid_geometry_spatial_condition import (
+            GridGeometrySpatialCondition,
+        )
+        from ..models.inline_compute import InlineCompute
+
+        output = self.output
+
+        from_ = self.from_
+
+        name: None | str | Unset
+        if isinstance(self.name, Unset):
+            name = UNSET
+        else:
+            name = self.name
+
+        description: None | str | Unset
+        if isinstance(self.description, Unset):
+            description = UNSET
+        else:
+            description = self.description
+
+        conditions: list[dict[str, Any]] | None | Unset
+        if isinstance(self.conditions, Unset):
+            conditions = UNSET
+        elif isinstance(self.conditions, list):
+            conditions = []
+            for conditions_type_0_item_data in self.conditions:
+                conditions_type_0_item: dict[str, Any]
+                if isinstance(
+                    conditions_type_0_item_data, ComposeAttributeCondition
+                ) or isinstance(
+                    conditions_type_0_item_data, GridGeometrySpatialCondition
+                ):
+                    conditions_type_0_item = conditions_type_0_item_data.to_dict()
+                else:
+                    conditions_type_0_item = conditions_type_0_item_data.to_dict()
+
+                conditions.append(conditions_type_0_item)
+
+        else:
+            conditions = self.conditions
+
+        else_: dict[str, Any] | float | int | None | str | Unset
+        if isinstance(self.else_, Unset):
+            else_ = UNSET
+        elif isinstance(self.else_, ComposeLiteral) or isinstance(
+            self.else_, InlineCompute
+        ):
+            else_ = self.else_.to_dict()
+        else:
+            else_ = self.else_
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "output": output,
+                "from": from_,
+            }
+        )
+        if name is not UNSET:
+            field_dict["name"] = name
+        if description is not UNSET:
+            field_dict["description"] = description
+        if conditions is not UNSET:
+            field_dict["conditions"] = conditions
+        if else_ is not UNSET:
+            field_dict["else"] = else_
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        from ..models.compose_attribute_condition import ComposeAttributeCondition
+        from ..models.compose_literal import ComposeLiteral
+        from ..models.grid_feature_spatial_condition import GridFeatureSpatialCondition
+        from ..models.grid_geometry_spatial_condition import (
+            GridGeometrySpatialCondition,
+        )
+        from ..models.inline_compute import InlineCompute
+
+        d = dict(src_dict)
+        output = d.pop("output")
+
+        from_ = d.pop("from")
+
+        def _parse_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        name = _parse_name(d.pop("name", UNSET))
+
+        def _parse_description(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        description = _parse_description(d.pop("description", UNSET))
+
+        def _parse_conditions(
+            data: object,
+        ) -> (
+            list[
+                ComposeAttributeCondition
+                | GridFeatureSpatialCondition
+                | GridGeometrySpatialCondition
+            ]
+            | None
+            | Unset
+        ):
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                conditions_type_0 = []
+                _conditions_type_0 = data
+                for conditions_type_0_item_data in _conditions_type_0:
+
+                    def _parse_conditions_type_0_item(
+                        data: object,
+                    ) -> (
+                        ComposeAttributeCondition
+                        | GridFeatureSpatialCondition
+                        | GridGeometrySpatialCondition
+                    ):
+                        try:
+                            if not isinstance(data, dict):
+                                raise TypeError()
+                            conditions_type_0_item_type_0 = (
+                                ComposeAttributeCondition.from_dict(data)
+                            )
+
+                            return conditions_type_0_item_type_0
+                        except (TypeError, ValueError, AttributeError, KeyError):
+                            pass
+                        try:
+                            if not isinstance(data, dict):
+                                raise TypeError()
+                            conditions_type_0_item_type_1 = (
+                                GridGeometrySpatialCondition.from_dict(data)
+                            )
+
+                            return conditions_type_0_item_type_1
+                        except (TypeError, ValueError, AttributeError, KeyError):
+                            pass
+                        if not isinstance(data, dict):
+                            raise TypeError()
+                        conditions_type_0_item_type_2 = (
+                            GridFeatureSpatialCondition.from_dict(data)
+                        )
+
+                        return conditions_type_0_item_type_2
+
+                    conditions_type_0_item = _parse_conditions_type_0_item(
+                        conditions_type_0_item_data
+                    )
+
+                    conditions_type_0.append(conditions_type_0_item)
+
+                return conditions_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(
+                list[
+                    ComposeAttributeCondition
+                    | GridFeatureSpatialCondition
+                    | GridGeometrySpatialCondition
+                ]
+                | None
+                | Unset,
+                data,
+            )
+
+        conditions = _parse_conditions(d.pop("conditions", UNSET))
+
+        def _parse_else_(
+            data: object,
+        ) -> ComposeLiteral | float | InlineCompute | int | None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                else_type_3 = ComposeLiteral.from_dict(data)
+
+                return else_type_3
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                else_type_4 = InlineCompute.from_dict(data)
+
+                return else_type_4
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(
+                ComposeLiteral | float | InlineCompute | int | None | str | Unset, data
+            )
+
+        else_ = _parse_else_(d.pop("else", UNSET))
+
+        compose_select = cls(
+            output=output,
+            from_=from_,
+            name=name,
+            description=description,
+            conditions=conditions,
+            else_=else_,
+        )
+
+        compose_select.additional_properties = d
+        return compose_select
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/continuous_band_summary.py
+++ b/fastfuels_sdk/v2/client_library/models/continuous_band_summary.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -72,7 +73,7 @@ class ContinuousBandSummary:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         type_ = cast(Literal["continuous"], d.pop("type"))
         if type_ != "continuous":

--- a/fastfuels_sdk/v2/client_library/models/continuous_column_summary.py
+++ b/fastfuels_sdk/v2/client_library/models/continuous_column_summary.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    Self,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ContinuousColumnSummary")
+
+
+@_attrs_define
+class ContinuousColumnSummary:
+    """
+    Attributes:
+        type_ (Literal['continuous']):
+        count (int):
+        null_count (int):
+        min_ (float | None):
+        max_ (float | None):
+        mean (float | None):
+        std (float | None):
+    """
+
+    type_: Literal["continuous"]
+    count: int
+    null_count: int
+    min_: float | None
+    max_: float | None
+    mean: float | None
+    std: float | None
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
+        count = self.count
+
+        null_count = self.null_count
+
+        min_: float | None
+        min_ = self.min_
+
+        max_: float | None
+        max_ = self.max_
+
+        mean: float | None
+        mean = self.mean
+
+        std: float | None
+        std = self.std
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "type": type_,
+                "count": count,
+                "null_count": null_count,
+                "min": min_,
+                "max": max_,
+                "mean": mean,
+                "std": std,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        d = dict(src_dict)
+        type_ = cast(Literal["continuous"], d.pop("type"))
+        if type_ != "continuous":
+            raise ValueError(f"type must match const 'continuous', got '{type_}'")
+
+        count = d.pop("count")
+
+        null_count = d.pop("null_count")
+
+        def _parse_min_(data: object) -> float | None:
+            if data is None:
+                return data
+            return cast(float | None, data)
+
+        min_ = _parse_min_(d.pop("min"))
+
+        def _parse_max_(data: object) -> float | None:
+            if data is None:
+                return data
+            return cast(float | None, data)
+
+        max_ = _parse_max_(d.pop("max"))
+
+        def _parse_mean(data: object) -> float | None:
+            if data is None:
+                return data
+            return cast(float | None, data)
+
+        mean = _parse_mean(d.pop("mean"))
+
+        def _parse_std(data: object) -> float | None:
+            if data is None:
+                return data
+            return cast(float | None, data)
+
+        std = _parse_std(d.pop("std"))
+
+        continuous_column_summary = cls(
+            type_=type_,
+            count=count,
+            null_count=null_count,
+            min_=min_,
+            max_=max_,
+            mean=mean,
+            std=std,
+        )
+
+        continuous_column_summary.additional_properties = d
+        return continuous_column_summary
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/count_usage.py
+++ b/fastfuels_sdk/v2/client_library/models/count_usage.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Self, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.usage_count import UsageCount
+
+
+T = TypeVar("T", bound="CountUsage")
+
+
+@_attrs_define
+class CountUsage:
+    """Usage for a count-only resource type (domains, applications, API keys).
+
+    Attributes:
+        total (UsageCount): A count-based usage/limit pair (resources or concurrent jobs).
+    """
+
+    total: UsageCount
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        total = self.total.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "total": total,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        from ..models.usage_count import UsageCount
+
+        d = dict(src_dict)
+        total = UsageCount.from_dict(d.pop("total"))
+
+        count_usage = cls(
+            total=total,
+        )
+
+        count_usage.additional_properties = d
+        return count_usage
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/create_application_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_application_request.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
-from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
@@ -22,7 +21,6 @@ class CreateApplicationRequest:
 
     name: str
     description: None | str | Unset = UNSET
-    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         name = self.name
@@ -34,7 +32,7 @@ class CreateApplicationRequest:
             description = self.description
 
         field_dict: dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
+
         field_dict.update(
             {
                 "name": name,
@@ -46,7 +44,7 @@ class CreateApplicationRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         name = d.pop("name")
 
@@ -64,21 +62,4 @@ class CreateApplicationRequest:
             description=description,
         )
 
-        create_application_request.additional_properties = d
         return create_application_request
-
-    @property
-    def additional_keys(self) -> list[str]:
-        return list(self.additional_properties.keys())
-
-    def __getitem__(self, key: str) -> Any:
-        return self.additional_properties[key]
-
-    def __setitem__(self, key: str, value: Any) -> None:
-        self.additional_properties[key] = value
-
-    def __delitem__(self, key: str) -> None:
-        del self.additional_properties[key]
-
-    def __contains__(self, key: str) -> bool:
-        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/create_chm_inventory_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_chm_inventory_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -119,7 +119,7 @@ class CreateChmInventoryRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.inventory_basal_area_treatment import InventoryBasalAreaTreatment
         from ..models.inventory_diameter_treatment import InventoryDiameterTreatment
         from ..models.inventory_modification import InventoryModification

--- a/fastfuels_sdk/v2/client_library/models/create_compose_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_compose_request.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.compose_compute import ComposeCompute
+    from ..models.compose_input import ComposeInput
+    from ..models.compose_select import ComposeSelect
+    from ..models.grid_modification import GridModification
+
+
+T = TypeVar("T", bound="CreateComposeRequest")
+
+
+@_attrs_define
+class CreateComposeRequest:
+    """Request to create a grid by composing one or more existing grids.
+
+    Attributes:
+        inputs (list[ComposeInput]):
+        select (list[ComposeSelect] | Unset):
+        compute (list[ComposeCompute] | Unset):
+        name (str | Unset):  Default: ''.
+        description (str | Unset):  Default: ''.
+        tags (list[str] | Unset):
+        modifications (list[GridModification] | Unset):
+    """
+
+    inputs: list[ComposeInput]
+    select: list[ComposeSelect] | Unset = UNSET
+    compute: list[ComposeCompute] | Unset = UNSET
+    name: str | Unset = ""
+    description: str | Unset = ""
+    tags: list[str] | Unset = UNSET
+    modifications: list[GridModification] | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        inputs = []
+        for inputs_item_data in self.inputs:
+            inputs_item = inputs_item_data.to_dict()
+            inputs.append(inputs_item)
+
+        select: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.select, Unset):
+            select = []
+            for select_item_data in self.select:
+                select_item = select_item_data.to_dict()
+                select.append(select_item)
+
+        compute: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.compute, Unset):
+            compute = []
+            for compute_item_data in self.compute:
+                compute_item = compute_item_data.to_dict()
+                compute.append(compute_item)
+
+        name = self.name
+
+        description = self.description
+
+        tags: list[str] | Unset = UNSET
+        if not isinstance(self.tags, Unset):
+            tags = self.tags
+
+        modifications: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.modifications, Unset):
+            modifications = []
+            for modifications_item_data in self.modifications:
+                modifications_item = modifications_item_data.to_dict()
+                modifications.append(modifications_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "inputs": inputs,
+            }
+        )
+        if select is not UNSET:
+            field_dict["select"] = select
+        if compute is not UNSET:
+            field_dict["compute"] = compute
+        if name is not UNSET:
+            field_dict["name"] = name
+        if description is not UNSET:
+            field_dict["description"] = description
+        if tags is not UNSET:
+            field_dict["tags"] = tags
+        if modifications is not UNSET:
+            field_dict["modifications"] = modifications
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        from ..models.compose_compute import ComposeCompute
+        from ..models.compose_input import ComposeInput
+        from ..models.compose_select import ComposeSelect
+        from ..models.grid_modification import GridModification
+
+        d = dict(src_dict)
+        inputs = []
+        _inputs = d.pop("inputs")
+        for inputs_item_data in _inputs:
+            inputs_item = ComposeInput.from_dict(inputs_item_data)
+
+            inputs.append(inputs_item)
+
+        _select = d.pop("select", UNSET)
+        select: list[ComposeSelect] | Unset = UNSET
+        if _select is not UNSET:
+            select = []
+            for select_item_data in _select:
+                select_item = ComposeSelect.from_dict(select_item_data)
+
+                select.append(select_item)
+
+        _compute = d.pop("compute", UNSET)
+        compute: list[ComposeCompute] | Unset = UNSET
+        if _compute is not UNSET:
+            compute = []
+            for compute_item_data in _compute:
+                compute_item = ComposeCompute.from_dict(compute_item_data)
+
+                compute.append(compute_item)
+
+        name = d.pop("name", UNSET)
+
+        description = d.pop("description", UNSET)
+
+        tags = cast(list[str], d.pop("tags", UNSET))
+
+        _modifications = d.pop("modifications", UNSET)
+        modifications: list[GridModification] | Unset = UNSET
+        if _modifications is not UNSET:
+            modifications = []
+            for modifications_item_data in _modifications:
+                modifications_item = GridModification.from_dict(modifications_item_data)
+
+                modifications.append(modifications_item)
+
+        create_compose_request = cls(
+            inputs=inputs,
+            select=select,
+            compute=compute,
+            name=name,
+            description=description,
+            tags=tags,
+            modifications=modifications,
+        )
+
+        create_compose_request.additional_properties = d
+        return create_compose_request
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/create_domain_request_body.py
+++ b/fastfuels_sdk/v2/client_library/models/create_domain_request_body.py
@@ -5,6 +5,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -131,7 +132,7 @@ class CreateDomainRequestBody:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.domain_style import DomainStyle
         from ..models.geo_json_crs import GeoJsonCRS
         from ..models.geo_json_feature import GeoJsonFeature

--- a/fastfuels_sdk/v2/client_library/models/create_duet_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_duet_request.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..models.duet_band import DuetBand
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.duet_calibration import DuetCalibration
+
+
+T = TypeVar("T", bound="CreateDuetRequest")
+
+
+@_attrs_define
+class CreateDuetRequest:
+    """Request body for creating a DUET surface fuel grid from a tree grid.
+
+    Does not extend CreateGridRequestBase: like the 3D grids it derives from,
+    DUET grids do not support modifications.
+
+        Attributes:
+            years_since_burn (int): Years of litter accumulation to simulate. DUET begins the year of the last burn, when
+                standing grass and litter have been consumed, so this is the stand's time since fire. It is the highest-leverage
+                parameter in the model and also drives runtime.
+            source_grid_id (str): ID of a completed 3D tree grid carrying the `bulk_density.foliage.live`, `spcd`, and
+                `fuel_moisture.live` bands.
+            wind_direction (int | Unset): Prevailing wind direction in whole degrees clockwise from north. Default: 270.
+            wind_variability (int | Unset): Angular spread of wind direction, in whole degrees. Default: 30.
+            name (str | Unset):  Default: ''.
+            description (str | Unset):  Default: ''.
+            tags (list[str] | Unset):
+            bands (list[DuetBand] | Unset): Which output bands to produce. Defaults to `fuel_load.grass` and
+                `fuel_load.litter`.
+            calibration (DuetCalibration | None | Unset): Optional calibration targets. DUET supplies the spatial pattern of
+                surface fuels; its raw magnitudes are not physical. Without calibration the raw values are stored as-is.
+    """
+
+    years_since_burn: int
+    source_grid_id: str
+    wind_direction: int | Unset = 270
+    wind_variability: int | Unset = 30
+    name: str | Unset = ""
+    description: str | Unset = ""
+    tags: list[str] | Unset = UNSET
+    bands: list[DuetBand] | Unset = UNSET
+    calibration: DuetCalibration | None | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.duet_calibration import DuetCalibration
+
+        years_since_burn = self.years_since_burn
+
+        source_grid_id = self.source_grid_id
+
+        wind_direction = self.wind_direction
+
+        wind_variability = self.wind_variability
+
+        name = self.name
+
+        description = self.description
+
+        tags: list[str] | Unset = UNSET
+        if not isinstance(self.tags, Unset):
+            tags = self.tags
+
+        bands: list[str] | Unset = UNSET
+        if not isinstance(self.bands, Unset):
+            bands = []
+            for bands_item_data in self.bands:
+                bands_item = bands_item_data.value
+                bands.append(bands_item)
+
+        calibration: dict[str, Any] | None | Unset
+        if isinstance(self.calibration, Unset):
+            calibration = UNSET
+        elif isinstance(self.calibration, DuetCalibration):
+            calibration = self.calibration.to_dict()
+        else:
+            calibration = self.calibration
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "years_since_burn": years_since_burn,
+                "source_grid_id": source_grid_id,
+            }
+        )
+        if wind_direction is not UNSET:
+            field_dict["wind_direction"] = wind_direction
+        if wind_variability is not UNSET:
+            field_dict["wind_variability"] = wind_variability
+        if name is not UNSET:
+            field_dict["name"] = name
+        if description is not UNSET:
+            field_dict["description"] = description
+        if tags is not UNSET:
+            field_dict["tags"] = tags
+        if bands is not UNSET:
+            field_dict["bands"] = bands
+        if calibration is not UNSET:
+            field_dict["calibration"] = calibration
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        from ..models.duet_calibration import DuetCalibration
+
+        d = dict(src_dict)
+        years_since_burn = d.pop("years_since_burn")
+
+        source_grid_id = d.pop("source_grid_id")
+
+        wind_direction = d.pop("wind_direction", UNSET)
+
+        wind_variability = d.pop("wind_variability", UNSET)
+
+        name = d.pop("name", UNSET)
+
+        description = d.pop("description", UNSET)
+
+        tags = cast(list[str], d.pop("tags", UNSET))
+
+        _bands = d.pop("bands", UNSET)
+        bands: list[DuetBand] | Unset = UNSET
+        if _bands is not UNSET:
+            bands = []
+            for bands_item_data in _bands:
+                bands_item = DuetBand(bands_item_data)
+
+                bands.append(bands_item)
+
+        def _parse_calibration(data: object) -> DuetCalibration | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                calibration_type_0 = DuetCalibration.from_dict(data)
+
+                return calibration_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(DuetCalibration | None | Unset, data)
+
+        calibration = _parse_calibration(d.pop("calibration", UNSET))
+
+        create_duet_request = cls(
+            years_since_burn=years_since_burn,
+            source_grid_id=source_grid_id,
+            wind_direction=wind_direction,
+            wind_variability=wind_variability,
+            name=name,
+            description=description,
+            tags=tags,
+            bands=bands,
+            calibration=calibration,
+        )
+
+        return create_duet_request

--- a/fastfuels_sdk/v2/client_library/models/create_fbfm_13_lookup_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_fbfm_13_lookup_request.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.fbfm_13_lookup_band import Fbfm13LookupBand
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.grid_modification import GridModification
+
+
+T = TypeVar("T", bound="CreateFbfm13LookupRequest")
+
+
+@_attrs_define
+class CreateFbfm13LookupRequest:
+    """Request to create a grid by looking up FBFM13 fuel parameters.
+
+    Unlike entry-point grid creation requests, domain_id is not required
+    because derived grids carry the same domain reference as their source.
+
+        Attributes:
+            source_grid_id (str): Grid containing FBFM13 codes
+            bands (list[Fbfm13LookupBand]):
+            source_band (str | Unset): Band in source grid containing FBFM13 codes Default: 'fbfm13'.
+            name (str | Unset):  Default: ''.
+            description (str | Unset):  Default: ''.
+            tags (list[str] | Unset):
+            modifications (list[GridModification] | Unset):
+    """
+
+    source_grid_id: str
+    bands: list[Fbfm13LookupBand]
+    source_band: str | Unset = "fbfm13"
+    name: str | Unset = ""
+    description: str | Unset = ""
+    tags: list[str] | Unset = UNSET
+    modifications: list[GridModification] | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        source_grid_id = self.source_grid_id
+
+        bands = []
+        for bands_item_data in self.bands:
+            bands_item = bands_item_data.value
+            bands.append(bands_item)
+
+        source_band = self.source_band
+
+        name = self.name
+
+        description = self.description
+
+        tags: list[str] | Unset = UNSET
+        if not isinstance(self.tags, Unset):
+            tags = self.tags
+
+        modifications: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.modifications, Unset):
+            modifications = []
+            for modifications_item_data in self.modifications:
+                modifications_item = modifications_item_data.to_dict()
+                modifications.append(modifications_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "source_grid_id": source_grid_id,
+                "bands": bands,
+            }
+        )
+        if source_band is not UNSET:
+            field_dict["source_band"] = source_band
+        if name is not UNSET:
+            field_dict["name"] = name
+        if description is not UNSET:
+            field_dict["description"] = description
+        if tags is not UNSET:
+            field_dict["tags"] = tags
+        if modifications is not UNSET:
+            field_dict["modifications"] = modifications
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        from ..models.grid_modification import GridModification
+
+        d = dict(src_dict)
+        source_grid_id = d.pop("source_grid_id")
+
+        bands = []
+        _bands = d.pop("bands")
+        for bands_item_data in _bands:
+            bands_item = Fbfm13LookupBand(bands_item_data)
+
+            bands.append(bands_item)
+
+        source_band = d.pop("source_band", UNSET)
+
+        name = d.pop("name", UNSET)
+
+        description = d.pop("description", UNSET)
+
+        tags = cast(list[str], d.pop("tags", UNSET))
+
+        _modifications = d.pop("modifications", UNSET)
+        modifications: list[GridModification] | Unset = UNSET
+        if _modifications is not UNSET:
+            modifications = []
+            for modifications_item_data in _modifications:
+                modifications_item = GridModification.from_dict(modifications_item_data)
+
+                modifications.append(modifications_item)
+
+        create_fbfm_13_lookup_request = cls(
+            source_grid_id=source_grid_id,
+            bands=bands,
+            source_band=source_band,
+            name=name,
+            description=description,
+            tags=tags,
+            modifications=modifications,
+        )
+
+        create_fbfm_13_lookup_request.additional_properties = d
+        return create_fbfm_13_lookup_request
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/create_fbfm_40_lookup_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_fbfm_40_lookup_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -89,7 +89,7 @@ class CreateFbfm40LookupRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.grid_modification import GridModification
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/create_fccs_lookup_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_fccs_lookup_request.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.fccs_lookup_band import FccsLookupBand
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.grid_modification import GridModification
+
+
+T = TypeVar("T", bound="CreateFccsLookupRequest")
+
+
+@_attrs_define
+class CreateFccsLookupRequest:
+    """Request to create a grid by looking up FCCS fuel parameters.
+
+    Unlike entry-point grid creation requests, domain_id is not required
+    because derived grids carry the same domain reference as their source.
+
+        Attributes:
+            source_grid_id (str): Grid containing FCCS codes
+            bands (list[FccsLookupBand]):
+            source_band (str | Unset): Band in source grid containing FCCS codes Default: 'fccs'.
+            name (str | Unset):  Default: ''.
+            description (str | Unset):  Default: ''.
+            tags (list[str] | Unset):
+            modifications (list[GridModification] | Unset):
+    """
+
+    source_grid_id: str
+    bands: list[FccsLookupBand]
+    source_band: str | Unset = "fccs"
+    name: str | Unset = ""
+    description: str | Unset = ""
+    tags: list[str] | Unset = UNSET
+    modifications: list[GridModification] | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        source_grid_id = self.source_grid_id
+
+        bands = []
+        for bands_item_data in self.bands:
+            bands_item = bands_item_data.value
+            bands.append(bands_item)
+
+        source_band = self.source_band
+
+        name = self.name
+
+        description = self.description
+
+        tags: list[str] | Unset = UNSET
+        if not isinstance(self.tags, Unset):
+            tags = self.tags
+
+        modifications: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.modifications, Unset):
+            modifications = []
+            for modifications_item_data in self.modifications:
+                modifications_item = modifications_item_data.to_dict()
+                modifications.append(modifications_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "source_grid_id": source_grid_id,
+                "bands": bands,
+            }
+        )
+        if source_band is not UNSET:
+            field_dict["source_band"] = source_band
+        if name is not UNSET:
+            field_dict["name"] = name
+        if description is not UNSET:
+            field_dict["description"] = description
+        if tags is not UNSET:
+            field_dict["tags"] = tags
+        if modifications is not UNSET:
+            field_dict["modifications"] = modifications
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        from ..models.grid_modification import GridModification
+
+        d = dict(src_dict)
+        source_grid_id = d.pop("source_grid_id")
+
+        bands = []
+        _bands = d.pop("bands")
+        for bands_item_data in _bands:
+            bands_item = FccsLookupBand(bands_item_data)
+
+            bands.append(bands_item)
+
+        source_band = d.pop("source_band", UNSET)
+
+        name = d.pop("name", UNSET)
+
+        description = d.pop("description", UNSET)
+
+        tags = cast(list[str], d.pop("tags", UNSET))
+
+        _modifications = d.pop("modifications", UNSET)
+        modifications: list[GridModification] | Unset = UNSET
+        if _modifications is not UNSET:
+            modifications = []
+            for modifications_item_data in _modifications:
+                modifications_item = GridModification.from_dict(modifications_item_data)
+
+                modifications.append(modifications_item)
+
+        create_fccs_lookup_request = cls(
+            source_grid_id=source_grid_id,
+            bands=bands,
+            source_band=source_band,
+            name=name,
+            description=description,
+            tags=tags,
+            modifications=modifications,
+        )
+
+        create_fccs_lookup_request.additional_properties = d
+        return create_fccs_lookup_request
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/create_gdam_inventory_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_gdam_inventory_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -83,7 +83,7 @@ class CreateGdamInventoryRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         source_tree_inventory_id = d.pop("source_tree_inventory_id")
 

--- a/fastfuels_sdk/v2/client_library/models/create_geo_tiff_upload_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_geo_tiff_upload_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -70,7 +70,7 @@ class CreateGeoTIFFUploadRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.upload_band_definition import UploadBandDefinition
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/create_inventory_upload_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_inventory_upload_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -73,7 +73,7 @@ class CreateInventoryUploadRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.inventory_column_mapping import InventoryColumnMapping
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/create_key_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_key_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -83,7 +83,7 @@ class CreateKeyRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         name = d.pop("name")
 

--- a/fastfuels_sdk/v2/client_library/models/create_key_response.py
+++ b/fastfuels_sdk/v2/client_library/models/create_key_response.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -120,7 +120,7 @@ class CreateKeyResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         id = d.pop("id")
 

--- a/fastfuels_sdk/v2/client_library/models/create_landfire_canopy_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_landfire_canopy_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -99,9 +99,9 @@ class CreateLandfireCanopyRequest:
         alignment: dict[str, Any] | Unset
         if isinstance(self.alignment, Unset):
             alignment = UNSET
-        elif isinstance(self.alignment, GridAlignmentDomainTarget):
-            alignment = self.alignment.to_dict()
-        elif isinstance(self.alignment, GridAlignmentNativeTarget):
+        elif isinstance(self.alignment, GridAlignmentDomainTarget) or isinstance(
+            self.alignment, GridAlignmentNativeTarget
+        ):
             alignment = self.alignment.to_dict()
         else:
             alignment = self.alignment.to_dict()
@@ -140,7 +140,7 @@ class CreateLandfireCanopyRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.grid_alignment_domain_target import GridAlignmentDomainTarget
         from ..models.grid_alignment_grid_target import GridAlignmentGridTarget
         from ..models.grid_alignment_native_target import GridAlignmentNativeTarget

--- a/fastfuels_sdk/v2/client_library/models/create_landfire_fbfm_13_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_landfire_fbfm_13_request.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.landfire_fbfm_13_version import LandfireFbfm13Version
+from ..models.non_burnable_fuel_model import NonBurnableFuelModel
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.grid_alignment_domain_target import GridAlignmentDomainTarget
+    from ..models.grid_alignment_grid_target import GridAlignmentGridTarget
+    from ..models.grid_alignment_native_target import GridAlignmentNativeTarget
+    from ..models.grid_modification import GridModification
+
+
+T = TypeVar("T", bound="CreateLandfireFbfm13Request")
+
+
+@_attrs_define
+class CreateLandfireFbfm13Request:
+    """Request to create a grid from LANDFIRE FBFM13.
+
+    Returns a single-band grid with categorical fuel model codes.
+    To convert codes to fuel parameters, use /grids/lookup/fbfm13.
+
+        Attributes:
+            name (str | Unset):  Default: ''.
+            description (str | Unset):  Default: ''.
+            tags (list[str] | Unset):
+            modifications (list[GridModification] | Unset): Rules applied to the grid after it is built from its source.
+                Each rule has a list of `conditions` (ANDed together) and a list of `actions` (applied where the conditions
+                match). Conditions can be attribute-based (compare a band value) or spatial (test cell location against a
+                geometry). Spatial conditions come in two variants discriminated by `source`: `geometry` (inline GeoJSON) or
+                `feature` (reference a persisted Feature resource — road, water, layerset — in the same domain by `feature_id`).
+                Both spatial variants accept `buffer_m` (meters, applied in the domain's projected CRS) to widen the geometry,
+                and `target` (`centroid` or `cell`) to choose which part of the cell is tested. Actions modify band values via
+                `replace`, `multiply`, `divide`, `add`, or `subtract`. See the `GridModification` schema for the full field
+                reference and worked examples.
+            extent_buffer_cells (int | Unset): Number of result-grid cells included as a buffer around the domain extent in
+                the stored grid. The buffer is measured after the source raster is projected into the domain CRS, so a cell
+                means one cell in the returned grid rather than one source raster cell. Provides context for later operations
+                (resample, reproject, focal filters, derivative calculations) that are sensitive to edges. Default 0 adds no
+                buffer. Maximum: 10 cells. Default: 0.
+            alignment (GridAlignmentDomainTarget | GridAlignmentGridTarget | GridAlignmentNativeTarget | Unset): Per-fetch
+                alignment target. Default `target="domain"` anchors output cells to the domain origin so cross-source
+                composition works by construction. `target="native"` preserves the source pixel anchor. `target="grid"` aligns
+                to an existing grid by id.
+            version (LandfireFbfm13Version | Unset): Available LANDFIRE FBFM13 data versions.
+            remove_non_burnable (list[NonBurnableFuelModel] | None | Unset):
+    """
+
+    name: str | Unset = ""
+    description: str | Unset = ""
+    tags: list[str] | Unset = UNSET
+    modifications: list[GridModification] | Unset = UNSET
+    extent_buffer_cells: int | Unset = 0
+    alignment: (
+        GridAlignmentDomainTarget
+        | GridAlignmentGridTarget
+        | GridAlignmentNativeTarget
+        | Unset
+    ) = UNSET
+    version: LandfireFbfm13Version | Unset = UNSET
+    remove_non_burnable: list[NonBurnableFuelModel] | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.grid_alignment_domain_target import GridAlignmentDomainTarget
+        from ..models.grid_alignment_native_target import GridAlignmentNativeTarget
+
+        name = self.name
+
+        description = self.description
+
+        tags: list[str] | Unset = UNSET
+        if not isinstance(self.tags, Unset):
+            tags = self.tags
+
+        modifications: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.modifications, Unset):
+            modifications = []
+            for modifications_item_data in self.modifications:
+                modifications_item = modifications_item_data.to_dict()
+                modifications.append(modifications_item)
+
+        extent_buffer_cells = self.extent_buffer_cells
+
+        alignment: dict[str, Any] | Unset
+        if isinstance(self.alignment, Unset):
+            alignment = UNSET
+        elif isinstance(self.alignment, GridAlignmentDomainTarget) or isinstance(
+            self.alignment, GridAlignmentNativeTarget
+        ):
+            alignment = self.alignment.to_dict()
+        else:
+            alignment = self.alignment.to_dict()
+
+        version: str | Unset = UNSET
+        if not isinstance(self.version, Unset):
+            version = self.version.value
+
+        remove_non_burnable: list[str] | None | Unset
+        if isinstance(self.remove_non_burnable, Unset):
+            remove_non_burnable = UNSET
+        elif isinstance(self.remove_non_burnable, list):
+            remove_non_burnable = []
+            for remove_non_burnable_type_0_item_data in self.remove_non_burnable:
+                remove_non_burnable_type_0_item = (
+                    remove_non_burnable_type_0_item_data.value
+                )
+                remove_non_burnable.append(remove_non_burnable_type_0_item)
+
+        else:
+            remove_non_burnable = self.remove_non_burnable
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if name is not UNSET:
+            field_dict["name"] = name
+        if description is not UNSET:
+            field_dict["description"] = description
+        if tags is not UNSET:
+            field_dict["tags"] = tags
+        if modifications is not UNSET:
+            field_dict["modifications"] = modifications
+        if extent_buffer_cells is not UNSET:
+            field_dict["extent_buffer_cells"] = extent_buffer_cells
+        if alignment is not UNSET:
+            field_dict["alignment"] = alignment
+        if version is not UNSET:
+            field_dict["version"] = version
+        if remove_non_burnable is not UNSET:
+            field_dict["remove_non_burnable"] = remove_non_burnable
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        from ..models.grid_alignment_domain_target import GridAlignmentDomainTarget
+        from ..models.grid_alignment_grid_target import GridAlignmentGridTarget
+        from ..models.grid_alignment_native_target import GridAlignmentNativeTarget
+        from ..models.grid_modification import GridModification
+
+        d = dict(src_dict)
+        name = d.pop("name", UNSET)
+
+        description = d.pop("description", UNSET)
+
+        tags = cast(list[str], d.pop("tags", UNSET))
+
+        _modifications = d.pop("modifications", UNSET)
+        modifications: list[GridModification] | Unset = UNSET
+        if _modifications is not UNSET:
+            modifications = []
+            for modifications_item_data in _modifications:
+                modifications_item = GridModification.from_dict(modifications_item_data)
+
+                modifications.append(modifications_item)
+
+        extent_buffer_cells = d.pop("extent_buffer_cells", UNSET)
+
+        def _parse_alignment(
+            data: object,
+        ) -> (
+            GridAlignmentDomainTarget
+            | GridAlignmentGridTarget
+            | GridAlignmentNativeTarget
+            | Unset
+        ):
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                alignment_type_0 = GridAlignmentDomainTarget.from_dict(data)
+
+                return alignment_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                alignment_type_1 = GridAlignmentNativeTarget.from_dict(data)
+
+                return alignment_type_1
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            if not isinstance(data, dict):
+                raise TypeError()
+            alignment_type_2 = GridAlignmentGridTarget.from_dict(data)
+
+            return alignment_type_2
+
+        alignment = _parse_alignment(d.pop("alignment", UNSET))
+
+        _version = d.pop("version", UNSET)
+        version: LandfireFbfm13Version | Unset
+        if isinstance(_version, Unset):
+            version = UNSET
+        else:
+            version = LandfireFbfm13Version(_version)
+
+        def _parse_remove_non_burnable(
+            data: object,
+        ) -> list[NonBurnableFuelModel] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                remove_non_burnable_type_0 = []
+                _remove_non_burnable_type_0 = data
+                for remove_non_burnable_type_0_item_data in _remove_non_burnable_type_0:
+                    remove_non_burnable_type_0_item = NonBurnableFuelModel(
+                        remove_non_burnable_type_0_item_data
+                    )
+
+                    remove_non_burnable_type_0.append(remove_non_burnable_type_0_item)
+
+                return remove_non_burnable_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[NonBurnableFuelModel] | None | Unset, data)
+
+        remove_non_burnable = _parse_remove_non_burnable(
+            d.pop("remove_non_burnable", UNSET)
+        )
+
+        create_landfire_fbfm_13_request = cls(
+            name=name,
+            description=description,
+            tags=tags,
+            modifications=modifications,
+            extent_buffer_cells=extent_buffer_cells,
+            alignment=alignment,
+            version=version,
+            remove_non_burnable=remove_non_burnable,
+        )
+
+        create_landfire_fbfm_13_request.additional_properties = d
+        return create_landfire_fbfm_13_request
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/create_landfire_fbfm_40_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_landfire_fbfm_40_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -92,9 +92,9 @@ class CreateLandfireFbfm40Request:
         alignment: dict[str, Any] | Unset
         if isinstance(self.alignment, Unset):
             alignment = UNSET
-        elif isinstance(self.alignment, GridAlignmentDomainTarget):
-            alignment = self.alignment.to_dict()
-        elif isinstance(self.alignment, GridAlignmentNativeTarget):
+        elif isinstance(self.alignment, GridAlignmentDomainTarget) or isinstance(
+            self.alignment, GridAlignmentNativeTarget
+        ):
             alignment = self.alignment.to_dict()
         else:
             alignment = self.alignment.to_dict()
@@ -140,7 +140,7 @@ class CreateLandfireFbfm40Request:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.grid_alignment_domain_target import GridAlignmentDomainTarget
         from ..models.grid_alignment_grid_target import GridAlignmentGridTarget
         from ..models.grid_alignment_native_target import GridAlignmentNativeTarget

--- a/fastfuels_sdk/v2/client_library/models/create_landfire_fccs_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_landfire_fccs_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -91,9 +91,9 @@ class CreateLandfireFccsRequest:
         alignment: dict[str, Any] | Unset
         if isinstance(self.alignment, Unset):
             alignment = UNSET
-        elif isinstance(self.alignment, GridAlignmentDomainTarget):
-            alignment = self.alignment.to_dict()
-        elif isinstance(self.alignment, GridAlignmentNativeTarget):
+        elif isinstance(self.alignment, GridAlignmentDomainTarget) or isinstance(
+            self.alignment, GridAlignmentNativeTarget
+        ):
             alignment = self.alignment.to_dict()
         else:
             alignment = self.alignment.to_dict()
@@ -127,7 +127,7 @@ class CreateLandfireFccsRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.grid_alignment_domain_target import GridAlignmentDomainTarget
         from ..models.grid_alignment_grid_target import GridAlignmentGridTarget
         from ..models.grid_alignment_native_target import GridAlignmentNativeTarget

--- a/fastfuels_sdk/v2/client_library/models/create_landfire_topography_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_landfire_topography_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -92,9 +92,9 @@ class CreateLandfireTopographyRequest:
         alignment: dict[str, Any] | Unset
         if isinstance(self.alignment, Unset):
             alignment = UNSET
-        elif isinstance(self.alignment, GridAlignmentDomainTarget):
-            alignment = self.alignment.to_dict()
-        elif isinstance(self.alignment, GridAlignmentNativeTarget):
+        elif isinstance(self.alignment, GridAlignmentDomainTarget) or isinstance(
+            self.alignment, GridAlignmentNativeTarget
+        ):
             alignment = self.alignment.to_dict()
         else:
             alignment = self.alignment.to_dict()
@@ -133,7 +133,7 @@ class CreateLandfireTopographyRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.grid_alignment_domain_target import GridAlignmentDomainTarget
         from ..models.grid_alignment_grid_target import GridAlignmentGridTarget
         from ..models.grid_alignment_native_target import GridAlignmentNativeTarget

--- a/fastfuels_sdk/v2/client_library/models/create_layerset_rasterize_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_layerset_rasterize_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -96,9 +96,9 @@ class CreateLayersetRasterizeRequest:
         alignment: dict[str, Any] | Unset
         if isinstance(self.alignment, Unset):
             alignment = UNSET
-        elif isinstance(self.alignment, GridAlignmentDomainTarget):
-            alignment = self.alignment.to_dict()
-        elif isinstance(self.alignment, GridAlignmentNativeTarget):
+        elif isinstance(self.alignment, GridAlignmentDomainTarget) or isinstance(
+            self.alignment, GridAlignmentNativeTarget
+        ):
             alignment = self.alignment.to_dict()
         else:
             alignment = self.alignment.to_dict()
@@ -132,7 +132,7 @@ class CreateLayersetRasterizeRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.grid_alignment_domain_target import GridAlignmentDomainTarget
         from ..models.grid_alignment_grid_target import GridAlignmentGridTarget
         from ..models.grid_alignment_native_target import GridAlignmentNativeTarget

--- a/fastfuels_sdk/v2/client_library/models/create_layerset_request_body.py
+++ b/fastfuels_sdk/v2/client_library/models/create_layerset_request_body.py
@@ -5,6 +5,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -116,7 +117,7 @@ class CreateLayersetRequestBody:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.layerset_crs import LayersetCrs
         from ..models.layerset_feature import LayersetFeature
 

--- a/fastfuels_sdk/v2/client_library/models/create_meta_chm_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_meta_chm_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -89,9 +89,9 @@ class CreateMetaChmRequest:
         alignment: dict[str, Any] | Unset
         if isinstance(self.alignment, Unset):
             alignment = UNSET
-        elif isinstance(self.alignment, GridAlignmentDomainTarget):
-            alignment = self.alignment.to_dict()
-        elif isinstance(self.alignment, GridAlignmentNativeTarget):
+        elif isinstance(self.alignment, GridAlignmentDomainTarget) or isinstance(
+            self.alignment, GridAlignmentNativeTarget
+        ):
             alignment = self.alignment.to_dict()
         else:
             alignment = self.alignment.to_dict()
@@ -121,7 +121,7 @@ class CreateMetaChmRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.grid_alignment_domain_target import GridAlignmentDomainTarget
         from ..models.grid_alignment_grid_target import GridAlignmentGridTarget
         from ..models.grid_alignment_native_target import GridAlignmentNativeTarget

--- a/fastfuels_sdk/v2/client_library/models/create_naip_chm_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_naip_chm_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -86,9 +86,9 @@ class CreateNaipChmRequest:
         alignment: dict[str, Any] | Unset
         if isinstance(self.alignment, Unset):
             alignment = UNSET
-        elif isinstance(self.alignment, GridAlignmentDomainTarget):
-            alignment = self.alignment.to_dict()
-        elif isinstance(self.alignment, GridAlignmentNativeTarget):
+        elif isinstance(self.alignment, GridAlignmentDomainTarget) or isinstance(
+            self.alignment, GridAlignmentNativeTarget
+        ):
             alignment = self.alignment.to_dict()
         else:
             alignment = self.alignment.to_dict()
@@ -112,7 +112,7 @@ class CreateNaipChmRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.grid_alignment_domain_target import GridAlignmentDomainTarget
         from ..models.grid_alignment_grid_target import GridAlignmentGridTarget
         from ..models.grid_alignment_native_target import GridAlignmentNativeTarget

--- a/fastfuels_sdk/v2/client_library/models/create_netcdf_upload_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_netcdf_upload_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -55,7 +55,7 @@ class CreateNetcdfUploadRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         name = d.pop("name", UNSET)
 

--- a/fastfuels_sdk/v2/client_library/models/create_osm_road_feature_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_osm_road_feature_request.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -69,7 +70,7 @@ class CreateOsmRoadFeatureRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         type_ = cast(Literal["road"] | Unset, d.pop("type", UNSET))
         if type_ != "road" and not isinstance(type_, Unset):

--- a/fastfuels_sdk/v2/client_library/models/create_osm_water_feature_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_osm_water_feature_request.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -69,7 +70,7 @@ class CreateOsmWaterFeatureRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         type_ = cast(Literal["water"] | Unset, d.pop("type", UNSET))
         if type_ != "water" and not isinstance(type_, Unset):

--- a/fastfuels_sdk/v2/client_library/models/create_pim_inventory_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_pim_inventory_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -118,7 +118,7 @@ class CreatePimInventoryRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.inventory_basal_area_treatment import InventoryBasalAreaTreatment
         from ..models.inventory_diameter_treatment import InventoryDiameterTreatment
         from ..models.inventory_modification import InventoryModification

--- a/fastfuels_sdk/v2/client_library/models/create_point_cloud_chm_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_point_cloud_chm_request.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.grid_alignment_domain_target import GridAlignmentDomainTarget
+    from ..models.grid_alignment_grid_target import GridAlignmentGridTarget
+    from ..models.grid_alignment_native_target import GridAlignmentNativeTarget
+    from ..models.grid_modification import GridModification
+
+
+T = TypeVar("T", bound="CreatePointCloudChmRequest")
+
+
+@_attrs_define
+class CreatePointCloudChmRequest:
+    """Request to create a canopy height model grid from a point cloud.
+
+    Returns a grid with a single continuous band:
+    - chm: Canopy height in meters
+
+    The point cloud must be airborne (`type: als`) and `completed`. Cell size
+    comes from `alignment.resolution`, defaulting to 1 m — unlike the
+    raster-backed canopy sources there is no source pixel size to inherit.
+
+        Attributes:
+            source_point_cloud_id (str): ID of the point cloud to rasterize. Must be an ALS cloud in this domain.
+            name (str | Unset):  Default: ''.
+            description (str | Unset):  Default: ''.
+            tags (list[str] | Unset):
+            modifications (list[GridModification] | Unset): Rules applied to the grid after it is built from its source.
+                Each rule has a list of `conditions` (ANDed together) and a list of `actions` (applied where the conditions
+                match). Conditions can be attribute-based (compare a band value) or spatial (test cell location against a
+                geometry). Spatial conditions come in two variants discriminated by `source`: `geometry` (inline GeoJSON) or
+                `feature` (reference a persisted Feature resource — road, water, layerset — in the same domain by `feature_id`).
+                Both spatial variants accept `buffer_m` (meters, applied in the domain's projected CRS) to widen the geometry,
+                and `target` (`centroid` or `cell`) to choose which part of the cell is tested. Actions modify band values via
+                `replace`, `multiply`, `divide`, `add`, or `subtract`. See the `GridModification` schema for the full field
+                reference and worked examples.
+            extent_buffer_cells (int | Unset): Number of result-grid cells included as a buffer around the domain extent in
+                the stored grid. The buffer is measured after the source raster is projected into the domain CRS, so a cell
+                means one cell in the returned grid rather than one source raster cell. Provides context for later operations
+                (resample, reproject, focal filters, derivative calculations) that are sensitive to edges. Default 0 adds no
+                buffer. Maximum: 10 cells. Default: 0.
+            alignment (GridAlignmentDomainTarget | GridAlignmentGridTarget | GridAlignmentNativeTarget | Unset): Per-fetch
+                alignment target. Default `target="domain"` anchors output cells to the domain origin so cross-source
+                composition works by construction. `target="native"` preserves the source pixel anchor. `target="grid"` aligns
+                to an existing grid by id.
+    """
+
+    source_point_cloud_id: str
+    name: str | Unset = ""
+    description: str | Unset = ""
+    tags: list[str] | Unset = UNSET
+    modifications: list[GridModification] | Unset = UNSET
+    extent_buffer_cells: int | Unset = 0
+    alignment: (
+        GridAlignmentDomainTarget
+        | GridAlignmentGridTarget
+        | GridAlignmentNativeTarget
+        | Unset
+    ) = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.grid_alignment_domain_target import GridAlignmentDomainTarget
+        from ..models.grid_alignment_native_target import GridAlignmentNativeTarget
+
+        source_point_cloud_id = self.source_point_cloud_id
+
+        name = self.name
+
+        description = self.description
+
+        tags: list[str] | Unset = UNSET
+        if not isinstance(self.tags, Unset):
+            tags = self.tags
+
+        modifications: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.modifications, Unset):
+            modifications = []
+            for modifications_item_data in self.modifications:
+                modifications_item = modifications_item_data.to_dict()
+                modifications.append(modifications_item)
+
+        extent_buffer_cells = self.extent_buffer_cells
+
+        alignment: dict[str, Any] | Unset
+        if isinstance(self.alignment, Unset):
+            alignment = UNSET
+        elif isinstance(self.alignment, GridAlignmentDomainTarget) or isinstance(
+            self.alignment, GridAlignmentNativeTarget
+        ):
+            alignment = self.alignment.to_dict()
+        else:
+            alignment = self.alignment.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "source_point_cloud_id": source_point_cloud_id,
+            }
+        )
+        if name is not UNSET:
+            field_dict["name"] = name
+        if description is not UNSET:
+            field_dict["description"] = description
+        if tags is not UNSET:
+            field_dict["tags"] = tags
+        if modifications is not UNSET:
+            field_dict["modifications"] = modifications
+        if extent_buffer_cells is not UNSET:
+            field_dict["extent_buffer_cells"] = extent_buffer_cells
+        if alignment is not UNSET:
+            field_dict["alignment"] = alignment
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        from ..models.grid_alignment_domain_target import GridAlignmentDomainTarget
+        from ..models.grid_alignment_grid_target import GridAlignmentGridTarget
+        from ..models.grid_alignment_native_target import GridAlignmentNativeTarget
+        from ..models.grid_modification import GridModification
+
+        d = dict(src_dict)
+        source_point_cloud_id = d.pop("source_point_cloud_id")
+
+        name = d.pop("name", UNSET)
+
+        description = d.pop("description", UNSET)
+
+        tags = cast(list[str], d.pop("tags", UNSET))
+
+        _modifications = d.pop("modifications", UNSET)
+        modifications: list[GridModification] | Unset = UNSET
+        if _modifications is not UNSET:
+            modifications = []
+            for modifications_item_data in _modifications:
+                modifications_item = GridModification.from_dict(modifications_item_data)
+
+                modifications.append(modifications_item)
+
+        extent_buffer_cells = d.pop("extent_buffer_cells", UNSET)
+
+        def _parse_alignment(
+            data: object,
+        ) -> (
+            GridAlignmentDomainTarget
+            | GridAlignmentGridTarget
+            | GridAlignmentNativeTarget
+            | Unset
+        ):
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                alignment_type_0 = GridAlignmentDomainTarget.from_dict(data)
+
+                return alignment_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                alignment_type_1 = GridAlignmentNativeTarget.from_dict(data)
+
+                return alignment_type_1
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            if not isinstance(data, dict):
+                raise TypeError()
+            alignment_type_2 = GridAlignmentGridTarget.from_dict(data)
+
+            return alignment_type_2
+
+        alignment = _parse_alignment(d.pop("alignment", UNSET))
+
+        create_point_cloud_chm_request = cls(
+            source_point_cloud_id=source_point_cloud_id,
+            name=name,
+            description=description,
+            tags=tags,
+            modifications=modifications,
+            extent_buffer_cells=extent_buffer_cells,
+            alignment=alignment,
+        )
+
+        create_point_cloud_chm_request.additional_properties = d
+        return create_point_cloud_chm_request
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/create_point_cloud_upload_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_point_cloud_upload_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -69,7 +69,7 @@ class CreatePointCloudUploadRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         type_ = PointCloudType(d.pop("type"))
 

--- a/fastfuels_sdk/v2/client_library/models/create_resample_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_resample_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -70,9 +70,9 @@ class CreateResampleRequest:
         alignment: dict[str, Any] | Unset
         if isinstance(self.alignment, Unset):
             alignment = UNSET
-        elif isinstance(self.alignment, GridAlignmentDomainTarget):
-            alignment = self.alignment.to_dict()
-        elif isinstance(self.alignment, GridAlignmentNativeTarget):
+        elif isinstance(self.alignment, GridAlignmentDomainTarget) or isinstance(
+            self.alignment, GridAlignmentNativeTarget
+        ):
             alignment = self.alignment.to_dict()
         else:
             alignment = self.alignment.to_dict()
@@ -119,7 +119,7 @@ class CreateResampleRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.create_resample_request_method_overrides import (
             CreateResampleRequestMethodOverrides,
         )

--- a/fastfuels_sdk/v2/client_library/models/create_resample_request_method_overrides.py
+++ b/fastfuels_sdk/v2/client_library/models/create_resample_request_method_overrides.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -31,7 +31,7 @@ class CreateResampleRequestMethodOverrides:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         create_resample_request_method_overrides = cls()
 

--- a/fastfuels_sdk/v2/client_library/models/create_three_dep_point_cloud_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_three_dep_point_cloud_request.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Self, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="CreateThreeDepPointCloudRequest")
+
+
+@_attrs_define
+class CreateThreeDepPointCloudRequest:
+    """Request body for fetching a point cloud from USGS 3DEP.
+
+    Attributes:
+        name (str | Unset): Human-readable name for the point cloud. Default: ''.
+        description (str | Unset): Longer free-text description of the point cloud. Default: ''.
+        tags (list[str] | Unset): Tags for organizing and filtering point clouds.
+        datasets (list[str] | None | Unset): Names of the 3DEP acquisitions to read, in priority order. Omit this to let
+            the backend choose, which it does by preferring a single acquisition that covers the whole domain and otherwise
+            combining the fewest acquisitions that fill it. Set it to pin the result to specific acquisitions — for example
+            to force a higher-density or more recent survey where several overlap. Where two listed acquisitions overlap,
+            the one listed first is used. Names come from the coverage endpoint; every name must exist and overlap the
+            domain.
+    """
+
+    name: str | Unset = ""
+    description: str | Unset = ""
+    tags: list[str] | Unset = UNSET
+    datasets: list[str] | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        name = self.name
+
+        description = self.description
+
+        tags: list[str] | Unset = UNSET
+        if not isinstance(self.tags, Unset):
+            tags = self.tags
+
+        datasets: list[str] | None | Unset
+        if isinstance(self.datasets, Unset):
+            datasets = UNSET
+        elif isinstance(self.datasets, list):
+            datasets = self.datasets
+
+        else:
+            datasets = self.datasets
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if name is not UNSET:
+            field_dict["name"] = name
+        if description is not UNSET:
+            field_dict["description"] = description
+        if tags is not UNSET:
+            field_dict["tags"] = tags
+        if datasets is not UNSET:
+            field_dict["datasets"] = datasets
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        d = dict(src_dict)
+        name = d.pop("name", UNSET)
+
+        description = d.pop("description", UNSET)
+
+        tags = cast(list[str], d.pop("tags", UNSET))
+
+        def _parse_datasets(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                datasets_type_0 = cast(list[str], data)
+
+                return datasets_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        datasets = _parse_datasets(d.pop("datasets", UNSET))
+
+        create_three_dep_point_cloud_request = cls(
+            name=name,
+            description=description,
+            tags=tags,
+            datasets=datasets,
+        )
+
+        create_three_dep_point_cloud_request.additional_properties = d
+        return create_three_dep_point_cloud_request
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/create_three_dep_topography_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_three_dep_topography_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -95,9 +95,9 @@ class CreateThreeDepTopographyRequest:
         alignment: dict[str, Any] | Unset
         if isinstance(self.alignment, Unset):
             alignment = UNSET
-        elif isinstance(self.alignment, GridAlignmentDomainTarget):
-            alignment = self.alignment.to_dict()
-        elif isinstance(self.alignment, GridAlignmentNativeTarget):
+        elif isinstance(self.alignment, GridAlignmentDomainTarget) or isinstance(
+            self.alignment, GridAlignmentNativeTarget
+        ):
             alignment = self.alignment.to_dict()
         else:
             alignment = self.alignment.to_dict()
@@ -136,7 +136,7 @@ class CreateThreeDepTopographyRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.grid_alignment_domain_target import GridAlignmentDomainTarget
         from ..models.grid_alignment_grid_target import GridAlignmentGridTarget
         from ..models.grid_alignment_native_target import GridAlignmentNativeTarget

--- a/fastfuels_sdk/v2/client_library/models/create_tree_inventory_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_tree_inventory_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 
@@ -160,7 +160,7 @@ class CreateTreeInventoryRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.allometry_biomass_source import AllometryBiomassSource
         from ..models.allometry_max_crown_radius_source import (
             AllometryMaxCrownRadiusSource,

--- a/fastfuels_sdk/v2/client_library/models/create_tree_map_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_tree_map_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -93,9 +93,9 @@ class CreateTreeMapRequest:
         alignment: dict[str, Any] | Unset
         if isinstance(self.alignment, Unset):
             alignment = UNSET
-        elif isinstance(self.alignment, GridAlignmentDomainTarget):
-            alignment = self.alignment.to_dict()
-        elif isinstance(self.alignment, GridAlignmentNativeTarget):
+        elif isinstance(self.alignment, GridAlignmentDomainTarget) or isinstance(
+            self.alignment, GridAlignmentNativeTarget
+        ):
             alignment = self.alignment.to_dict()
         else:
             alignment = self.alignment.to_dict()
@@ -134,7 +134,7 @@ class CreateTreeMapRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.grid_alignment_domain_target import GridAlignmentDomainTarget
         from ..models.grid_alignment_grid_target import GridAlignmentGridTarget
         from ..models.grid_alignment_native_target import GridAlignmentNativeTarget

--- a/fastfuels_sdk/v2/client_library/models/create_uniform_request.py
+++ b/fastfuels_sdk/v2/client_library/models/create_uniform_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -92,7 +92,7 @@ class CreateUniformRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.grid_modification import GridModification
         from ..models.uniform_band_input import UniformBandInput
 

--- a/fastfuels_sdk/v2/client_library/models/dense_grid_data.py
+++ b/fastfuels_sdk/v2/client_library/models/dense_grid_data.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -47,7 +48,7 @@ class DenseGridData:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         format_ = cast(Literal["dense"], d.pop("format"))
         if format_ != "dense":

--- a/fastfuels_sdk/v2/client_library/models/domain.py
+++ b/fastfuels_sdk/v2/client_library/models/domain.py
@@ -6,6 +6,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -163,7 +164,7 @@ class Domain:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.domain_style import DomainStyle
         from ..models.geo_json_crs import GeoJsonCRS
         from ..models.geo_json_feature import GeoJsonFeature

--- a/fastfuels_sdk/v2/client_library/models/domain_lattice.py
+++ b/fastfuels_sdk/v2/client_library/models/domain_lattice.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -67,7 +67,7 @@ class DomainLattice:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         crs = d.pop("crs")
 

--- a/fastfuels_sdk/v2/client_library/models/domain_style.py
+++ b/fastfuels_sdk/v2/client_library/models/domain_style.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -81,7 +81,7 @@ class DomainStyle:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
 
         def _parse_stroke_color(data: object) -> None | str | Unset:

--- a/fastfuels_sdk/v2/client_library/models/duet_band.py
+++ b/fastfuels_sdk/v2/client_library/models/duet_band.py
@@ -1,0 +1,22 @@
+from enum import Enum
+
+
+class DuetBand(str, Enum):
+    FUEL_DEPTH_GRASS = "fuel_depth.grass"
+    FUEL_DEPTH_LITTER = "fuel_depth.litter"
+    FUEL_DEPTH_LITTER_CONIFEROUS = "fuel_depth.litter.coniferous"
+    FUEL_DEPTH_LITTER_DECIDUOUS = "fuel_depth.litter.deciduous"
+    FUEL_DEPTH_TOTAL = "fuel_depth.total"
+    FUEL_LOAD_GRASS = "fuel_load.grass"
+    FUEL_LOAD_LITTER = "fuel_load.litter"
+    FUEL_LOAD_LITTER_CONIFEROUS = "fuel_load.litter.coniferous"
+    FUEL_LOAD_LITTER_DECIDUOUS = "fuel_load.litter.deciduous"
+    FUEL_LOAD_TOTAL = "fuel_load.total"
+    FUEL_MOISTURE_GRASS = "fuel_moisture.grass"
+    FUEL_MOISTURE_LITTER = "fuel_moisture.litter"
+    FUEL_MOISTURE_LITTER_CONIFEROUS = "fuel_moisture.litter.coniferous"
+    FUEL_MOISTURE_LITTER_DECIDUOUS = "fuel_moisture.litter.deciduous"
+    FUEL_MOISTURE_TOTAL = "fuel_moisture.total"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/fastfuels_sdk/v2/client_library/models/duet_calibration.py
+++ b/fastfuels_sdk/v2/client_library/models/duet_calibration.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.duet_parameter_calibration import DuetParameterCalibration
+
+
+T = TypeVar("T", bound="DuetCalibration")
+
+
+@_attrs_define
+class DuetCalibration:
+    """Calibration targets, keyed by fuel parameter.
+
+    Each parameter is calibrated independently; omitted parameters keep DUET's
+    raw values.
+
+        Attributes:
+            fuel_load (DuetParameterCalibration | None | Unset):
+            fuel_depth (DuetParameterCalibration | None | Unset):
+            fuel_moisture (DuetParameterCalibration | None | Unset):
+    """
+
+    fuel_load: DuetParameterCalibration | None | Unset = UNSET
+    fuel_depth: DuetParameterCalibration | None | Unset = UNSET
+    fuel_moisture: DuetParameterCalibration | None | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.duet_parameter_calibration import DuetParameterCalibration
+
+        fuel_load: dict[str, Any] | None | Unset
+        if isinstance(self.fuel_load, Unset):
+            fuel_load = UNSET
+        elif isinstance(self.fuel_load, DuetParameterCalibration):
+            fuel_load = self.fuel_load.to_dict()
+        else:
+            fuel_load = self.fuel_load
+
+        fuel_depth: dict[str, Any] | None | Unset
+        if isinstance(self.fuel_depth, Unset):
+            fuel_depth = UNSET
+        elif isinstance(self.fuel_depth, DuetParameterCalibration):
+            fuel_depth = self.fuel_depth.to_dict()
+        else:
+            fuel_depth = self.fuel_depth
+
+        fuel_moisture: dict[str, Any] | None | Unset
+        if isinstance(self.fuel_moisture, Unset):
+            fuel_moisture = UNSET
+        elif isinstance(self.fuel_moisture, DuetParameterCalibration):
+            fuel_moisture = self.fuel_moisture.to_dict()
+        else:
+            fuel_moisture = self.fuel_moisture
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update({})
+        if fuel_load is not UNSET:
+            field_dict["fuel_load"] = fuel_load
+        if fuel_depth is not UNSET:
+            field_dict["fuel_depth"] = fuel_depth
+        if fuel_moisture is not UNSET:
+            field_dict["fuel_moisture"] = fuel_moisture
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        from ..models.duet_parameter_calibration import DuetParameterCalibration
+
+        d = dict(src_dict)
+
+        def _parse_fuel_load(data: object) -> DuetParameterCalibration | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                fuel_load_type_0 = DuetParameterCalibration.from_dict(data)
+
+                return fuel_load_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(DuetParameterCalibration | None | Unset, data)
+
+        fuel_load = _parse_fuel_load(d.pop("fuel_load", UNSET))
+
+        def _parse_fuel_depth(data: object) -> DuetParameterCalibration | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                fuel_depth_type_0 = DuetParameterCalibration.from_dict(data)
+
+                return fuel_depth_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(DuetParameterCalibration | None | Unset, data)
+
+        fuel_depth = _parse_fuel_depth(d.pop("fuel_depth", UNSET))
+
+        def _parse_fuel_moisture(
+            data: object,
+        ) -> DuetParameterCalibration | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                fuel_moisture_type_0 = DuetParameterCalibration.from_dict(data)
+
+                return fuel_moisture_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(DuetParameterCalibration | None | Unset, data)
+
+        fuel_moisture = _parse_fuel_moisture(d.pop("fuel_moisture", UNSET))
+
+        duet_calibration = cls(
+            fuel_load=fuel_load,
+            fuel_depth=fuel_depth,
+            fuel_moisture=fuel_moisture,
+        )
+
+        return duet_calibration

--- a/fastfuels_sdk/v2/client_library/models/duet_constant_calibration_target.py
+++ b/fastfuels_sdk/v2/client_library/models/duet_constant_calibration_target.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    Self,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="DuetConstantCalibrationTarget")
+
+
+@_attrs_define
+class DuetConstantCalibrationTarget:
+    """Assign a single value to every fuel-bearing cell.
+
+    Reasonable only when that value is the only one available.
+
+        Attributes:
+            value (float): Target value.
+            method (Literal['constant'] | Unset):  Default: 'constant'.
+    """
+
+    value: float
+    method: Literal["constant"] | Unset = "constant"
+
+    def to_dict(self) -> dict[str, Any]:
+        value = self.value
+
+        method = self.method
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "value": value,
+            }
+        )
+        if method is not UNSET:
+            field_dict["method"] = method
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        d = dict(src_dict)
+        value = d.pop("value")
+
+        method = cast(Literal["constant"] | Unset, d.pop("method", UNSET))
+        if method != "constant" and not isinstance(method, Unset):
+            raise ValueError(f"method must match const 'constant', got '{method}'")
+
+        duet_constant_calibration_target = cls(
+            value=value,
+            method=method,
+        )
+
+        return duet_constant_calibration_target

--- a/fastfuels_sdk/v2/client_library/models/duet_max_min_calibration_target.py
+++ b/fastfuels_sdk/v2/client_library/models/duet_max_min_calibration_target.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    Self,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="DuetMaxMinCalibrationTarget")
+
+
+@_attrs_define
+class DuetMaxMinCalibrationTarget:
+    """Rescale a fuel type to a target maximum and minimum.
+
+    Best when fuel data are limited, or when their distribution does not
+    resemble DUET's.
+
+        Attributes:
+            max_ (float): Target maximum.
+            method (Literal['maxmin'] | Unset):  Default: 'maxmin'.
+            min_ (float | Unset): Target minimum. Default: 0.0.
+    """
+
+    max_: float
+    method: Literal["maxmin"] | Unset = "maxmin"
+    min_: float | Unset = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        max_ = self.max_
+
+        method = self.method
+
+        min_ = self.min_
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "max": max_,
+            }
+        )
+        if method is not UNSET:
+            field_dict["method"] = method
+        if min_ is not UNSET:
+            field_dict["min"] = min_
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        d = dict(src_dict)
+        max_ = d.pop("max")
+
+        method = cast(Literal["maxmin"] | Unset, d.pop("method", UNSET))
+        if method != "maxmin" and not isinstance(method, Unset):
+            raise ValueError(f"method must match const 'maxmin', got '{method}'")
+
+        min_ = d.pop("min", UNSET)
+
+        duet_max_min_calibration_target = cls(
+            max_=max_,
+            method=method,
+            min_=min_,
+        )
+
+        return duet_max_min_calibration_target

--- a/fastfuels_sdk/v2/client_library/models/duet_mean_sd_calibration_target.py
+++ b/fastfuels_sdk/v2/client_library/models/duet_mean_sd_calibration_target.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    Self,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="DuetMeanSdCalibrationTarget")
+
+
+@_attrs_define
+class DuetMeanSdCalibrationTarget:
+    """Rescale a fuel type to a target mean and standard deviation.
+
+    Appropriate only when the targets come from a dataset large enough to
+    approximate a normal distribution.
+
+        Attributes:
+            mean (float): Target mean.
+            sd (float): Target standard deviation.
+            method (Literal['meansd'] | Unset):  Default: 'meansd'.
+    """
+
+    mean: float
+    sd: float
+    method: Literal["meansd"] | Unset = "meansd"
+
+    def to_dict(self) -> dict[str, Any]:
+        mean = self.mean
+
+        sd = self.sd
+
+        method = self.method
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "mean": mean,
+                "sd": sd,
+            }
+        )
+        if method is not UNSET:
+            field_dict["method"] = method
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        d = dict(src_dict)
+        mean = d.pop("mean")
+
+        sd = d.pop("sd")
+
+        method = cast(Literal["meansd"] | Unset, d.pop("method", UNSET))
+        if method != "meansd" and not isinstance(method, Unset):
+            raise ValueError(f"method must match const 'meansd', got '{method}'")
+
+        duet_mean_sd_calibration_target = cls(
+            mean=mean,
+            sd=sd,
+            method=method,
+        )
+
+        return duet_mean_sd_calibration_target

--- a/fastfuels_sdk/v2/client_library/models/duet_parameter_calibration.py
+++ b/fastfuels_sdk/v2/client_library/models/duet_parameter_calibration.py
@@ -1,0 +1,415 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.duet_constant_calibration_target import DuetConstantCalibrationTarget
+    from ..models.duet_max_min_calibration_target import DuetMaxMinCalibrationTarget
+    from ..models.duet_mean_sd_calibration_target import DuetMeanSdCalibrationTarget
+
+
+T = TypeVar("T", bound="DuetParameterCalibration")
+
+
+@_attrs_define
+class DuetParameterCalibration:
+    """Per-fuel-type calibration targets for one fuel parameter.
+
+    `all` is exclusive: it calibrates every fuel type together and cannot be
+    combined with a per-type target.
+
+        Attributes:
+            grass (DuetConstantCalibrationTarget | DuetMaxMinCalibrationTarget | DuetMeanSdCalibrationTarget | None |
+                Unset):
+            coniferous (DuetConstantCalibrationTarget | DuetMaxMinCalibrationTarget | DuetMeanSdCalibrationTarget | None |
+                Unset):
+            deciduous (DuetConstantCalibrationTarget | DuetMaxMinCalibrationTarget | DuetMeanSdCalibrationTarget | None |
+                Unset):
+            litter (DuetConstantCalibrationTarget | DuetMaxMinCalibrationTarget | DuetMeanSdCalibrationTarget | None |
+                Unset):
+            all_ (DuetConstantCalibrationTarget | DuetMaxMinCalibrationTarget | DuetMeanSdCalibrationTarget | None | Unset):
+    """
+
+    grass: (
+        DuetConstantCalibrationTarget
+        | DuetMaxMinCalibrationTarget
+        | DuetMeanSdCalibrationTarget
+        | None
+        | Unset
+    ) = UNSET
+    coniferous: (
+        DuetConstantCalibrationTarget
+        | DuetMaxMinCalibrationTarget
+        | DuetMeanSdCalibrationTarget
+        | None
+        | Unset
+    ) = UNSET
+    deciduous: (
+        DuetConstantCalibrationTarget
+        | DuetMaxMinCalibrationTarget
+        | DuetMeanSdCalibrationTarget
+        | None
+        | Unset
+    ) = UNSET
+    litter: (
+        DuetConstantCalibrationTarget
+        | DuetMaxMinCalibrationTarget
+        | DuetMeanSdCalibrationTarget
+        | None
+        | Unset
+    ) = UNSET
+    all_: (
+        DuetConstantCalibrationTarget
+        | DuetMaxMinCalibrationTarget
+        | DuetMeanSdCalibrationTarget
+        | None
+        | Unset
+    ) = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.duet_constant_calibration_target import (
+            DuetConstantCalibrationTarget,
+        )
+        from ..models.duet_max_min_calibration_target import DuetMaxMinCalibrationTarget
+        from ..models.duet_mean_sd_calibration_target import DuetMeanSdCalibrationTarget
+
+        grass: dict[str, Any] | None | Unset
+        if isinstance(self.grass, Unset):
+            grass = UNSET
+        elif (
+            isinstance(self.grass, DuetMaxMinCalibrationTarget)
+            or isinstance(self.grass, DuetMeanSdCalibrationTarget)
+            or isinstance(self.grass, DuetConstantCalibrationTarget)
+        ):
+            grass = self.grass.to_dict()
+        else:
+            grass = self.grass
+
+        coniferous: dict[str, Any] | None | Unset
+        if isinstance(self.coniferous, Unset):
+            coniferous = UNSET
+        elif (
+            isinstance(self.coniferous, DuetMaxMinCalibrationTarget)
+            or isinstance(self.coniferous, DuetMeanSdCalibrationTarget)
+            or isinstance(self.coniferous, DuetConstantCalibrationTarget)
+        ):
+            coniferous = self.coniferous.to_dict()
+        else:
+            coniferous = self.coniferous
+
+        deciduous: dict[str, Any] | None | Unset
+        if isinstance(self.deciduous, Unset):
+            deciduous = UNSET
+        elif (
+            isinstance(self.deciduous, DuetMaxMinCalibrationTarget)
+            or isinstance(self.deciduous, DuetMeanSdCalibrationTarget)
+            or isinstance(self.deciduous, DuetConstantCalibrationTarget)
+        ):
+            deciduous = self.deciduous.to_dict()
+        else:
+            deciduous = self.deciduous
+
+        litter: dict[str, Any] | None | Unset
+        if isinstance(self.litter, Unset):
+            litter = UNSET
+        elif (
+            isinstance(self.litter, DuetMaxMinCalibrationTarget)
+            or isinstance(self.litter, DuetMeanSdCalibrationTarget)
+            or isinstance(self.litter, DuetConstantCalibrationTarget)
+        ):
+            litter = self.litter.to_dict()
+        else:
+            litter = self.litter
+
+        all_: dict[str, Any] | None | Unset
+        if isinstance(self.all_, Unset):
+            all_ = UNSET
+        elif (
+            isinstance(self.all_, DuetMaxMinCalibrationTarget)
+            or isinstance(self.all_, DuetMeanSdCalibrationTarget)
+            or isinstance(self.all_, DuetConstantCalibrationTarget)
+        ):
+            all_ = self.all_.to_dict()
+        else:
+            all_ = self.all_
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update({})
+        if grass is not UNSET:
+            field_dict["grass"] = grass
+        if coniferous is not UNSET:
+            field_dict["coniferous"] = coniferous
+        if deciduous is not UNSET:
+            field_dict["deciduous"] = deciduous
+        if litter is not UNSET:
+            field_dict["litter"] = litter
+        if all_ is not UNSET:
+            field_dict["all"] = all_
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        from ..models.duet_constant_calibration_target import (
+            DuetConstantCalibrationTarget,
+        )
+        from ..models.duet_max_min_calibration_target import DuetMaxMinCalibrationTarget
+        from ..models.duet_mean_sd_calibration_target import DuetMeanSdCalibrationTarget
+
+        d = dict(src_dict)
+
+        def _parse_grass(
+            data: object,
+        ) -> (
+            DuetConstantCalibrationTarget
+            | DuetMaxMinCalibrationTarget
+            | DuetMeanSdCalibrationTarget
+            | None
+            | Unset
+        ):
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                grass_type_0_type_0 = DuetMaxMinCalibrationTarget.from_dict(data)
+
+                return grass_type_0_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                grass_type_0_type_1 = DuetMeanSdCalibrationTarget.from_dict(data)
+
+                return grass_type_0_type_1
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                grass_type_0_type_2 = DuetConstantCalibrationTarget.from_dict(data)
+
+                return grass_type_0_type_2
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(
+                DuetConstantCalibrationTarget
+                | DuetMaxMinCalibrationTarget
+                | DuetMeanSdCalibrationTarget
+                | None
+                | Unset,
+                data,
+            )
+
+        grass = _parse_grass(d.pop("grass", UNSET))
+
+        def _parse_coniferous(
+            data: object,
+        ) -> (
+            DuetConstantCalibrationTarget
+            | DuetMaxMinCalibrationTarget
+            | DuetMeanSdCalibrationTarget
+            | None
+            | Unset
+        ):
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                coniferous_type_0_type_0 = DuetMaxMinCalibrationTarget.from_dict(data)
+
+                return coniferous_type_0_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                coniferous_type_0_type_1 = DuetMeanSdCalibrationTarget.from_dict(data)
+
+                return coniferous_type_0_type_1
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                coniferous_type_0_type_2 = DuetConstantCalibrationTarget.from_dict(data)
+
+                return coniferous_type_0_type_2
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(
+                DuetConstantCalibrationTarget
+                | DuetMaxMinCalibrationTarget
+                | DuetMeanSdCalibrationTarget
+                | None
+                | Unset,
+                data,
+            )
+
+        coniferous = _parse_coniferous(d.pop("coniferous", UNSET))
+
+        def _parse_deciduous(
+            data: object,
+        ) -> (
+            DuetConstantCalibrationTarget
+            | DuetMaxMinCalibrationTarget
+            | DuetMeanSdCalibrationTarget
+            | None
+            | Unset
+        ):
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                deciduous_type_0_type_0 = DuetMaxMinCalibrationTarget.from_dict(data)
+
+                return deciduous_type_0_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                deciduous_type_0_type_1 = DuetMeanSdCalibrationTarget.from_dict(data)
+
+                return deciduous_type_0_type_1
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                deciduous_type_0_type_2 = DuetConstantCalibrationTarget.from_dict(data)
+
+                return deciduous_type_0_type_2
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(
+                DuetConstantCalibrationTarget
+                | DuetMaxMinCalibrationTarget
+                | DuetMeanSdCalibrationTarget
+                | None
+                | Unset,
+                data,
+            )
+
+        deciduous = _parse_deciduous(d.pop("deciduous", UNSET))
+
+        def _parse_litter(
+            data: object,
+        ) -> (
+            DuetConstantCalibrationTarget
+            | DuetMaxMinCalibrationTarget
+            | DuetMeanSdCalibrationTarget
+            | None
+            | Unset
+        ):
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                litter_type_0_type_0 = DuetMaxMinCalibrationTarget.from_dict(data)
+
+                return litter_type_0_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                litter_type_0_type_1 = DuetMeanSdCalibrationTarget.from_dict(data)
+
+                return litter_type_0_type_1
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                litter_type_0_type_2 = DuetConstantCalibrationTarget.from_dict(data)
+
+                return litter_type_0_type_2
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(
+                DuetConstantCalibrationTarget
+                | DuetMaxMinCalibrationTarget
+                | DuetMeanSdCalibrationTarget
+                | None
+                | Unset,
+                data,
+            )
+
+        litter = _parse_litter(d.pop("litter", UNSET))
+
+        def _parse_all_(
+            data: object,
+        ) -> (
+            DuetConstantCalibrationTarget
+            | DuetMaxMinCalibrationTarget
+            | DuetMeanSdCalibrationTarget
+            | None
+            | Unset
+        ):
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                all_type_0_type_0 = DuetMaxMinCalibrationTarget.from_dict(data)
+
+                return all_type_0_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                all_type_0_type_1 = DuetMeanSdCalibrationTarget.from_dict(data)
+
+                return all_type_0_type_1
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                all_type_0_type_2 = DuetConstantCalibrationTarget.from_dict(data)
+
+                return all_type_0_type_2
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(
+                DuetConstantCalibrationTarget
+                | DuetMaxMinCalibrationTarget
+                | DuetMeanSdCalibrationTarget
+                | None
+                | Unset,
+                data,
+            )
+
+        all_ = _parse_all_(d.pop("all", UNSET))
+
+        duet_parameter_calibration = cls(
+            grass=grass,
+            coniferous=coniferous,
+            deciduous=deciduous,
+            litter=litter,
+            all_=all_,
+        )
+
+        return duet_parameter_calibration

--- a/fastfuels_sdk/v2/client_library/models/duplicate_grid_request.py
+++ b/fastfuels_sdk/v2/client_library/models/duplicate_grid_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -64,7 +64,7 @@ class DuplicateGridRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
 
         def _parse_name(data: object) -> None | str | Unset:

--- a/fastfuels_sdk/v2/client_library/models/duplicate_inventory_request.py
+++ b/fastfuels_sdk/v2/client_library/models/duplicate_inventory_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -64,7 +64,7 @@ class DuplicateInventoryRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
 
         def _parse_name(data: object) -> None | str | Unset:

--- a/fastfuels_sdk/v2/client_library/models/export.py
+++ b/fastfuels_sdk/v2/client_library/models/export.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -159,7 +159,7 @@ class Export:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.export_source import ExportSource
         from ..models.job_error import JobError
         from ..models.job_progress import JobProgress

--- a/fastfuels_sdk/v2/client_library/models/export_grid_request.py
+++ b/fastfuels_sdk/v2/client_library/models/export_grid_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -71,7 +71,7 @@ class ExportGridRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
 
         def _parse_bands(data: object) -> list[str] | None | Unset:

--- a/fastfuels_sdk/v2/client_library/models/export_inventory_request.py
+++ b/fastfuels_sdk/v2/client_library/models/export_inventory_request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -71,7 +71,7 @@ class ExportInventoryRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
 
         def _parse_columns(data: object) -> list[str] | None | Unset:

--- a/fastfuels_sdk/v2/client_library/models/export_source.py
+++ b/fastfuels_sdk/v2/client_library/models/export_source.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -26,7 +26,7 @@ class ExportSource:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         export_source = cls()
 

--- a/fastfuels_sdk/v2/client_library/models/fbfm_13_lookup_band.py
+++ b/fastfuels_sdk/v2/client_library/models/fbfm_13_lookup_band.py
@@ -1,0 +1,16 @@
+from enum import Enum
+
+
+class Fbfm13LookupBand(str, Enum):
+    FUEL_DEPTH = "fuel_depth"
+    FUEL_LOAD_100HR = "fuel_load.100hr"
+    FUEL_LOAD_10HR = "fuel_load.10hr"
+    FUEL_LOAD_1HR = "fuel_load.1hr"
+    FUEL_LOAD_LIVE_FOLIAGE = "fuel_load.live_foliage"
+    SAVR_100HR = "savr.100hr"
+    SAVR_10HR = "savr.10hr"
+    SAVR_1HR = "savr.1hr"
+    SAVR_LIVE_FOLIAGE = "savr.live_foliage"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/fastfuels_sdk/v2/client_library/models/fccs_lookup_band.py
+++ b/fastfuels_sdk/v2/client_library/models/fccs_lookup_band.py
@@ -1,0 +1,19 @@
+from enum import Enum
+
+
+class FccsLookupBand(str, Enum):
+    DUFF_DEPTH = "duff_depth"
+    FUEL_LOAD_1000HR_ROTTEN = "fuel_load.1000hr_rotten"
+    FUEL_LOAD_1000HR_SOUND = "fuel_load.1000hr_sound"
+    FUEL_LOAD_100HR = "fuel_load.100hr"
+    FUEL_LOAD_10HR = "fuel_load.10hr"
+    FUEL_LOAD_1HR = "fuel_load.1hr"
+    FUEL_LOAD_DUFF = "fuel_load.duff"
+    FUEL_LOAD_LITTER = "fuel_load.litter"
+    FUEL_LOAD_LIVE_BRANCH = "fuel_load.live_branch"
+    FUEL_LOAD_LIVE_FOLIAGE = "fuel_load.live_foliage"
+    FUEL_LOAD_LIVE_HERB = "fuel_load.live_herb"
+    FUEL_LOAD_LIVE_SHRUB = "fuel_load.live_shrub"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/fastfuels_sdk/v2/client_library/models/feature.py
+++ b/fastfuels_sdk/v2/client_library/models/feature.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -154,7 +154,7 @@ class Feature:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.feature_georeference import FeatureGeoreference
         from ..models.feature_source import FeatureSource
         from ..models.job_error import JobError

--- a/fastfuels_sdk/v2/client_library/models/feature_data_metadata.py
+++ b/fastfuels_sdk/v2/client_library/models/feature_data_metadata.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -53,7 +53,7 @@ class FeatureDataMetadata:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.feature_partition_info import FeaturePartitionInfo
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/feature_georeference.py
+++ b/fastfuels_sdk/v2/client_library/models/feature_georeference.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -43,7 +43,7 @@ class FeatureGeoreference:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         crs = d.pop("crs")
 

--- a/fastfuels_sdk/v2/client_library/models/feature_partition_info.py
+++ b/fastfuels_sdk/v2/client_library/models/feature_partition_info.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -39,7 +39,7 @@ class FeaturePartitionInfo:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         index = d.pop("index")
 

--- a/fastfuels_sdk/v2/client_library/models/feature_source.py
+++ b/fastfuels_sdk/v2/client_library/models/feature_source.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -23,7 +23,7 @@ class FeatureSource:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         feature_source = cls()
 

--- a/fastfuels_sdk/v2/client_library/models/fia_species_group_share.py
+++ b/fastfuels_sdk/v2/client_library/models/fia_species_group_share.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Self, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="FIASpeciesGroupShare")
+
+
+@_attrs_define
+class FIASpeciesGroupShare:
+    """Basal area share for a single FIA species group.
+
+    Attributes:
+        spgrpcd (int): FIA Species Group Code (SPGRPCD).
+        name (str): Common group name, e.g. 'Douglas-fir'.
+        basal_area_share (float): Fraction of total stand basal area, 0..1.
+    """
+
+    spgrpcd: int
+    name: str
+    basal_area_share: float
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        spgrpcd = self.spgrpcd
+
+        name = self.name
+
+        basal_area_share = self.basal_area_share
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "spgrpcd": spgrpcd,
+                "name": name,
+                "basal_area_share": basal_area_share,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        d = dict(src_dict)
+        spgrpcd = d.pop("spgrpcd")
+
+        name = d.pop("name")
+
+        basal_area_share = d.pop("basal_area_share")
+
+        fia_species_group_share = cls(
+            spgrpcd=spgrpcd,
+            name=name,
+            basal_area_share=basal_area_share,
+        )
+
+        fia_species_group_share.additional_properties = d
+        return fia_species_group_share
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/field_source.py
+++ b/fastfuels_sdk/v2/client_library/models/field_source.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -45,7 +45,7 @@ class FieldSource:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         grid_id = d.pop("grid_id")
 

--- a/fastfuels_sdk/v2/client_library/models/fine_biomass_config.py
+++ b/fastfuels_sdk/v2/client_library/models/fine_biomass_config.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -42,7 +43,7 @@ class FineBiomassConfig:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         recipe = cast(Literal["foliage_plus_branchwood_fraction"], d.pop("recipe"))
         if recipe != "foliage_plus_branchwood_fraction":

--- a/fastfuels_sdk/v2/client_library/models/geo_json_crs.py
+++ b/fastfuels_sdk/v2/client_library/models/geo_json_crs.py
@@ -5,6 +5,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -51,7 +52,7 @@ class GeoJsonCRS:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.geo_json_crs_properties import GeoJsonCRSProperties
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/geo_json_crs_properties.py
+++ b/fastfuels_sdk/v2/client_library/models/geo_json_crs_properties.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -33,7 +33,7 @@ class GeoJsonCRSProperties:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         name = d.pop("name", UNSET)
 

--- a/fastfuels_sdk/v2/client_library/models/geo_json_feature.py
+++ b/fastfuels_sdk/v2/client_library/models/geo_json_feature.py
@@ -5,6 +5,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -76,27 +77,23 @@ class GeoJsonFeature:
         type_ = self.type_
 
         geometry: dict[str, Any] | None
-        if isinstance(self.geometry, Point):
-            geometry = self.geometry.to_dict()
-        elif isinstance(self.geometry, MultiPoint):
-            geometry = self.geometry.to_dict()
-        elif isinstance(self.geometry, LineString):
-            geometry = self.geometry.to_dict()
-        elif isinstance(self.geometry, MultiLineString):
-            geometry = self.geometry.to_dict()
-        elif isinstance(self.geometry, Polygon):
-            geometry = self.geometry.to_dict()
-        elif isinstance(self.geometry, MultiPolygon):
-            geometry = self.geometry.to_dict()
-        elif isinstance(self.geometry, GeometryCollection):
+        if (
+            isinstance(self.geometry, Point)
+            or isinstance(self.geometry, MultiPoint)
+            or isinstance(self.geometry, LineString)
+            or isinstance(self.geometry, MultiLineString)
+            or isinstance(self.geometry, Polygon)
+            or isinstance(self.geometry, MultiPolygon)
+            or isinstance(self.geometry, GeometryCollection)
+        ):
             geometry = self.geometry.to_dict()
         else:
             geometry = self.geometry
 
         properties: dict[str, Any] | None
-        if isinstance(self.properties, GeoJsonFeaturePropertiesType0):
-            properties = self.properties.to_dict()
-        elif isinstance(self.properties, BaseModel):
+        if isinstance(self.properties, GeoJsonFeaturePropertiesType0) or isinstance(
+            self.properties, BaseModel
+        ):
             properties = self.properties.to_dict()
         else:
             properties = self.properties
@@ -137,7 +134,7 @@ class GeoJsonFeature:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.base_model import BaseModel
         from ..models.geo_json_feature_properties_type_0 import (
             GeoJsonFeaturePropertiesType0,

--- a/fastfuels_sdk/v2/client_library/models/geo_json_feature.py
+++ b/fastfuels_sdk/v2/client_library/models/geo_json_feature.py
@@ -34,7 +34,7 @@ T = TypeVar("T", bound="GeoJsonFeature")
 
 @_attrs_define
 class GeoJsonFeature:
-    """Feature Model
+    """Generic GeoJSON feature with a generator-safe OpenAPI title.
 
     Attributes:
         type_ (Literal['Feature']):

--- a/fastfuels_sdk/v2/client_library/models/geo_json_feature_collection.py
+++ b/fastfuels_sdk/v2/client_library/models/geo_json_feature_collection.py
@@ -21,11 +21,11 @@ if TYPE_CHECKING:
     from ..models.geo_json_feature import GeoJsonFeature
 
 
-T = TypeVar("T", bound="CreateDomainRequestBody")
+T = TypeVar("T", bound="GeoJsonFeatureCollection")
 
 
 @_attrs_define
-class CreateDomainRequestBody:
+class GeoJsonFeatureCollection:
     """
     Attributes:
         type_ (Literal['FeatureCollection']):
@@ -231,7 +231,7 @@ class CreateDomainRequestBody:
 
         style = _parse_style(d.pop("style", UNSET))
 
-        create_domain_request_body = cls(
+        geo_json_feature_collection = cls(
             type_=type_,
             features=features,
             bbox=bbox,
@@ -243,8 +243,8 @@ class CreateDomainRequestBody:
             style=style,
         )
 
-        create_domain_request_body.additional_properties = d
-        return create_domain_request_body
+        geo_json_feature_collection.additional_properties = d
+        return geo_json_feature_collection
 
     @property
     def additional_keys(self) -> list[str]:

--- a/fastfuels_sdk/v2/client_library/models/geo_json_feature_properties_type_0.py
+++ b/fastfuels_sdk/v2/client_library/models/geo_json_feature_properties_type_0.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -23,7 +23,7 @@ class GeoJsonFeaturePropertiesType0:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         geo_json_feature_properties_type_0 = cls()
 

--- a/fastfuels_sdk/v2/client_library/models/geometry_collection.py
+++ b/fastfuels_sdk/v2/client_library/models/geometry_collection.py
@@ -5,6 +5,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -63,17 +64,14 @@ class GeometryCollection:
         geometries = []
         for geometries_item_data in self.geometries:
             geometries_item: dict[str, Any]
-            if isinstance(geometries_item_data, Point):
-                geometries_item = geometries_item_data.to_dict()
-            elif isinstance(geometries_item_data, MultiPoint):
-                geometries_item = geometries_item_data.to_dict()
-            elif isinstance(geometries_item_data, LineString):
-                geometries_item = geometries_item_data.to_dict()
-            elif isinstance(geometries_item_data, MultiLineString):
-                geometries_item = geometries_item_data.to_dict()
-            elif isinstance(geometries_item_data, Polygon):
-                geometries_item = geometries_item_data.to_dict()
-            elif isinstance(geometries_item_data, MultiPolygon):
+            if (
+                isinstance(geometries_item_data, Point)
+                or isinstance(geometries_item_data, MultiPoint)
+                or isinstance(geometries_item_data, LineString)
+                or isinstance(geometries_item_data, MultiLineString)
+                or isinstance(geometries_item_data, Polygon)
+                or isinstance(geometries_item_data, MultiPolygon)
+            ):
                 geometries_item = geometries_item_data.to_dict()
             else:
                 geometries_item = geometries_item_data.to_dict()
@@ -107,7 +105,7 @@ class GeometryCollection:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.line_string import LineString
         from ..models.multi_line_string import MultiLineString
         from ..models.multi_point import MultiPoint

--- a/fastfuels_sdk/v2/client_library/models/georeference.py
+++ b/fastfuels_sdk/v2/client_library/models/georeference.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -59,7 +59,7 @@ class Georeference:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         crs = d.pop("crs")
 

--- a/fastfuels_sdk/v2/client_library/models/georeference_3d.py
+++ b/fastfuels_sdk/v2/client_library/models/georeference_3d.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -62,7 +62,7 @@ class Georeference3D:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         crs = d.pop("crs")
 

--- a/fastfuels_sdk/v2/client_library/models/grid.py
+++ b/fastfuels_sdk/v2/client_library/models/grid.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -142,9 +142,9 @@ class Grid:
         georeference: dict[str, Any] | None | Unset
         if isinstance(self.georeference, Unset):
             georeference = UNSET
-        elif isinstance(self.georeference, Georeference):
-            georeference = self.georeference.to_dict()
-        elif isinstance(self.georeference, Georeference3D):
+        elif isinstance(self.georeference, Georeference) or isinstance(
+            self.georeference, Georeference3D
+        ):
             georeference = self.georeference.to_dict()
         else:
             georeference = self.georeference
@@ -206,7 +206,7 @@ class Grid:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.band import Band
         from ..models.chunks import Chunks
         from ..models.georeference import Georeference

--- a/fastfuels_sdk/v2/client_library/models/grid_alignment_domain_target.py
+++ b/fastfuels_sdk/v2/client_library/models/grid_alignment_domain_target.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -66,7 +67,7 @@ class GridAlignmentDomainTarget:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         target = cast(Literal["domain"] | Unset, d.pop("target", UNSET))
         if target != "domain" and not isinstance(target, Unset):

--- a/fastfuels_sdk/v2/client_library/models/grid_alignment_grid_target.py
+++ b/fastfuels_sdk/v2/client_library/models/grid_alignment_grid_target.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -74,7 +75,7 @@ class GridAlignmentGridTarget:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         target = cast(Literal["grid"], d.pop("target"))
         if target != "grid":

--- a/fastfuels_sdk/v2/client_library/models/grid_alignment_native_target.py
+++ b/fastfuels_sdk/v2/client_library/models/grid_alignment_native_target.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -67,7 +68,7 @@ class GridAlignmentNativeTarget:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         target = cast(Literal["native"], d.pop("target"))
         if target != "native":

--- a/fastfuels_sdk/v2/client_library/models/grid_data_chunk_metadata.py
+++ b/fastfuels_sdk/v2/client_library/models/grid_data_chunk_metadata.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -86,7 +86,7 @@ class GridDataChunkMetadata:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         index = d.pop("index")
 

--- a/fastfuels_sdk/v2/client_library/models/grid_data_response.py
+++ b/fastfuels_sdk/v2/client_library/models/grid_data_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -62,7 +62,7 @@ class GridDataResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.dense_grid_data import DenseGridData
         from ..models.grid_data_chunk_metadata import GridDataChunkMetadata
         from ..models.sparse_grid_data import SparseGridData

--- a/fastfuels_sdk/v2/client_library/models/grid_feature_spatial_condition.py
+++ b/fastfuels_sdk/v2/client_library/models/grid_feature_spatial_condition.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -88,7 +89,7 @@ class GridFeatureSpatialCondition:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         source = cast(Literal["feature"], d.pop("source"))
         if source != "feature":

--- a/fastfuels_sdk/v2/client_library/models/grid_geometry_spatial_condition.py
+++ b/fastfuels_sdk/v2/client_library/models/grid_geometry_spatial_condition.py
@@ -5,6 +5,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -114,7 +115,7 @@ class GridGeometrySpatialCondition:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.grid_geometry_spatial_condition_crs_type_0 import (
             GridGeometrySpatialConditionCrsType0,
         )

--- a/fastfuels_sdk/v2/client_library/models/grid_geometry_spatial_condition_crs_type_0.py
+++ b/fastfuels_sdk/v2/client_library/models/grid_geometry_spatial_condition_crs_type_0.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -23,7 +23,7 @@ class GridGeometrySpatialConditionCrsType0:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         grid_geometry_spatial_condition_crs_type_0 = cls()
 

--- a/fastfuels_sdk/v2/client_library/models/grid_geometry_spatial_condition_geometry.py
+++ b/fastfuels_sdk/v2/client_library/models/grid_geometry_spatial_condition_geometry.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -26,7 +26,7 @@ class GridGeometrySpatialConditionGeometry:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         grid_geometry_spatial_condition_geometry = cls()
 

--- a/fastfuels_sdk/v2/client_library/models/grid_modification.py
+++ b/fastfuels_sdk/v2/client_library/models/grid_modification.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -54,9 +54,9 @@ class GridModification:
         conditions = []
         for conditions_item_data in self.conditions:
             conditions_item: dict[str, Any]
-            if isinstance(conditions_item_data, GridModificationCondition):
-                conditions_item = conditions_item_data.to_dict()
-            elif isinstance(conditions_item_data, GridGeometrySpatialCondition):
+            if isinstance(
+                conditions_item_data, GridModificationCondition
+            ) or isinstance(conditions_item_data, GridGeometrySpatialCondition):
                 conditions_item = conditions_item_data.to_dict()
             else:
                 conditions_item = conditions_item_data.to_dict()
@@ -80,7 +80,7 @@ class GridModification:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.grid_feature_spatial_condition import GridFeatureSpatialCondition
         from ..models.grid_geometry_spatial_condition import (
             GridGeometrySpatialCondition,

--- a/fastfuels_sdk/v2/client_library/models/grid_modification_action.py
+++ b/fastfuels_sdk/v2/client_library/models/grid_modification_action.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -49,7 +49,7 @@ class GridModificationAction:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         band = d.pop("band")
 

--- a/fastfuels_sdk/v2/client_library/models/grid_modification_condition.py
+++ b/fastfuels_sdk/v2/client_library/models/grid_modification_condition.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -57,7 +57,7 @@ class GridModificationCondition:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         band = d.pop("band")
 

--- a/fastfuels_sdk/v2/client_library/models/grid_source.py
+++ b/fastfuels_sdk/v2/client_library/models/grid_source.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -23,7 +23,7 @@ class GridSource:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         grid_source = cls()
 

--- a/fastfuels_sdk/v2/client_library/models/grid_upload_created_response.py
+++ b/fastfuels_sdk/v2/client_library/models/grid_upload_created_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -51,7 +51,7 @@ class GridUploadCreatedResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.grid import Grid
         from ..models.grid_upload_spec import GridUploadSpec
 

--- a/fastfuels_sdk/v2/client_library/models/grid_upload_spec.py
+++ b/fastfuels_sdk/v2/client_library/models/grid_upload_spec.py
@@ -6,6 +6,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -72,7 +73,7 @@ class GridUploadSpec:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.grid_upload_spec_headers import GridUploadSpecHeaders
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/grid_upload_spec_headers.py
+++ b/fastfuels_sdk/v2/client_library/models/grid_upload_spec_headers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -23,7 +23,7 @@ class GridUploadSpecHeaders:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         grid_upload_spec_headers = cls()
 

--- a/fastfuels_sdk/v2/client_library/models/http_validation_error.py
+++ b/fastfuels_sdk/v2/client_library/models/http_validation_error.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -42,7 +42,7 @@ class HTTPValidationError:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.validation_error import ValidationError
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/inline_compute.py
+++ b/fastfuels_sdk/v2/client_library/models/inline_compute.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.compose_operator import ComposeOperator
+
+if TYPE_CHECKING:
+    from ..models.compose_literal import ComposeLiteral
+
+
+T = TypeVar("T", bound="InlineCompute")
+
+
+@_attrs_define
+class InlineCompute:
+    """A computation body: an operator over operands.
+
+    Usable on its own as a conditional-fallback value; `ComposeCompute`
+    extends it with an output target and optional conditions.
+
+        Attributes:
+            operator (ComposeOperator): Operators available for compose computations.
+            operands (list[ComposeLiteral | float | int | str]):
+    """
+
+    operator: ComposeOperator
+    operands: list[ComposeLiteral | float | int | str]
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.compose_literal import ComposeLiteral
+
+        operator = self.operator.value
+
+        operands = []
+        for operands_item_data in self.operands:
+            operands_item: dict[str, Any] | float | int | str
+            if isinstance(operands_item_data, ComposeLiteral):
+                operands_item = operands_item_data.to_dict()
+            else:
+                operands_item = operands_item_data
+            operands.append(operands_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "operator": operator,
+                "operands": operands,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        from ..models.compose_literal import ComposeLiteral
+
+        d = dict(src_dict)
+        operator = ComposeOperator(d.pop("operator"))
+
+        operands = []
+        _operands = d.pop("operands")
+        for operands_item_data in _operands:
+
+            def _parse_operands_item(
+                data: object,
+            ) -> ComposeLiteral | float | int | str:
+                try:
+                    if not isinstance(data, dict):
+                        raise TypeError()
+                    operands_item_type_3 = ComposeLiteral.from_dict(data)
+
+                    return operands_item_type_3
+                except (TypeError, ValueError, AttributeError, KeyError):
+                    pass
+                return cast(ComposeLiteral | float | int | str, data)
+
+            operands_item = _parse_operands_item(operands_item_data)
+
+            operands.append(operands_item)
+
+        inline_compute = cls(
+            operator=operator,
+            operands=operands,
+        )
+
+        inline_compute.additional_properties = d
+        return inline_compute
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/inventory.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from ..models.inventory_source import InventorySource
     from ..models.job_error import JobError
     from ..models.job_progress import JobProgress
+    from ..models.tree_forestry_metrics import TreeForestryMetrics
 
 
 T = TypeVar("T", bound="Inventory")
@@ -51,6 +52,7 @@ class Inventory:
             modifications (list[InventoryModification] | Unset):
             treatments (list[InventoryBasalAreaTreatment | InventoryDiameterTreatment] | Unset):
             columns (list[Column] | Unset):
+            forestry_metrics (None | TreeForestryMetrics | Unset):
             georeference (InventoryGeoreference | None | Unset): Spatial reference. Null until backend completes processing.
             error (JobError | None | Unset): Error details if status is 'failed'.
             tags (list[str] | Unset):
@@ -72,6 +74,7 @@ class Inventory:
         list[InventoryBasalAreaTreatment | InventoryDiameterTreatment] | Unset
     ) = UNSET
     columns: list[Column] | Unset = UNSET
+    forestry_metrics: None | TreeForestryMetrics | Unset = UNSET
     georeference: InventoryGeoreference | None | Unset = UNSET
     error: JobError | None | Unset = UNSET
     tags: list[str] | Unset = UNSET
@@ -82,6 +85,7 @@ class Inventory:
         from ..models.inventory_georeference import InventoryGeoreference
         from ..models.job_error import JobError
         from ..models.job_progress import JobProgress
+        from ..models.tree_forestry_metrics import TreeForestryMetrics
 
         id = self.id
 
@@ -153,6 +157,14 @@ class Inventory:
                 columns_item = columns_item_data.to_dict()
                 columns.append(columns_item)
 
+        forestry_metrics: dict[str, Any] | None | Unset
+        if isinstance(self.forestry_metrics, Unset):
+            forestry_metrics = UNSET
+        elif isinstance(self.forestry_metrics, TreeForestryMetrics):
+            forestry_metrics = self.forestry_metrics.to_dict()
+        else:
+            forestry_metrics = self.forestry_metrics
+
         georeference: dict[str, Any] | None | Unset
         if isinstance(self.georeference, Unset):
             georeference = UNSET
@@ -202,6 +214,8 @@ class Inventory:
             field_dict["treatments"] = treatments
         if columns is not UNSET:
             field_dict["columns"] = columns
+        if forestry_metrics is not UNSET:
+            field_dict["forestry_metrics"] = forestry_metrics
         if georeference is not UNSET:
             field_dict["georeference"] = georeference
         if error is not UNSET:
@@ -212,7 +226,7 @@ class Inventory:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.column import Column
         from ..models.inventory_basal_area_treatment import InventoryBasalAreaTreatment
         from ..models.inventory_diameter_treatment import InventoryDiameterTreatment
@@ -221,6 +235,7 @@ class Inventory:
         from ..models.inventory_source import InventorySource
         from ..models.job_error import JobError
         from ..models.job_progress import JobProgress
+        from ..models.tree_forestry_metrics import TreeForestryMetrics
 
         d = dict(src_dict)
         id = d.pop("id")
@@ -348,6 +363,23 @@ class Inventory:
 
                 columns.append(columns_item)
 
+        def _parse_forestry_metrics(data: object) -> None | TreeForestryMetrics | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                forestry_metrics_type_0 = TreeForestryMetrics.from_dict(data)
+
+                return forestry_metrics_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | TreeForestryMetrics | Unset, data)
+
+        forestry_metrics = _parse_forestry_metrics(d.pop("forestry_metrics", UNSET))
+
         def _parse_georeference(data: object) -> InventoryGeoreference | None | Unset:
             if data is None:
                 return data
@@ -399,6 +431,7 @@ class Inventory:
             modifications=modifications,
             treatments=treatments,
             columns=columns,
+            forestry_metrics=forestry_metrics,
             georeference=georeference,
             error=error,
             tags=tags,

--- a/fastfuels_sdk/v2/client_library/models/inventory_basal_area_treatment.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_basal_area_treatment.py
@@ -5,6 +5,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -106,7 +107,7 @@ class InventoryBasalAreaTreatment:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.inventory_feature_spatial_condition import (
             InventoryFeatureSpatialCondition,
         )

--- a/fastfuels_sdk/v2/client_library/models/inventory_biomass_column.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_biomass_column.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 
@@ -43,7 +43,7 @@ class InventoryBiomassColumn:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         column = d.pop("column")
 

--- a/fastfuels_sdk/v2/client_library/models/inventory_column_mapping.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_column_mapping.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 
@@ -100,7 +100,7 @@ class InventoryColumnMapping:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
 
         def _parse_x(data: object) -> None | str | Unset:

--- a/fastfuels_sdk/v2/client_library/models/inventory_column_max_crown_radius_source.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_column_max_crown_radius_source.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -57,7 +58,7 @@ class InventoryColumnMaxCrownRadiusSource:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         column = d.pop("column")
 

--- a/fastfuels_sdk/v2/client_library/models/inventory_columns_biomass_source.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_columns_biomass_source.py
@@ -5,6 +5,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -91,7 +92,7 @@ class InventoryColumnsBiomassSource:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.fine_biomass_config import FineBiomassConfig
         from ..models.inventory_columns_biomass_source_columns import (
             InventoryColumnsBiomassSourceColumns,

--- a/fastfuels_sdk/v2/client_library/models/inventory_columns_biomass_source_columns.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_columns_biomass_source_columns.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -30,7 +30,7 @@ class InventoryColumnsBiomassSourceColumns:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.inventory_biomass_column import InventoryBiomassColumn
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/inventory_columns_biomass_source_component_states.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_columns_biomass_source_component_states.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -30,7 +30,7 @@ class InventoryColumnsBiomassSourceComponentStates:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.biomass_component_state import BiomassComponentState
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/inventory_data_metadata.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_data_metadata.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -60,7 +60,7 @@ class InventoryDataMetadata:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.inventory_partition_info import InventoryPartitionInfo
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/inventory_data_response.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_data_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -66,7 +66,7 @@ class InventoryDataResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.inventory_data_response_data_type_1_item import (
             InventoryDataResponseDataType1Item,
         )

--- a/fastfuels_sdk/v2/client_library/models/inventory_data_response_data_type_1_item.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_data_response_data_type_1_item.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -23,7 +23,7 @@ class InventoryDataResponseDataType1Item:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         inventory_data_response_data_type_1_item = cls()
 

--- a/fastfuels_sdk/v2/client_library/models/inventory_diameter_treatment.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_diameter_treatment.py
@@ -5,6 +5,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -106,7 +107,7 @@ class InventoryDiameterTreatment:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.inventory_feature_spatial_condition import (
             InventoryFeatureSpatialCondition,
         )

--- a/fastfuels_sdk/v2/client_library/models/inventory_expression_condition.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_expression_condition.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -39,7 +39,7 @@ class InventoryExpressionCondition:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         expression = d.pop("expression")
 

--- a/fastfuels_sdk/v2/client_library/models/inventory_feature_spatial_condition.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_feature_spatial_condition.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -79,7 +80,7 @@ class InventoryFeatureSpatialCondition:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         source = cast(Literal["feature"], d.pop("source"))
         if source != "feature":

--- a/fastfuels_sdk/v2/client_library/models/inventory_geometry_spatial_condition.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_geometry_spatial_condition.py
@@ -5,6 +5,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -103,7 +104,7 @@ class InventoryGeometrySpatialCondition:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.inventory_geometry_spatial_condition_crs_type_0 import (
             InventoryGeometrySpatialConditionCrsType0,
         )

--- a/fastfuels_sdk/v2/client_library/models/inventory_geometry_spatial_condition_crs_type_0.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_geometry_spatial_condition_crs_type_0.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -23,7 +23,7 @@ class InventoryGeometrySpatialConditionCrsType0:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         inventory_geometry_spatial_condition_crs_type_0 = cls()
 

--- a/fastfuels_sdk/v2/client_library/models/inventory_geometry_spatial_condition_geometry.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_geometry_spatial_condition_geometry.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -26,7 +26,7 @@ class InventoryGeometrySpatialConditionGeometry:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         inventory_geometry_spatial_condition_geometry = cls()
 

--- a/fastfuels_sdk/v2/client_library/models/inventory_georeference.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_georeference.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -43,7 +43,7 @@ class InventoryGeoreference:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         crs = d.pop("crs")
 

--- a/fastfuels_sdk/v2/client_library/models/inventory_modification.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_modification.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -56,11 +56,11 @@ class InventoryModification:
         conditions = []
         for conditions_item_data in self.conditions:
             conditions_item: dict[str, Any]
-            if isinstance(conditions_item_data, InventoryModificationCondition):
-                conditions_item = conditions_item_data.to_dict()
-            elif isinstance(conditions_item_data, InventoryExpressionCondition):
-                conditions_item = conditions_item_data.to_dict()
-            elif isinstance(conditions_item_data, InventoryGeometrySpatialCondition):
+            if (
+                isinstance(conditions_item_data, InventoryModificationCondition)
+                or isinstance(conditions_item_data, InventoryExpressionCondition)
+                or isinstance(conditions_item_data, InventoryGeometrySpatialCondition)
+            ):
                 conditions_item = conditions_item_data.to_dict()
             else:
                 conditions_item = conditions_item_data.to_dict()
@@ -89,7 +89,7 @@ class InventoryModification:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.inventory_expression_condition import InventoryExpressionCondition
         from ..models.inventory_feature_spatial_condition import (
             InventoryFeatureSpatialCondition,

--- a/fastfuels_sdk/v2/client_library/models/inventory_modification_action.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_modification_action.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -62,7 +62,7 @@ class InventoryModificationAction:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         attribute = InventoryAttribute(d.pop("attribute"))
 

--- a/fastfuels_sdk/v2/client_library/models/inventory_modification_condition.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_modification_condition.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -71,7 +71,7 @@ class InventoryModificationCondition:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         attribute = InventoryAttribute(d.pop("attribute"))
 

--- a/fastfuels_sdk/v2/client_library/models/inventory_partition_info.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_partition_info.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -38,7 +38,7 @@ class InventoryPartitionInfo:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         index = d.pop("index")
 

--- a/fastfuels_sdk/v2/client_library/models/inventory_source.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_source.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -23,7 +23,7 @@ class InventorySource:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         inventory_source = cls()
 

--- a/fastfuels_sdk/v2/client_library/models/inventory_upload_created_response.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_upload_created_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -47,7 +47,7 @@ class InventoryUploadCreatedResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.inventory import Inventory
         from ..models.inventory_upload_spec import InventoryUploadSpec
 

--- a/fastfuels_sdk/v2/client_library/models/inventory_upload_spec.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_upload_spec.py
@@ -6,6 +6,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -72,7 +73,7 @@ class InventoryUploadSpec:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.inventory_upload_spec_headers import InventoryUploadSpecHeaders
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/inventory_upload_spec_headers.py
+++ b/fastfuels_sdk/v2/client_library/models/inventory_upload_spec_headers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -23,7 +23,7 @@ class InventoryUploadSpecHeaders:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         inventory_upload_spec_headers = cls()
 

--- a/fastfuels_sdk/v2/client_library/models/job_error.py
+++ b/fastfuels_sdk/v2/client_library/models/job_error.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -73,7 +73,7 @@ class JobError:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         code = d.pop("code")
 

--- a/fastfuels_sdk/v2/client_library/models/job_progress.py
+++ b/fastfuels_sdk/v2/client_library/models/job_progress.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -53,7 +53,7 @@ class JobProgress:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         message = d.pop("message")
 

--- a/fastfuels_sdk/v2/client_library/models/job_resource_usage.py
+++ b/fastfuels_sdk/v2/client_library/models/job_resource_usage.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Self, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.usage_count import UsageCount
+    from ..models.usage_storage import UsageStorage
+
+
+T = TypeVar("T", bound="JobResourceUsage")
+
+
+@_attrs_define
+class JobResourceUsage:
+    """Usage for a resource type that produces jobs and stores artifacts.
+
+    Attributes:
+        active (UsageCount): A count-based usage/limit pair (resources or concurrent jobs).
+        total (UsageCount): A count-based usage/limit pair (resources or concurrent jobs).
+        storage (UsageStorage): A storage usage/limit pair, in bytes.
+    """
+
+    active: UsageCount
+    total: UsageCount
+    storage: UsageStorage
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        active = self.active.to_dict()
+
+        total = self.total.to_dict()
+
+        storage = self.storage.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "active": active,
+                "total": total,
+                "storage": storage,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        from ..models.usage_count import UsageCount
+        from ..models.usage_storage import UsageStorage
+
+        d = dict(src_dict)
+        active = UsageCount.from_dict(d.pop("active"))
+
+        total = UsageCount.from_dict(d.pop("total"))
+
+        storage = UsageStorage.from_dict(d.pop("storage"))
+
+        job_resource_usage = cls(
+            active=active,
+            total=total,
+            storage=storage,
+        )
+
+        job_resource_usage.additional_properties = d
+        return job_resource_usage
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/key.py
+++ b/fastfuels_sdk/v2/client_library/models/key.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -115,7 +115,7 @@ class Key:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         id = d.pop("id")
 

--- a/fastfuels_sdk/v2/client_library/models/landfire_fbfm_13_version.py
+++ b/fastfuels_sdk/v2/client_library/models/landfire_fbfm_13_version.py
@@ -1,9 +1,9 @@
 from enum import Enum
 
 
-class InventoryDataFormat(str, Enum):
-    CSV = "csv"
-    JSON = "json"
+class LandfireFbfm13Version(str, Enum):
+    VALUE_0 = "2023"
+    VALUE_1 = "2024"
 
     def __str__(self) -> str:
         return str(self.value)

--- a/fastfuels_sdk/v2/client_library/models/landscape_export_alignment_domain_target.py
+++ b/fastfuels_sdk/v2/client_library/models/landscape_export_alignment_domain_target.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    Self,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="LandscapeExportAlignmentDomainTarget")
+
+
+@_attrs_define
+class LandscapeExportAlignmentDomainTarget:
+    """Anchor the landscape to the Domain bounding box.
+
+    Output cells tile the Domain bbox at `resolution`, padded outward if the
+    bbox isn't already a whole multiple. The default 30 m matches LANDFIRE's
+    native resolution.
+
+        Attributes:
+            target (Literal['domain'] | Unset):  Default: 'domain'.
+            resolution (float | Unset): Landscape cell size in meters. Defaults to 30 m, LANDFIRE's native resolution.
+                Default: 30.0.
+    """
+
+    target: Literal["domain"] | Unset = "domain"
+    resolution: float | Unset = 30.0
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        target = self.target
+
+        resolution = self.resolution
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if target is not UNSET:
+            field_dict["target"] = target
+        if resolution is not UNSET:
+            field_dict["resolution"] = resolution
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        d = dict(src_dict)
+        target = cast(Literal["domain"] | Unset, d.pop("target", UNSET))
+        if target != "domain" and not isinstance(target, Unset):
+            raise ValueError(f"target must match const 'domain', got '{target}'")
+
+        resolution = d.pop("resolution", UNSET)
+
+        landscape_export_alignment_domain_target = cls(
+            target=target,
+            resolution=resolution,
+        )
+
+        landscape_export_alignment_domain_target.additional_properties = d
+        return landscape_export_alignment_domain_target
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/landscape_export_alignment_grid_target.py
+++ b/fastfuels_sdk/v2/client_library/models/landscape_export_alignment_grid_target.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    Self,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="LandscapeExportAlignmentGridTarget")
+
+
+@_attrs_define
+class LandscapeExportAlignmentGridTarget:
+    """Anchor the landscape to an existing grid's lattice.
+
+    Useful when role grids share a non-Domain-anchored lattice (e.g. all
+    chained off a `target="native"` master grid). The referenced grid's
+    CRS, transform, and shape become the landscape lattice.
+
+        Attributes:
+            target (Literal['grid']):
+            grid_id (str): Existing grid whose lattice (CRS, transform, shape) the landscape should match exactly.
+    """
+
+    target: Literal["grid"]
+    grid_id: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        target = self.target
+
+        grid_id = self.grid_id
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "target": target,
+                "grid_id": grid_id,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        d = dict(src_dict)
+        target = cast(Literal["grid"], d.pop("target"))
+        if target != "grid":
+            raise ValueError(f"target must match const 'grid', got '{target}'")
+
+        grid_id = d.pop("grid_id")
+
+        landscape_export_alignment_grid_target = cls(
+            target=target,
+            grid_id=grid_id,
+        )
+
+        landscape_export_alignment_grid_target.additional_properties = d
+        return landscape_export_alignment_grid_target
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/landscape_export_request.py
+++ b/fastfuels_sdk/v2/client_library/models/landscape_export_request.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.landscape_export_request_fire_behavior_fuel_model import (
+    LandscapeExportRequestFireBehaviorFuelModel,
+)
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.landscape_export_alignment_domain_target import (
+        LandscapeExportAlignmentDomainTarget,
+    )
+    from ..models.landscape_export_alignment_grid_target import (
+        LandscapeExportAlignmentGridTarget,
+    )
+    from ..models.landscape_field_source import LandscapeFieldSource
+
+
+T = TypeVar("T", bound="LandscapeExportRequest")
+
+
+@_attrs_define
+class LandscapeExportRequest:
+    """Request body for creating a landscape export.
+
+    Eight required roles produce an 8-band landscape GeoTIFF in LANDFIRE band
+    order: elevation, slope, aspect, fuel model, canopy cover, canopy height,
+    canopy base height, canopy bulk density. This is the shape modern fire
+    behavior tools consume — IFTDSS requires all eight bands for upload.
+
+    The landscape lattice is defined by the `alignment` field — either the
+    Domain bounding box tiled at `resolution` (default 30 m, LANDFIRE-native),
+    or the lattice of an existing grid. Every role grid must be lattice-aligned
+    to the landscape and cover its full extent; otherwise the request is
+    rejected with 422. The exporter only crops oversized roles by integer
+    slicing — it never resamples or reprojects. To change a grid's resolution
+    or anchor, use `POST /v2/domains/{domain_id}/grids/{grid_id}/resample`.
+
+        Attributes:
+            fire_behavior_fuel_model (LandscapeExportRequestFireBehaviorFuelModel): How the `fuel_model` band's codes should
+                be interpreted: `'fbfm40'` (Scott-Burgan 40) or `'fbfm13'` (Anderson 13). Recorded in the landscape file so fire
+                behavior tools apply the right classification.
+            elevation (LandscapeFieldSource): A single landscape band drawn from one band on one grid.
+            slope (LandscapeFieldSource): A single landscape band drawn from one band on one grid.
+            aspect (LandscapeFieldSource): A single landscape band drawn from one band on one grid.
+            fuel_model (LandscapeFieldSource): A single landscape band drawn from one band on one grid.
+            canopy_cover (LandscapeFieldSource): A single landscape band drawn from one band on one grid.
+            canopy_height (LandscapeFieldSource): A single landscape band drawn from one band on one grid.
+            canopy_base_height (LandscapeFieldSource): A single landscape band drawn from one band on one grid.
+            canopy_bulk_density (LandscapeFieldSource): A single landscape band drawn from one band on one grid.
+            alignment (LandscapeExportAlignmentDomainTarget | LandscapeExportAlignmentGridTarget | Unset): How the landscape
+                lattice is defined. Discriminated by `target`: `'domain'` (default) tiles the Domain bbox at `resolution`;
+                `'grid'` matches an existing grid's lattice exactly. Omit for the default Domain-anchored 30 m landscape.
+            expiration_days (int | Unset): Days until the signed download URL expires (max 7). Default: 7.
+            name (str | Unset):  Default: ''.
+            description (str | Unset):  Default: ''.
+            tags (list[str] | Unset):
+    """
+
+    fire_behavior_fuel_model: LandscapeExportRequestFireBehaviorFuelModel
+    elevation: LandscapeFieldSource
+    slope: LandscapeFieldSource
+    aspect: LandscapeFieldSource
+    fuel_model: LandscapeFieldSource
+    canopy_cover: LandscapeFieldSource
+    canopy_height: LandscapeFieldSource
+    canopy_base_height: LandscapeFieldSource
+    canopy_bulk_density: LandscapeFieldSource
+    alignment: (
+        LandscapeExportAlignmentDomainTarget
+        | LandscapeExportAlignmentGridTarget
+        | Unset
+    ) = UNSET
+    expiration_days: int | Unset = 7
+    name: str | Unset = ""
+    description: str | Unset = ""
+    tags: list[str] | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.landscape_export_alignment_domain_target import (
+            LandscapeExportAlignmentDomainTarget,
+        )
+
+        fire_behavior_fuel_model = self.fire_behavior_fuel_model.value
+
+        elevation = self.elevation.to_dict()
+
+        slope = self.slope.to_dict()
+
+        aspect = self.aspect.to_dict()
+
+        fuel_model = self.fuel_model.to_dict()
+
+        canopy_cover = self.canopy_cover.to_dict()
+
+        canopy_height = self.canopy_height.to_dict()
+
+        canopy_base_height = self.canopy_base_height.to_dict()
+
+        canopy_bulk_density = self.canopy_bulk_density.to_dict()
+
+        alignment: dict[str, Any] | Unset
+        if isinstance(self.alignment, Unset):
+            alignment = UNSET
+        elif isinstance(self.alignment, LandscapeExportAlignmentDomainTarget):
+            alignment = self.alignment.to_dict()
+        else:
+            alignment = self.alignment.to_dict()
+
+        expiration_days = self.expiration_days
+
+        name = self.name
+
+        description = self.description
+
+        tags: list[str] | Unset = UNSET
+        if not isinstance(self.tags, Unset):
+            tags = self.tags
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "fire_behavior_fuel_model": fire_behavior_fuel_model,
+                "elevation": elevation,
+                "slope": slope,
+                "aspect": aspect,
+                "fuel_model": fuel_model,
+                "canopy_cover": canopy_cover,
+                "canopy_height": canopy_height,
+                "canopy_base_height": canopy_base_height,
+                "canopy_bulk_density": canopy_bulk_density,
+            }
+        )
+        if alignment is not UNSET:
+            field_dict["alignment"] = alignment
+        if expiration_days is not UNSET:
+            field_dict["expiration_days"] = expiration_days
+        if name is not UNSET:
+            field_dict["name"] = name
+        if description is not UNSET:
+            field_dict["description"] = description
+        if tags is not UNSET:
+            field_dict["tags"] = tags
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        from ..models.landscape_export_alignment_domain_target import (
+            LandscapeExportAlignmentDomainTarget,
+        )
+        from ..models.landscape_export_alignment_grid_target import (
+            LandscapeExportAlignmentGridTarget,
+        )
+        from ..models.landscape_field_source import LandscapeFieldSource
+
+        d = dict(src_dict)
+        fire_behavior_fuel_model = LandscapeExportRequestFireBehaviorFuelModel(
+            d.pop("fire_behavior_fuel_model")
+        )
+
+        elevation = LandscapeFieldSource.from_dict(d.pop("elevation"))
+
+        slope = LandscapeFieldSource.from_dict(d.pop("slope"))
+
+        aspect = LandscapeFieldSource.from_dict(d.pop("aspect"))
+
+        fuel_model = LandscapeFieldSource.from_dict(d.pop("fuel_model"))
+
+        canopy_cover = LandscapeFieldSource.from_dict(d.pop("canopy_cover"))
+
+        canopy_height = LandscapeFieldSource.from_dict(d.pop("canopy_height"))
+
+        canopy_base_height = LandscapeFieldSource.from_dict(d.pop("canopy_base_height"))
+
+        canopy_bulk_density = LandscapeFieldSource.from_dict(
+            d.pop("canopy_bulk_density")
+        )
+
+        def _parse_alignment(
+            data: object,
+        ) -> (
+            LandscapeExportAlignmentDomainTarget
+            | LandscapeExportAlignmentGridTarget
+            | Unset
+        ):
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                alignment_type_0 = LandscapeExportAlignmentDomainTarget.from_dict(data)
+
+                return alignment_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            if not isinstance(data, dict):
+                raise TypeError()
+            alignment_type_1 = LandscapeExportAlignmentGridTarget.from_dict(data)
+
+            return alignment_type_1
+
+        alignment = _parse_alignment(d.pop("alignment", UNSET))
+
+        expiration_days = d.pop("expiration_days", UNSET)
+
+        name = d.pop("name", UNSET)
+
+        description = d.pop("description", UNSET)
+
+        tags = cast(list[str], d.pop("tags", UNSET))
+
+        landscape_export_request = cls(
+            fire_behavior_fuel_model=fire_behavior_fuel_model,
+            elevation=elevation,
+            slope=slope,
+            aspect=aspect,
+            fuel_model=fuel_model,
+            canopy_cover=canopy_cover,
+            canopy_height=canopy_height,
+            canopy_base_height=canopy_base_height,
+            canopy_bulk_density=canopy_bulk_density,
+            alignment=alignment,
+            expiration_days=expiration_days,
+            name=name,
+            description=description,
+            tags=tags,
+        )
+
+        landscape_export_request.additional_properties = d
+        return landscape_export_request
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/landscape_export_request_fire_behavior_fuel_model.py
+++ b/fastfuels_sdk/v2/client_library/models/landscape_export_request_fire_behavior_fuel_model.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class LandscapeExportRequestFireBehaviorFuelModel(str, Enum):
+    FBFM13 = "fbfm13"
+    FBFM40 = "fbfm40"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/fastfuels_sdk/v2/client_library/models/landscape_field_source.py
+++ b/fastfuels_sdk/v2/client_library/models/landscape_field_source.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Self, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="LandscapeFieldSource")
+
+
+@_attrs_define
+class LandscapeFieldSource:
+    """A single landscape band drawn from one band on one grid.
+
+    Attributes:
+        grid_id (str): Grid containing the source band.
+        band (str): Band key on that grid (e.g. 'elevation').
+    """
+
+    grid_id: str
+    band: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        grid_id = self.grid_id
+
+        band = self.band
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "grid_id": grid_id,
+                "band": band,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        d = dict(src_dict)
+        grid_id = d.pop("grid_id")
+
+        band = d.pop("band")
+
+        landscape_field_source = cls(
+            grid_id=grid_id,
+            band=band,
+        )
+
+        landscape_field_source.additional_properties = d
+        return landscape_field_source
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/layerset_crs.py
+++ b/fastfuels_sdk/v2/client_library/models/layerset_crs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -51,7 +51,7 @@ class LayersetCrs:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.layerset_crs_properties import LayersetCrsProperties
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/layerset_crs_properties.py
+++ b/fastfuels_sdk/v2/client_library/models/layerset_crs_properties.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -23,7 +23,7 @@ class LayersetCrsProperties:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         layerset_crs_properties = cls()
 

--- a/fastfuels_sdk/v2/client_library/models/layerset_feature.py
+++ b/fastfuels_sdk/v2/client_library/models/layerset_feature.py
@@ -5,6 +5,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -60,9 +61,9 @@ class LayersetFeature:
         type_ = self.type_
 
         geometry: dict[str, Any] | None
-        if isinstance(self.geometry, Polygon):
-            geometry = self.geometry.to_dict()
-        elif isinstance(self.geometry, MultiPolygon):
+        if isinstance(self.geometry, Polygon) or isinstance(
+            self.geometry, MultiPolygon
+        ):
             geometry = self.geometry.to_dict()
         else:
             geometry = self.geometry
@@ -105,7 +106,7 @@ class LayersetFeature:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.layerset_properties import LayersetProperties
         from ..models.multi_polygon import MultiPolygon
         from ..models.polygon import Polygon

--- a/fastfuels_sdk/v2/client_library/models/layerset_properties.py
+++ b/fastfuels_sdk/v2/client_library/models/layerset_properties.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -123,7 +123,7 @@ class LayersetProperties:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         fuel_type = d.pop("fuel_type")
 

--- a/fastfuels_sdk/v2/client_library/models/line_string.py
+++ b/fastfuels_sdk/v2/client_library/models/line_string.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -75,7 +76,7 @@ class LineString:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         type_ = cast(Literal["LineString"], d.pop("type"))
         if type_ != "LineString":

--- a/fastfuels_sdk/v2/client_library/models/list_applications_response.py
+++ b/fastfuels_sdk/v2/client_library/models/list_applications_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -56,7 +56,7 @@ class ListApplicationsResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.application import Application
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/list_domains_response.py
+++ b/fastfuels_sdk/v2/client_library/models/list_domains_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -56,7 +56,7 @@ class ListDomainsResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.domain import Domain
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/list_exports_response.py
+++ b/fastfuels_sdk/v2/client_library/models/list_exports_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -56,7 +56,7 @@ class ListExportsResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.export import Export
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/list_features_response.py
+++ b/fastfuels_sdk/v2/client_library/models/list_features_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -56,7 +56,7 @@ class ListFeaturesResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.feature import Feature
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/list_grids_response.py
+++ b/fastfuels_sdk/v2/client_library/models/list_grids_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -56,7 +56,7 @@ class ListGridsResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.grid import Grid
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/list_inventories_response.py
+++ b/fastfuels_sdk/v2/client_library/models/list_inventories_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -56,7 +56,7 @@ class ListInventoriesResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.inventory import Inventory
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/list_keys_response.py
+++ b/fastfuels_sdk/v2/client_library/models/list_keys_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -56,7 +56,7 @@ class ListKeysResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.key import Key
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/list_point_clouds_response.py
+++ b/fastfuels_sdk/v2/client_library/models/list_point_clouds_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -56,7 +56,7 @@ class ListPointCloudsResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.point_cloud import PointCloud
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/moisture_model.py
+++ b/fastfuels_sdk/v2/client_library/models/moisture_model.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 
@@ -56,7 +56,7 @@ class MoistureModel:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.uniform_moisture_value import UniformMoistureValue
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/multi_line_string.py
+++ b/fastfuels_sdk/v2/client_library/models/multi_line_string.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -81,7 +82,7 @@ class MultiLineString:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         type_ = cast(Literal["MultiLineString"], d.pop("type"))
         if type_ != "MultiLineString":

--- a/fastfuels_sdk/v2/client_library/models/multi_point.py
+++ b/fastfuels_sdk/v2/client_library/models/multi_point.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -75,7 +76,7 @@ class MultiPoint:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         type_ = cast(Literal["MultiPoint"], d.pop("type"))
         if type_ != "MultiPoint":

--- a/fastfuels_sdk/v2/client_library/models/multi_polygon.py
+++ b/fastfuels_sdk/v2/client_library/models/multi_polygon.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -87,7 +88,7 @@ class MultiPolygon:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         type_ = cast(Literal["MultiPolygon"], d.pop("type"))
         if type_ != "MultiPolygon":

--- a/fastfuels_sdk/v2/client_library/models/point.py
+++ b/fastfuels_sdk/v2/client_library/models/point.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -71,7 +72,7 @@ class Point:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         type_ = cast(Literal["Point"], d.pop("type"))
         if type_ != "Point":

--- a/fastfuels_sdk/v2/client_library/models/point_cloud.py
+++ b/fastfuels_sdk/v2/client_library/models/point_cloud.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -206,7 +206,7 @@ class PointCloud:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.job_error import JobError
         from ..models.job_progress import JobProgress
         from ..models.point_cloud_georeference import PointCloudGeoreference

--- a/fastfuels_sdk/v2/client_library/models/point_cloud_georeference.py
+++ b/fastfuels_sdk/v2/client_library/models/point_cloud_georeference.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -18,7 +18,9 @@ class PointCloudGeoreference:
 
         Attributes:
             crs (str): Coordinate reference system the points are stored in, as an authority code (e.g. `EPSG:32613`). This
-                is always the domain's CRS: uploads in a different CRS are reprojected during ingestion.
+                is always the domain's CRS: uploads in a different CRS are reprojected during ingestion. Only horizontal
+                coordinates are transformed — elevations are stored exactly as the source provided them and are never converted
+                between reference surfaces.
             bounds (list[float]): Axis-aligned 3D bounding box of every point, given as `[min_x, min_y, min_z, max_x, max_y,
                 max_z]` in the units of `crs`. Point clouds are three-dimensional, so the box includes a vertical (z) extent.
                 Use it to check coverage against a domain before deriving products from the cloud.
@@ -49,7 +51,7 @@ class PointCloudGeoreference:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         crs = d.pop("crs")
 

--- a/fastfuels_sdk/v2/client_library/models/point_cloud_source.py
+++ b/fastfuels_sdk/v2/client_library/models/point_cloud_source.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -27,7 +27,7 @@ class PointCloudSource:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         point_cloud_source = cls()
 

--- a/fastfuels_sdk/v2/client_library/models/point_cloud_summary.py
+++ b/fastfuels_sdk/v2/client_library/models/point_cloud_summary.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -49,7 +49,7 @@ class PointCloudSummary:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         point_count = d.pop("point_count")
 

--- a/fastfuels_sdk/v2/client_library/models/point_cloud_three_dep_coverage_response.py
+++ b/fastfuels_sdk/v2/client_library/models/point_cloud_three_dep_coverage_response.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Self, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.three_dep_dataset_coverage import ThreeDepDatasetCoverage
+
+
+T = TypeVar("T", bound="PointCloudThreeDepCoverageResponse")
+
+
+@_attrs_define
+class PointCloudThreeDepCoverageResponse:
+    """Response model for the 3DEP point cloud coverage pre-flight check.
+
+    Attributes:
+        available (bool): Whether any 3DEP lidar covers this domain. When false, a create request for this domain is
+            rejected.
+        coverage_fraction (float): Fraction of the domain covered by 3DEP lidar, from `0.0` to `1.0`. This is the union
+            of every available acquisition, so it never exceeds 1.0 no matter how much the acquisitions overlap.
+        datasets (list[ThreeDepDatasetCoverage]): Acquisitions that would be read, in the order they would be used.
+            Empty when no lidar covers the domain.
+        estimated_point_count (int): Approximate total number of points a fetch would return, summed across
+            acquisitions.
+        point_budget (int): Maximum number of points a single fetch may return. Shrink the domain if the estimate
+            exceeds it.
+        exceeds_point_budget (bool): Whether the estimate is over `point_budget`. When true, a create request for this
+            domain is rejected, so check this before committing to a fetch.
+    """
+
+    available: bool
+    coverage_fraction: float
+    datasets: list[ThreeDepDatasetCoverage]
+    estimated_point_count: int
+    point_budget: int
+    exceeds_point_budget: bool
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        available = self.available
+
+        coverage_fraction = self.coverage_fraction
+
+        datasets = []
+        for datasets_item_data in self.datasets:
+            datasets_item = datasets_item_data.to_dict()
+            datasets.append(datasets_item)
+
+        estimated_point_count = self.estimated_point_count
+
+        point_budget = self.point_budget
+
+        exceeds_point_budget = self.exceeds_point_budget
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "available": available,
+                "coverage_fraction": coverage_fraction,
+                "datasets": datasets,
+                "estimated_point_count": estimated_point_count,
+                "point_budget": point_budget,
+                "exceeds_point_budget": exceeds_point_budget,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        from ..models.three_dep_dataset_coverage import ThreeDepDatasetCoverage
+
+        d = dict(src_dict)
+        available = d.pop("available")
+
+        coverage_fraction = d.pop("coverage_fraction")
+
+        datasets = []
+        _datasets = d.pop("datasets")
+        for datasets_item_data in _datasets:
+            datasets_item = ThreeDepDatasetCoverage.from_dict(datasets_item_data)
+
+            datasets.append(datasets_item)
+
+        estimated_point_count = d.pop("estimated_point_count")
+
+        point_budget = d.pop("point_budget")
+
+        exceeds_point_budget = d.pop("exceeds_point_budget")
+
+        point_cloud_three_dep_coverage_response = cls(
+            available=available,
+            coverage_fraction=coverage_fraction,
+            datasets=datasets,
+            estimated_point_count=estimated_point_count,
+            point_budget=point_budget,
+            exceeds_point_budget=exceeds_point_budget,
+        )
+
+        point_cloud_three_dep_coverage_response.additional_properties = d
+        return point_cloud_three_dep_coverage_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/point_cloud_upload_created_response.py
+++ b/fastfuels_sdk/v2/client_library/models/point_cloud_upload_created_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -59,7 +59,7 @@ class PointCloudUploadCreatedResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.point_cloud import PointCloud
         from ..models.point_cloud_upload_spec import PointCloudUploadSpec
 

--- a/fastfuels_sdk/v2/client_library/models/point_cloud_upload_spec.py
+++ b/fastfuels_sdk/v2/client_library/models/point_cloud_upload_spec.py
@@ -6,6 +6,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -78,7 +79,7 @@ class PointCloudUploadSpec:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.point_cloud_upload_spec_headers import PointCloudUploadSpecHeaders
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/point_cloud_upload_spec_headers.py
+++ b/fastfuels_sdk/v2/client_library/models/point_cloud_upload_spec_headers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -26,7 +26,7 @@ class PointCloudUploadSpecHeaders:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         point_cloud_upload_spec_headers = cls()
 

--- a/fastfuels_sdk/v2/client_library/models/polygon.py
+++ b/fastfuels_sdk/v2/client_library/models/polygon.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -81,7 +82,7 @@ class Polygon:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         type_ = cast(Literal["Polygon"], d.pop("type"))
         if type_ != "Polygon":

--- a/fastfuels_sdk/v2/client_library/models/quic_fire_export_alignment_domain_target.py
+++ b/fastfuels_sdk/v2/client_library/models/quic_fire_export_alignment_domain_target.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -32,7 +33,9 @@ class QUICFireExportAlignmentDomainTarget:
                 Default: 2.0.
             dy (float | Unset): Horizontal fire-grid cell size in y (UTM north-south), in meters. Must equal `dx` — non-
                 square fire-grid cells are not supported. Default: 2.0.
-            dz (float | Unset): Vertical fire-grid cell size, in meters. QUIC-Fire recommends 1 m. Default: 1.0.
+            dz (float | Unset): Vertical fire-grid cell size, in meters. QUIC-Fire recommends 1 m. Must equal the 3D tree
+                grid's voxelization vertical resolution (`resolution.vertical`): the exporter never resamples vertically, so a
+                mismatch is rejected with 422 rather than silently applied. Default: 1.0.
     """
 
     target: Literal["domain"] | Unset = "domain"
@@ -65,7 +68,7 @@ class QUICFireExportAlignmentDomainTarget:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         target = cast(Literal["domain"] | Unset, d.pop("target", UNSET))
         if target != "domain" and not isinstance(target, Unset):

--- a/fastfuels_sdk/v2/client_library/models/quic_fire_export_alignment_grid_target.py
+++ b/fastfuels_sdk/v2/client_library/models/quic_fire_export_alignment_grid_target.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -50,7 +51,7 @@ class QUICFireExportAlignmentGridTarget:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         target = cast(Literal["grid"], d.pop("target"))
         if target != "grid":

--- a/fastfuels_sdk/v2/client_library/models/quicfire_export_request.py
+++ b/fastfuels_sdk/v2/client_library/models/quicfire_export_request.py
@@ -5,6 +5,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -42,6 +43,17 @@ class QuicfireExportRequest:
     fire grid and cover its full extent; otherwise the request is rejected.
     The exporter only crops oversized roles by integer slicing — it never
     resamples or reprojects.
+
+    The output resolution is set here, on the export, via `alignment.dx`/`dy`
+    (default 2 m, QUIC-Fire's recommended value). It is a separate setting
+    from the resolution of each grid you built — changing your grids does not
+    change the export, and vice versa. Because the exporter never resamples,
+    every role grid must already be built at the fire-grid resolution. To
+    export at 1 m, for example, set `dx`/`dy` to 1 and build all role grids at
+    1 m (2D grids at 1 m via their `alignment.resolution`, and the 3D tree
+    grid at 1 m via `resolution.horizontal` — 3D grids cannot be resampled).
+    The same holds vertically: `alignment.dz` must equal the 3D tree grid's
+    `resolution.vertical`, or the request is rejected with 422.
 
         Attributes:
             canopy_bulk_density (FieldSource): A single physical quantity drawn from one band on one grid.
@@ -227,7 +239,7 @@ class QuicfireExportRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.field_source import FieldSource
         from ..models.quic_fire_export_alignment_domain_target import (
             QUICFireExportAlignmentDomainTarget,

--- a/fastfuels_sdk/v2/client_library/models/quota_exceeded_detail.py
+++ b/fastfuels_sdk/v2/client_library/models/quota_exceeded_detail.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, Self, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="QuotaExceededDetail")
+
+
+@_attrs_define
+class QuotaExceededDetail:
+    """Structured ``detail`` for a 429 quota rejection.
+
+    The flat ``{reason, quota, message, current, limit}`` shape is the template
+    for future structured error details: a machine-readable ``reason`` code plus
+    flat, typed context fields.
+
+        Attributes:
+            quota (str): The Quotas field that was exceeded.
+            message (str): Human-readable explanation and next steps.
+            current (int): The owner's current usage for this quota.
+            limit (int): The limit that was reached.
+            reason (str | Unset): Machine-readable error code. Default: 'QUOTA_EXCEEDED'.
+            window_reset_on (datetime.datetime | None | Unset): When a windowed (weekly) quota resets; absent for non-
+                windowed quotas.
+    """
+
+    quota: str
+    message: str
+    current: int
+    limit: int
+    reason: str | Unset = "QUOTA_EXCEEDED"
+    window_reset_on: datetime.datetime | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        quota = self.quota
+
+        message = self.message
+
+        current = self.current
+
+        limit = self.limit
+
+        reason = self.reason
+
+        window_reset_on: None | str | Unset
+        if isinstance(self.window_reset_on, Unset):
+            window_reset_on = UNSET
+        elif isinstance(self.window_reset_on, datetime.datetime):
+            window_reset_on = self.window_reset_on.isoformat()
+        else:
+            window_reset_on = self.window_reset_on
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "quota": quota,
+                "message": message,
+                "current": current,
+                "limit": limit,
+            }
+        )
+        if reason is not UNSET:
+            field_dict["reason"] = reason
+        if window_reset_on is not UNSET:
+            field_dict["window_reset_on"] = window_reset_on
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        d = dict(src_dict)
+        quota = d.pop("quota")
+
+        message = d.pop("message")
+
+        current = d.pop("current")
+
+        limit = d.pop("limit")
+
+        reason = d.pop("reason", UNSET)
+
+        def _parse_window_reset_on(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                window_reset_on_type_0 = datetime.datetime.fromisoformat(data)
+
+                return window_reset_on_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        window_reset_on = _parse_window_reset_on(d.pop("window_reset_on", UNSET))
+
+        quota_exceeded_detail = cls(
+            quota=quota,
+            message=message,
+            current=current,
+            limit=limit,
+            reason=reason,
+            window_reset_on=window_reset_on,
+        )
+
+        quota_exceeded_detail.additional_properties = d
+        return quota_exceeded_detail
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/quotas.py
+++ b/fastfuels_sdk/v2/client_library/models/quotas.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Self, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="Quotas")
+
+
+@_attrs_define
+class Quotas:
+    """Usage limits for an owner. Field defaults are the standard tier.
+
+    Attributes:
+        max_active_grids (int | Unset):  Default: 25.
+        max_active_exports (int | Unset):  Default: 10.
+        max_active_inventories (int | Unset):  Default: 10.
+        max_active_features (int | Unset):  Default: 10.
+        max_active_pointclouds (int | Unset):  Default: 5.
+        max_domains (int | Unset):  Default: 50.
+        max_grids (int | Unset):  Default: 1000.
+        max_exports (int | Unset):  Default: 500.
+        max_inventories (int | Unset):  Default: 500.
+        max_features (int | Unset):  Default: 500.
+        max_pointclouds (int | Unset):  Default: 50.
+        max_api_keys (int | Unset):  Default: 50.
+        max_applications (int | Unset):  Default: 5.
+        max_grid_storage_bytes (int | Unset):  Default: 53687091200.
+        max_export_storage_bytes (int | Unset):  Default: 26843545600.
+        max_inventory_storage_bytes (int | Unset):  Default: 10737418240.
+        max_feature_storage_bytes (int | Unset):  Default: 1073741824.
+        max_pointcloud_storage_bytes (int | Unset):  Default: 53687091200.
+        max_weekly_grid_dispatches (int | Unset): Grid worker jobs allowed per ISO week (Monday 00:00 UTC reset):
+            creates, modifications, duplicates, and uploads all count. Deleting grids does not refund spent budget. Default:
+            500.
+        max_weekly_export_dispatches (int | Unset): Export worker jobs allowed per ISO week (Monday 00:00 UTC reset).
+            Deleting exports does not refund spent budget. Default: 250.
+        max_weekly_inventory_dispatches (int | Unset): Inventory worker jobs allowed per ISO week (Monday 00:00 UTC
+            reset): creates, modifications, treatments, duplicates, and uploads all count. Deleting inventories does not
+            refund spent budget. Default: 250.
+        max_weekly_feature_dispatches (int | Unset): Feature worker jobs allowed per ISO week (Monday 00:00 UTC reset).
+            Synchronous layerset creates are exempt. Deleting features does not refund spent budget. Default: 250.
+        max_weekly_pointcloud_dispatches (int | Unset): Point cloud worker jobs allowed per ISO week (Monday 00:00 UTC
+            reset): each upload counts. Deleting point clouds does not refund spent budget. Default: 50.
+        resource_ttl_days (int | None | Unset):  Default: 180.
+        failed_resource_ttl_days (int | None | Unset):  Default: 14.
+    """
+
+    max_active_grids: int | Unset = 25
+    max_active_exports: int | Unset = 10
+    max_active_inventories: int | Unset = 10
+    max_active_features: int | Unset = 10
+    max_active_pointclouds: int | Unset = 5
+    max_domains: int | Unset = 50
+    max_grids: int | Unset = 1000
+    max_exports: int | Unset = 500
+    max_inventories: int | Unset = 500
+    max_features: int | Unset = 500
+    max_pointclouds: int | Unset = 50
+    max_api_keys: int | Unset = 50
+    max_applications: int | Unset = 5
+    max_grid_storage_bytes: int | Unset = 53687091200
+    max_export_storage_bytes: int | Unset = 26843545600
+    max_inventory_storage_bytes: int | Unset = 10737418240
+    max_feature_storage_bytes: int | Unset = 1073741824
+    max_pointcloud_storage_bytes: int | Unset = 53687091200
+    max_weekly_grid_dispatches: int | Unset = 500
+    max_weekly_export_dispatches: int | Unset = 250
+    max_weekly_inventory_dispatches: int | Unset = 250
+    max_weekly_feature_dispatches: int | Unset = 250
+    max_weekly_pointcloud_dispatches: int | Unset = 50
+    resource_ttl_days: int | None | Unset = 180
+    failed_resource_ttl_days: int | None | Unset = 14
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        max_active_grids = self.max_active_grids
+
+        max_active_exports = self.max_active_exports
+
+        max_active_inventories = self.max_active_inventories
+
+        max_active_features = self.max_active_features
+
+        max_active_pointclouds = self.max_active_pointclouds
+
+        max_domains = self.max_domains
+
+        max_grids = self.max_grids
+
+        max_exports = self.max_exports
+
+        max_inventories = self.max_inventories
+
+        max_features = self.max_features
+
+        max_pointclouds = self.max_pointclouds
+
+        max_api_keys = self.max_api_keys
+
+        max_applications = self.max_applications
+
+        max_grid_storage_bytes = self.max_grid_storage_bytes
+
+        max_export_storage_bytes = self.max_export_storage_bytes
+
+        max_inventory_storage_bytes = self.max_inventory_storage_bytes
+
+        max_feature_storage_bytes = self.max_feature_storage_bytes
+
+        max_pointcloud_storage_bytes = self.max_pointcloud_storage_bytes
+
+        max_weekly_grid_dispatches = self.max_weekly_grid_dispatches
+
+        max_weekly_export_dispatches = self.max_weekly_export_dispatches
+
+        max_weekly_inventory_dispatches = self.max_weekly_inventory_dispatches
+
+        max_weekly_feature_dispatches = self.max_weekly_feature_dispatches
+
+        max_weekly_pointcloud_dispatches = self.max_weekly_pointcloud_dispatches
+
+        resource_ttl_days: int | None | Unset
+        if isinstance(self.resource_ttl_days, Unset):
+            resource_ttl_days = UNSET
+        else:
+            resource_ttl_days = self.resource_ttl_days
+
+        failed_resource_ttl_days: int | None | Unset
+        if isinstance(self.failed_resource_ttl_days, Unset):
+            failed_resource_ttl_days = UNSET
+        else:
+            failed_resource_ttl_days = self.failed_resource_ttl_days
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if max_active_grids is not UNSET:
+            field_dict["max_active_grids"] = max_active_grids
+        if max_active_exports is not UNSET:
+            field_dict["max_active_exports"] = max_active_exports
+        if max_active_inventories is not UNSET:
+            field_dict["max_active_inventories"] = max_active_inventories
+        if max_active_features is not UNSET:
+            field_dict["max_active_features"] = max_active_features
+        if max_active_pointclouds is not UNSET:
+            field_dict["max_active_pointclouds"] = max_active_pointclouds
+        if max_domains is not UNSET:
+            field_dict["max_domains"] = max_domains
+        if max_grids is not UNSET:
+            field_dict["max_grids"] = max_grids
+        if max_exports is not UNSET:
+            field_dict["max_exports"] = max_exports
+        if max_inventories is not UNSET:
+            field_dict["max_inventories"] = max_inventories
+        if max_features is not UNSET:
+            field_dict["max_features"] = max_features
+        if max_pointclouds is not UNSET:
+            field_dict["max_pointclouds"] = max_pointclouds
+        if max_api_keys is not UNSET:
+            field_dict["max_api_keys"] = max_api_keys
+        if max_applications is not UNSET:
+            field_dict["max_applications"] = max_applications
+        if max_grid_storage_bytes is not UNSET:
+            field_dict["max_grid_storage_bytes"] = max_grid_storage_bytes
+        if max_export_storage_bytes is not UNSET:
+            field_dict["max_export_storage_bytes"] = max_export_storage_bytes
+        if max_inventory_storage_bytes is not UNSET:
+            field_dict["max_inventory_storage_bytes"] = max_inventory_storage_bytes
+        if max_feature_storage_bytes is not UNSET:
+            field_dict["max_feature_storage_bytes"] = max_feature_storage_bytes
+        if max_pointcloud_storage_bytes is not UNSET:
+            field_dict["max_pointcloud_storage_bytes"] = max_pointcloud_storage_bytes
+        if max_weekly_grid_dispatches is not UNSET:
+            field_dict["max_weekly_grid_dispatches"] = max_weekly_grid_dispatches
+        if max_weekly_export_dispatches is not UNSET:
+            field_dict["max_weekly_export_dispatches"] = max_weekly_export_dispatches
+        if max_weekly_inventory_dispatches is not UNSET:
+            field_dict["max_weekly_inventory_dispatches"] = (
+                max_weekly_inventory_dispatches
+            )
+        if max_weekly_feature_dispatches is not UNSET:
+            field_dict["max_weekly_feature_dispatches"] = max_weekly_feature_dispatches
+        if max_weekly_pointcloud_dispatches is not UNSET:
+            field_dict["max_weekly_pointcloud_dispatches"] = (
+                max_weekly_pointcloud_dispatches
+            )
+        if resource_ttl_days is not UNSET:
+            field_dict["resource_ttl_days"] = resource_ttl_days
+        if failed_resource_ttl_days is not UNSET:
+            field_dict["failed_resource_ttl_days"] = failed_resource_ttl_days
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        d = dict(src_dict)
+        max_active_grids = d.pop("max_active_grids", UNSET)
+
+        max_active_exports = d.pop("max_active_exports", UNSET)
+
+        max_active_inventories = d.pop("max_active_inventories", UNSET)
+
+        max_active_features = d.pop("max_active_features", UNSET)
+
+        max_active_pointclouds = d.pop("max_active_pointclouds", UNSET)
+
+        max_domains = d.pop("max_domains", UNSET)
+
+        max_grids = d.pop("max_grids", UNSET)
+
+        max_exports = d.pop("max_exports", UNSET)
+
+        max_inventories = d.pop("max_inventories", UNSET)
+
+        max_features = d.pop("max_features", UNSET)
+
+        max_pointclouds = d.pop("max_pointclouds", UNSET)
+
+        max_api_keys = d.pop("max_api_keys", UNSET)
+
+        max_applications = d.pop("max_applications", UNSET)
+
+        max_grid_storage_bytes = d.pop("max_grid_storage_bytes", UNSET)
+
+        max_export_storage_bytes = d.pop("max_export_storage_bytes", UNSET)
+
+        max_inventory_storage_bytes = d.pop("max_inventory_storage_bytes", UNSET)
+
+        max_feature_storage_bytes = d.pop("max_feature_storage_bytes", UNSET)
+
+        max_pointcloud_storage_bytes = d.pop("max_pointcloud_storage_bytes", UNSET)
+
+        max_weekly_grid_dispatches = d.pop("max_weekly_grid_dispatches", UNSET)
+
+        max_weekly_export_dispatches = d.pop("max_weekly_export_dispatches", UNSET)
+
+        max_weekly_inventory_dispatches = d.pop(
+            "max_weekly_inventory_dispatches", UNSET
+        )
+
+        max_weekly_feature_dispatches = d.pop("max_weekly_feature_dispatches", UNSET)
+
+        max_weekly_pointcloud_dispatches = d.pop(
+            "max_weekly_pointcloud_dispatches", UNSET
+        )
+
+        def _parse_resource_ttl_days(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        resource_ttl_days = _parse_resource_ttl_days(d.pop("resource_ttl_days", UNSET))
+
+        def _parse_failed_resource_ttl_days(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        failed_resource_ttl_days = _parse_failed_resource_ttl_days(
+            d.pop("failed_resource_ttl_days", UNSET)
+        )
+
+        quotas = cls(
+            max_active_grids=max_active_grids,
+            max_active_exports=max_active_exports,
+            max_active_inventories=max_active_inventories,
+            max_active_features=max_active_features,
+            max_active_pointclouds=max_active_pointclouds,
+            max_domains=max_domains,
+            max_grids=max_grids,
+            max_exports=max_exports,
+            max_inventories=max_inventories,
+            max_features=max_features,
+            max_pointclouds=max_pointclouds,
+            max_api_keys=max_api_keys,
+            max_applications=max_applications,
+            max_grid_storage_bytes=max_grid_storage_bytes,
+            max_export_storage_bytes=max_export_storage_bytes,
+            max_inventory_storage_bytes=max_inventory_storage_bytes,
+            max_feature_storage_bytes=max_feature_storage_bytes,
+            max_pointcloud_storage_bytes=max_pointcloud_storage_bytes,
+            max_weekly_grid_dispatches=max_weekly_grid_dispatches,
+            max_weekly_export_dispatches=max_weekly_export_dispatches,
+            max_weekly_inventory_dispatches=max_weekly_inventory_dispatches,
+            max_weekly_feature_dispatches=max_weekly_feature_dispatches,
+            max_weekly_pointcloud_dispatches=max_weekly_pointcloud_dispatches,
+            resource_ttl_days=resource_ttl_days,
+            failed_resource_ttl_days=failed_resource_ttl_days,
+        )
+
+        quotas.additional_properties = d
+        return quotas
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/remove_action.py
+++ b/fastfuels_sdk/v2/client_library/models/remove_action.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -39,7 +40,7 @@ class RemoveAction:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         modifier = cast(Literal["remove"] | Unset, d.pop("modifier", UNSET))
         if modifier != "remove" and not isinstance(modifier, Unset):

--- a/fastfuels_sdk/v2/client_library/models/resolution_3d.py
+++ b/fastfuels_sdk/v2/client_library/models/resolution_3d.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, Self, TypeVar
 
 from attrs import define as _attrs_define
 
@@ -40,7 +40,7 @@ class Resolution3D:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         horizontal = d.pop("horizontal")
 

--- a/fastfuels_sdk/v2/client_library/models/sparse_grid_data.py
+++ b/fastfuels_sdk/v2/client_library/models/sparse_grid_data.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -58,7 +59,7 @@ class SparseGridData:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         format_ = cast(Literal["sparse"], d.pop("format"))
         if format_ != "sparse":

--- a/fastfuels_sdk/v2/client_library/models/stem_isolation_lmf.py
+++ b/fastfuels_sdk/v2/client_library/models/stem_isolation_lmf.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -20,14 +21,20 @@ T = TypeVar("T", bound="StemIsolationLmf")
 class StemIsolationLmf:
     """Parameters for Local Maximum Filter (LMF) stem isolation.
 
-    Attributes:
-        name (Literal['lmf'] | Unset):  Default: 'lmf'.
-        min_height (float | Unset): Minimum height threshold (in CHM units) for a treetop. Default: 2.0.
-        footprint_size (int | Unset): Diameter of the circular footprint in pixels. Must be an odd integer. Default: 3.
+    When set, ``max_height`` must be greater than ``min_height``.
+
+        Attributes:
+            name (Literal['lmf'] | Unset):  Default: 'lmf'.
+            min_height (float | Unset): Minimum height threshold (in meters) for a treetop. Default: 2.0.
+            max_height (float | None | Unset): Maximum height threshold (in meters) for a treetop. CHM returns taller than
+                this are treated as artifacts (e.g. LiDAR noise spikes) and excluded before detection. Defaults to 120, above
+                the tallest known tree; set to null to disable the ceiling. Default: 120.0.
+            footprint_size (int | Unset): Diameter of the circular footprint in pixels. Must be an odd integer. Default: 3.
     """
 
     name: Literal["lmf"] | Unset = "lmf"
     min_height: float | Unset = 2.0
+    max_height: float | None | Unset = 120.0
     footprint_size: int | Unset = 3
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -35,6 +42,12 @@ class StemIsolationLmf:
         name = self.name
 
         min_height = self.min_height
+
+        max_height: float | None | Unset
+        if isinstance(self.max_height, Unset):
+            max_height = UNSET
+        else:
+            max_height = self.max_height
 
         footprint_size = self.footprint_size
 
@@ -45,13 +58,15 @@ class StemIsolationLmf:
             field_dict["name"] = name
         if min_height is not UNSET:
             field_dict["min_height"] = min_height
+        if max_height is not UNSET:
+            field_dict["max_height"] = max_height
         if footprint_size is not UNSET:
             field_dict["footprint_size"] = footprint_size
 
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         name = cast(Literal["lmf"] | Unset, d.pop("name", UNSET))
         if name != "lmf" and not isinstance(name, Unset):
@@ -59,11 +74,21 @@ class StemIsolationLmf:
 
         min_height = d.pop("min_height", UNSET)
 
+        def _parse_max_height(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        max_height = _parse_max_height(d.pop("max_height", UNSET))
+
         footprint_size = d.pop("footprint_size", UNSET)
 
         stem_isolation_lmf = cls(
             name=name,
             min_height=min_height,
+            max_height=max_height,
             footprint_size=footprint_size,
         )
 

--- a/fastfuels_sdk/v2/client_library/models/stem_isolation_vwf.py
+++ b/fastfuels_sdk/v2/client_library/models/stem_isolation_vwf.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -20,18 +21,24 @@ T = TypeVar("T", bound="StemIsolationVwf")
 class StemIsolationVwf:
     """Parameters for Variable Window Filter (VWF) stem isolation.
 
-    Attributes:
-        name (Literal['vwf'] | Unset):  Default: 'vwf'.
-        min_height (float | Unset): Minimum height threshold (in CHM units) for a treetop. Default: 2.0.
-        spatial_resolution (float | None | Unset): Spatial resolution of the CHM. If omitted, it will be automatically
-            inferred from the source grid metadata.
-        crown_ratio (float | Unset): Multiplier used to dynamically scale the search window based on pixel height.
-            Default: 0.1.
-        crown_offset (float | Unset): Constant offset (in meters) added to the dynamic search window. Default: 1.0.
+    When set, ``max_height`` must be greater than ``min_height``.
+
+        Attributes:
+            name (Literal['vwf'] | Unset):  Default: 'vwf'.
+            min_height (float | Unset): Minimum height threshold (in meters) for a treetop. Default: 2.0.
+            max_height (float | None | Unset): Maximum height threshold (in meters) for a treetop. CHM returns taller than
+                this are treated as artifacts (e.g. LiDAR noise spikes) and excluded before detection. Defaults to 120, above
+                the tallest known tree; set to null to disable the ceiling. Default: 120.0.
+            spatial_resolution (float | None | Unset): Spatial resolution of the CHM. If omitted, it will be automatically
+                inferred from the source grid metadata.
+            crown_ratio (float | Unset): Multiplier used to dynamically scale the search window based on pixel height.
+                Default: 0.1.
+            crown_offset (float | Unset): Constant offset (in meters) added to the dynamic search window. Default: 1.0.
     """
 
     name: Literal["vwf"] | Unset = "vwf"
     min_height: float | Unset = 2.0
+    max_height: float | None | Unset = 120.0
     spatial_resolution: float | None | Unset = UNSET
     crown_ratio: float | Unset = 0.1
     crown_offset: float | Unset = 1.0
@@ -41,6 +48,12 @@ class StemIsolationVwf:
         name = self.name
 
         min_height = self.min_height
+
+        max_height: float | None | Unset
+        if isinstance(self.max_height, Unset):
+            max_height = UNSET
+        else:
+            max_height = self.max_height
 
         spatial_resolution: float | None | Unset
         if isinstance(self.spatial_resolution, Unset):
@@ -59,6 +72,8 @@ class StemIsolationVwf:
             field_dict["name"] = name
         if min_height is not UNSET:
             field_dict["min_height"] = min_height
+        if max_height is not UNSET:
+            field_dict["max_height"] = max_height
         if spatial_resolution is not UNSET:
             field_dict["spatial_resolution"] = spatial_resolution
         if crown_ratio is not UNSET:
@@ -69,13 +84,22 @@ class StemIsolationVwf:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         name = cast(Literal["vwf"] | Unset, d.pop("name", UNSET))
         if name != "vwf" and not isinstance(name, Unset):
             raise ValueError(f"name must match const 'vwf', got '{name}'")
 
         min_height = d.pop("min_height", UNSET)
+
+        def _parse_max_height(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        max_height = _parse_max_height(d.pop("max_height", UNSET))
 
         def _parse_spatial_resolution(data: object) -> float | None | Unset:
             if data is None:
@@ -95,6 +119,7 @@ class StemIsolationVwf:
         stem_isolation_vwf = cls(
             name=name,
             min_height=min_height,
+            max_height=max_height,
             spatial_resolution=spatial_resolution,
             crown_ratio=crown_ratio,
             crown_offset=crown_offset,

--- a/fastfuels_sdk/v2/client_library/models/three_dep_coverage_response.py
+++ b/fastfuels_sdk/v2/client_library/models/three_dep_coverage_response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -65,7 +65,7 @@ class ThreeDepCoverageResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         resolution = ThreeDepResolution(d.pop("resolution"))
 

--- a/fastfuels_sdk/v2/client_library/models/three_dep_dataset_coverage.py
+++ b/fastfuels_sdk/v2/client_library/models/three_dep_dataset_coverage.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Self, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ThreeDepDatasetCoverage")
+
+
+@_attrs_define
+class ThreeDepDatasetCoverage:
+    """One 3DEP acquisition available over a domain, and what it would supply.
+
+    Attributes:
+        name (str): USGS acquisition name. Pass it in `datasets` on a create request to pin the fetch to this
+            acquisition.
+        url (str): Location of the acquisition's Entwine Point Tile index.
+        contribution_fraction (float): Fraction of the domain this acquisition would supply, from `0.0` to `1.0`.
+            Acquisitions overlap each other freely, so this is the share left over after the acquisitions listed before it
+            have taken their part — not the raw overlap. The values are therefore disjoint and sum to `coverage_fraction`.
+        estimated_density (float): Average point density of the acquisition, in points per square metre, computed over
+            its full published extent.
+        estimated_points (int): Approximate number of points this acquisition would contribute. Derived from its density
+            and the area it covers, so treat it as an order-of-magnitude figure rather than an exact count.
+    """
+
+    name: str
+    url: str
+    contribution_fraction: float
+    estimated_density: float
+    estimated_points: int
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        name = self.name
+
+        url = self.url
+
+        contribution_fraction = self.contribution_fraction
+
+        estimated_density = self.estimated_density
+
+        estimated_points = self.estimated_points
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "name": name,
+                "url": url,
+                "contribution_fraction": contribution_fraction,
+                "estimated_density": estimated_density,
+                "estimated_points": estimated_points,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        d = dict(src_dict)
+        name = d.pop("name")
+
+        url = d.pop("url")
+
+        contribution_fraction = d.pop("contribution_fraction")
+
+        estimated_density = d.pop("estimated_density")
+
+        estimated_points = d.pop("estimated_points")
+
+        three_dep_dataset_coverage = cls(
+            name=name,
+            url=url,
+            contribution_fraction=contribution_fraction,
+            estimated_density=estimated_density,
+            estimated_points=estimated_points,
+        )
+
+        three_dep_dataset_coverage.additional_properties = d
+        return three_dep_dataset_coverage
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/topography_three_dep_coverage_response.py
+++ b/fastfuels_sdk/v2/client_library/models/topography_three_dep_coverage_response.py
@@ -9,11 +9,11 @@ from attrs import field as _attrs_field
 from ..models.three_dep_resolution import ThreeDepResolution
 from ..types import UNSET, Unset
 
-T = TypeVar("T", bound="ThreeDepCoverageResponse")
+T = TypeVar("T", bound="TopographyThreeDepCoverageResponse")
 
 
 @_attrs_define
-class ThreeDepCoverageResponse:
+class TopographyThreeDepCoverageResponse:
     """Response model for 3DEP tile coverage pre-flight check.
 
     Attributes:
@@ -92,7 +92,7 @@ class ThreeDepCoverageResponse:
 
         acquisition_dates = _parse_acquisition_dates(d.pop("acquisition_dates", UNSET))
 
-        three_dep_coverage_response = cls(
+        topography_three_dep_coverage_response = cls(
             resolution=resolution,
             available=available,
             tile_count=tile_count,
@@ -100,8 +100,8 @@ class ThreeDepCoverageResponse:
             acquisition_dates=acquisition_dates,
         )
 
-        three_dep_coverage_response.additional_properties = d
-        return three_dep_coverage_response
+        topography_three_dep_coverage_response.additional_properties = d
+        return topography_three_dep_coverage_response
 
     @property
     def additional_keys(self) -> list[str]:

--- a/fastfuels_sdk/v2/client_library/models/tree_band.py
+++ b/fastfuels_sdk/v2/client_library/models/tree_band.py
@@ -10,6 +10,7 @@ class TreeBand(str, Enum):
     BULK_DENSITY_FOLIAGE_LIVE = "bulk_density.foliage.live"
     FUEL_MOISTURE_DEAD = "fuel_moisture.dead"
     FUEL_MOISTURE_LIVE = "fuel_moisture.live"
+    LEAF_AREA_DENSITY = "leaf_area_density"
     SAVR_FOLIAGE = "savr.foliage"
     SPCD = "spcd"
     TREE_ID = "tree_id"

--- a/fastfuels_sdk/v2/client_library/models/tree_forestry_metrics.py
+++ b/fastfuels_sdk/v2/client_library/models/tree_forestry_metrics.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    Self,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.fia_species_group_share import FIASpeciesGroupShare
+
+
+T = TypeVar("T", bound="TreeForestryMetrics")
+
+
+@_attrs_define
+class TreeForestryMetrics:
+    """Stand-level forestry scalars for a tree inventory.
+
+    Attributes:
+        type_ (Literal['tree']):
+        tree_count (int): Total trees in the inventory.
+        basal_area_per_area (float | None): Stand basal area divided by domain area. Unit: ft**2/acre.
+        tree_density (float | None): Trees per unit domain area (TPA). Unit: 1/acre.
+        quadratic_mean_diameter (float | None): Quadratic mean DBH. Unit: in.
+        dominant_species_groups (list[FIASpeciesGroupShare] | Unset): The N FIA species groups with the largest basal
+            area share, sorted descending (N defaults to 5). Only the top N are returned; any remaining groups are omitted,
+            so the listed shares may sum to less than 1.
+    """
+
+    type_: Literal["tree"]
+    tree_count: int
+    basal_area_per_area: float | None
+    tree_density: float | None
+    quadratic_mean_diameter: float | None
+    dominant_species_groups: list[FIASpeciesGroupShare] | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
+        tree_count = self.tree_count
+
+        basal_area_per_area: float | None
+        basal_area_per_area = self.basal_area_per_area
+
+        tree_density: float | None
+        tree_density = self.tree_density
+
+        quadratic_mean_diameter: float | None
+        quadratic_mean_diameter = self.quadratic_mean_diameter
+
+        dominant_species_groups: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.dominant_species_groups, Unset):
+            dominant_species_groups = []
+            for dominant_species_groups_item_data in self.dominant_species_groups:
+                dominant_species_groups_item = (
+                    dominant_species_groups_item_data.to_dict()
+                )
+                dominant_species_groups.append(dominant_species_groups_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "type": type_,
+                "tree_count": tree_count,
+                "basal_area_per_area": basal_area_per_area,
+                "tree_density": tree_density,
+                "quadratic_mean_diameter": quadratic_mean_diameter,
+            }
+        )
+        if dominant_species_groups is not UNSET:
+            field_dict["dominant_species_groups"] = dominant_species_groups
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        from ..models.fia_species_group_share import FIASpeciesGroupShare
+
+        d = dict(src_dict)
+        type_ = cast(Literal["tree"], d.pop("type"))
+        if type_ != "tree":
+            raise ValueError(f"type must match const 'tree', got '{type_}'")
+
+        tree_count = d.pop("tree_count")
+
+        def _parse_basal_area_per_area(data: object) -> float | None:
+            if data is None:
+                return data
+            return cast(float | None, data)
+
+        basal_area_per_area = _parse_basal_area_per_area(d.pop("basal_area_per_area"))
+
+        def _parse_tree_density(data: object) -> float | None:
+            if data is None:
+                return data
+            return cast(float | None, data)
+
+        tree_density = _parse_tree_density(d.pop("tree_density"))
+
+        def _parse_quadratic_mean_diameter(data: object) -> float | None:
+            if data is None:
+                return data
+            return cast(float | None, data)
+
+        quadratic_mean_diameter = _parse_quadratic_mean_diameter(
+            d.pop("quadratic_mean_diameter")
+        )
+
+        _dominant_species_groups = d.pop("dominant_species_groups", UNSET)
+        dominant_species_groups: list[FIASpeciesGroupShare] | Unset = UNSET
+        if _dominant_species_groups is not UNSET:
+            dominant_species_groups = []
+            for dominant_species_groups_item_data in _dominant_species_groups:
+                dominant_species_groups_item = FIASpeciesGroupShare.from_dict(
+                    dominant_species_groups_item_data
+                )
+
+                dominant_species_groups.append(dominant_species_groups_item)
+
+        tree_forestry_metrics = cls(
+            type_=type_,
+            tree_count=tree_count,
+            basal_area_per_area=basal_area_per_area,
+            tree_density=tree_density,
+            quadratic_mean_diameter=quadratic_mean_diameter,
+            dominant_species_groups=dominant_species_groups,
+        )
+
+        tree_forestry_metrics.additional_properties = d
+        return tree_forestry_metrics
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/uniform_band_input.py
+++ b/fastfuels_sdk/v2/client_library/models/uniform_band_input.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -45,7 +45,7 @@ class UniformBandInput:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         key = UniformBand(d.pop("key"))
 

--- a/fastfuels_sdk/v2/client_library/models/uniform_moisture_value.py
+++ b/fastfuels_sdk/v2/client_library/models/uniform_moisture_value.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
+    Self,
     TypeVar,
     cast,
 )
@@ -45,7 +46,7 @@ class UniformMoistureValue:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         method = cast(Literal["uniform"] | Unset, d.pop("method", UNSET))
         if method != "uniform" and not isinstance(method, Unset):

--- a/fastfuels_sdk/v2/client_library/models/update_application_request.py
+++ b/fastfuels_sdk/v2/client_library/models/update_application_request.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
-from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
@@ -22,7 +21,6 @@ class UpdateApplicationRequest:
 
     name: None | str | Unset = UNSET
     description: None | str | Unset = UNSET
-    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         name: None | str | Unset
@@ -38,7 +36,7 @@ class UpdateApplicationRequest:
             description = self.description
 
         field_dict: dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
+
         field_dict.update({})
         if name is not UNSET:
             field_dict["name"] = name
@@ -48,7 +46,7 @@ class UpdateApplicationRequest:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
 
         def _parse_name(data: object) -> None | str | Unset:
@@ -74,21 +72,4 @@ class UpdateApplicationRequest:
             description=description,
         )
 
-        update_application_request.additional_properties = d
         return update_application_request
-
-    @property
-    def additional_keys(self) -> list[str]:
-        return list(self.additional_properties.keys())
-
-    def __getitem__(self, key: str) -> Any:
-        return self.additional_properties[key]
-
-    def __setitem__(self, key: str, value: Any) -> None:
-        self.additional_properties[key] = value
-
-    def __delitem__(self, key: str) -> None:
-        del self.additional_properties[key]
-
-    def __contains__(self, key: str) -> bool:
-        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/update_domain_request_body.py
+++ b/fastfuels_sdk/v2/client_library/models/update_domain_request_body.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -83,7 +83,7 @@ class UpdateDomainRequestBody:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         from ..models.domain_style import DomainStyle
 
         d = dict(src_dict)

--- a/fastfuels_sdk/v2/client_library/models/update_export_request_body.py
+++ b/fastfuels_sdk/v2/client_library/models/update_export_request_body.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -61,7 +61,7 @@ class UpdateExportRequestBody:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
 
         def _parse_name(data: object) -> None | str | Unset:

--- a/fastfuels_sdk/v2/client_library/models/update_feature_request_body.py
+++ b/fastfuels_sdk/v2/client_library/models/update_feature_request_body.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -61,7 +61,7 @@ class UpdateFeatureRequestBody:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
 
         def _parse_name(data: object) -> None | str | Unset:

--- a/fastfuels_sdk/v2/client_library/models/update_grid_request_body.py
+++ b/fastfuels_sdk/v2/client_library/models/update_grid_request_body.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -61,7 +61,7 @@ class UpdateGridRequestBody:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
 
         def _parse_name(data: object) -> None | str | Unset:

--- a/fastfuels_sdk/v2/client_library/models/update_inventory_request_body.py
+++ b/fastfuels_sdk/v2/client_library/models/update_inventory_request_body.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -61,7 +61,7 @@ class UpdateInventoryRequestBody:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
 
         def _parse_name(data: object) -> None | str | Unset:

--- a/fastfuels_sdk/v2/client_library/models/update_point_cloud_request_body.py
+++ b/fastfuels_sdk/v2/client_library/models/update_point_cloud_request_body.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -65,7 +65,7 @@ class UpdatePointCloudRequestBody:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
 
         def _parse_name(data: object) -> None | str | Unset:

--- a/fastfuels_sdk/v2/client_library/models/upload_band_definition.py
+++ b/fastfuels_sdk/v2/client_library/models/upload_band_definition.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -53,7 +53,7 @@ class UploadBandDefinition:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         key = d.pop("key")
 

--- a/fastfuels_sdk/v2/client_library/models/usage.py
+++ b/fastfuels_sdk/v2/client_library/models/usage.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Self, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.count_usage import CountUsage
+    from ..models.job_resource_usage import JobResourceUsage
+    from ..models.usage_lifecycle import UsageLifecycle
+
+
+T = TypeVar("T", bound="Usage")
+
+
+@_attrs_define
+class Usage:
+    """An owner's current usage against their resolved limits.
+
+    Attributes:
+        grids (JobResourceUsage): Usage for a resource type that produces jobs and stores artifacts.
+        exports (JobResourceUsage): Usage for a resource type that produces jobs and stores artifacts.
+        inventories (JobResourceUsage): Usage for a resource type that produces jobs and stores artifacts.
+        features (JobResourceUsage): Usage for a resource type that produces jobs and stores artifacts.
+        pointclouds (JobResourceUsage): Usage for a resource type that produces jobs and stores artifacts.
+        domains (CountUsage): Usage for a count-only resource type (domains, applications, API keys).
+        applications (CountUsage): Usage for a count-only resource type (domains, applications, API keys).
+        api_keys (CountUsage): Usage for a count-only resource type (domains, applications, API keys).
+        lifecycle (UsageLifecycle): Retention policy in effect for the owner's resources.
+    """
+
+    grids: JobResourceUsage
+    exports: JobResourceUsage
+    inventories: JobResourceUsage
+    features: JobResourceUsage
+    pointclouds: JobResourceUsage
+    domains: CountUsage
+    applications: CountUsage
+    api_keys: CountUsage
+    lifecycle: UsageLifecycle
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        grids = self.grids.to_dict()
+
+        exports = self.exports.to_dict()
+
+        inventories = self.inventories.to_dict()
+
+        features = self.features.to_dict()
+
+        pointclouds = self.pointclouds.to_dict()
+
+        domains = self.domains.to_dict()
+
+        applications = self.applications.to_dict()
+
+        api_keys = self.api_keys.to_dict()
+
+        lifecycle = self.lifecycle.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "grids": grids,
+                "exports": exports,
+                "inventories": inventories,
+                "features": features,
+                "pointclouds": pointclouds,
+                "domains": domains,
+                "applications": applications,
+                "api_keys": api_keys,
+                "lifecycle": lifecycle,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        from ..models.count_usage import CountUsage
+        from ..models.job_resource_usage import JobResourceUsage
+        from ..models.usage_lifecycle import UsageLifecycle
+
+        d = dict(src_dict)
+        grids = JobResourceUsage.from_dict(d.pop("grids"))
+
+        exports = JobResourceUsage.from_dict(d.pop("exports"))
+
+        inventories = JobResourceUsage.from_dict(d.pop("inventories"))
+
+        features = JobResourceUsage.from_dict(d.pop("features"))
+
+        pointclouds = JobResourceUsage.from_dict(d.pop("pointclouds"))
+
+        domains = CountUsage.from_dict(d.pop("domains"))
+
+        applications = CountUsage.from_dict(d.pop("applications"))
+
+        api_keys = CountUsage.from_dict(d.pop("api_keys"))
+
+        lifecycle = UsageLifecycle.from_dict(d.pop("lifecycle"))
+
+        usage = cls(
+            grids=grids,
+            exports=exports,
+            inventories=inventories,
+            features=features,
+            pointclouds=pointclouds,
+            domains=domains,
+            applications=applications,
+            api_keys=api_keys,
+            lifecycle=lifecycle,
+        )
+
+        usage.additional_properties = d
+        return usage
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/usage_count.py
+++ b/fastfuels_sdk/v2/client_library/models/usage_count.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Self, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="UsageCount")
+
+
+@_attrs_define
+class UsageCount:
+    """A count-based usage/limit pair (resources or concurrent jobs).
+
+    Attributes:
+        usage (int): Current count.
+        limit (int): The limit this count is measured against.
+    """
+
+    usage: int
+    limit: int
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        usage = self.usage
+
+        limit = self.limit
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "usage": usage,
+                "limit": limit,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        d = dict(src_dict)
+        usage = d.pop("usage")
+
+        limit = d.pop("limit")
+
+        usage_count = cls(
+            usage=usage,
+            limit=limit,
+        )
+
+        usage_count.additional_properties = d
+        return usage_count
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/usage_lifecycle.py
+++ b/fastfuels_sdk/v2/client_library/models/usage_lifecycle.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, Self, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="UsageLifecycle")
+
+
+@_attrs_define
+class UsageLifecycle:
+    """Retention policy in effect for the owner's resources.
+
+    Attributes:
+        resource_ttl_days (int | None): Days a resource is retained after last modification; null never expires.
+        failed_resource_ttl_days (int | None): Shorter retention for failed resources; null never expires.
+        next_expiry_on (datetime.datetime | None | Unset): When the owner's next resource is scheduled to expire.
+            Populated once retention enforcement ships.
+    """
+
+    resource_ttl_days: int | None
+    failed_resource_ttl_days: int | None
+    next_expiry_on: datetime.datetime | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        resource_ttl_days: int | None
+        resource_ttl_days = self.resource_ttl_days
+
+        failed_resource_ttl_days: int | None
+        failed_resource_ttl_days = self.failed_resource_ttl_days
+
+        next_expiry_on: None | str | Unset
+        if isinstance(self.next_expiry_on, Unset):
+            next_expiry_on = UNSET
+        elif isinstance(self.next_expiry_on, datetime.datetime):
+            next_expiry_on = self.next_expiry_on.isoformat()
+        else:
+            next_expiry_on = self.next_expiry_on
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "resource_ttl_days": resource_ttl_days,
+                "failed_resource_ttl_days": failed_resource_ttl_days,
+            }
+        )
+        if next_expiry_on is not UNSET:
+            field_dict["next_expiry_on"] = next_expiry_on
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        d = dict(src_dict)
+
+        def _parse_resource_ttl_days(data: object) -> int | None:
+            if data is None:
+                return data
+            return cast(int | None, data)
+
+        resource_ttl_days = _parse_resource_ttl_days(d.pop("resource_ttl_days"))
+
+        def _parse_failed_resource_ttl_days(data: object) -> int | None:
+            if data is None:
+                return data
+            return cast(int | None, data)
+
+        failed_resource_ttl_days = _parse_failed_resource_ttl_days(
+            d.pop("failed_resource_ttl_days")
+        )
+
+        def _parse_next_expiry_on(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                next_expiry_on_type_0 = datetime.datetime.fromisoformat(data)
+
+                return next_expiry_on_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        next_expiry_on = _parse_next_expiry_on(d.pop("next_expiry_on", UNSET))
+
+        usage_lifecycle = cls(
+            resource_ttl_days=resource_ttl_days,
+            failed_resource_ttl_days=failed_resource_ttl_days,
+            next_expiry_on=next_expiry_on,
+        )
+
+        usage_lifecycle.additional_properties = d
+        return usage_lifecycle
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/usage_storage.py
+++ b/fastfuels_sdk/v2/client_library/models/usage_storage.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Self, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="UsageStorage")
+
+
+@_attrs_define
+class UsageStorage:
+    """A storage usage/limit pair, in bytes.
+
+    Attributes:
+        usage_bytes (int): Summed GCS artifact bytes in use.
+        limit_bytes (int): The storage limit, in bytes.
+    """
+
+    usage_bytes: int
+    limit_bytes: int
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        usage_bytes = self.usage_bytes
+
+        limit_bytes = self.limit_bytes
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "usage_bytes": usage_bytes,
+                "limit_bytes": limit_bytes,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        d = dict(src_dict)
+        usage_bytes = d.pop("usage_bytes")
+
+        limit_bytes = d.pop("limit_bytes")
+
+        usage_storage = cls(
+            usage_bytes=usage_bytes,
+            limit_bytes=limit_bytes,
+        )
+
+        usage_storage.additional_properties = d
+        return usage_storage
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/user_me_response.py
+++ b/fastfuels_sdk/v2/client_library/models/user_me_response.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Self, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.user_me_response_kind import UserMeResponseKind
+
+if TYPE_CHECKING:
+    from ..models.quotas import Quotas
+
+
+T = TypeVar("T", bound="UserMeResponse")
+
+
+@_attrs_define
+class UserMeResponse:
+    """The authenticated owner's identity and resolved quota configuration.
+
+    Attributes:
+        id (str): The authenticated owner's unique ID.
+        kind (UserMeResponseKind): Whether the credential authenticated a user or an application.
+        tier (str): The quota tier in effect for this owner.
+        quotas (Quotas): Usage limits for an owner. Field defaults are the standard tier.
+    """
+
+    id: str
+    kind: UserMeResponseKind
+    tier: str
+    quotas: Quotas
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        kind = self.kind.value
+
+        tier = self.tier
+
+        quotas = self.quotas.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "kind": kind,
+                "tier": tier,
+                "quotas": quotas,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        from ..models.quotas import Quotas
+
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        kind = UserMeResponseKind(d.pop("kind"))
+
+        tier = d.pop("tier")
+
+        quotas = Quotas.from_dict(d.pop("quotas"))
+
+        user_me_response = cls(
+            id=id,
+            kind=kind,
+            tier=tier,
+            quotas=quotas,
+        )
+
+        user_me_response.additional_properties = d
+        return user_me_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/fastfuels_sdk/v2/client_library/models/user_me_response_kind.py
+++ b/fastfuels_sdk/v2/client_library/models/user_me_response_kind.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class UserMeResponseKind(str, Enum):
+    APPLICATION = "application"
+    USER = "user"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/fastfuels_sdk/v2/client_library/models/validation_error.py
+++ b/fastfuels_sdk/v2/client_library/models/validation_error.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -47,7 +47,7 @@ class ValidationError:
         return field_dict
 
     @classmethod
-    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
         d = dict(src_dict)
         loc = []
         _loc = d.pop("loc")

--- a/fastfuels_sdk/v2/compose.py
+++ b/fastfuels_sdk/v2/compose.py
@@ -1,0 +1,326 @@
+"""Builders for grid-compose operations."""
+
+from collections.abc import Iterable
+
+from fastfuels_sdk.v2.client_library.models import (
+    ComposeAttributeCondition,
+    ComposeComparisonOperator,
+    ComposeCompute,
+    ComposeLiteral,
+    ComposeOperator,
+    ComposeSelect,
+    GridFeatureSpatialCondition,
+    GridGeometrySpatialCondition,
+    InlineCompute,
+)
+from fastfuels_sdk.v2.client_library.types import UNSET
+
+__all__ = ["select", "compute", "condition", "literal", "inline_compute"]
+
+_VARIADIC_OPERATORS = {
+    ComposeOperator.ADD,
+    ComposeOperator.AVERAGE,
+    ComposeOperator.MAX,
+    ComposeOperator.MIN,
+    ComposeOperator.MULTIPLY,
+}
+_ORDERING_OPERATORS = {
+    ComposeComparisonOperator.GE,
+    ComposeComparisonOperator.GT,
+    ComposeComparisonOperator.LE,
+    ComposeComparisonOperator.LT,
+}
+_CONDITION_TYPES = (
+    ComposeAttributeCondition,
+    GridFeatureSpatialCondition,
+    GridGeometrySpatialCondition,
+)
+_ELSE_TYPES = (ComposeLiteral, InlineCompute, int, float, str)
+
+
+def select(
+    output: str,
+    from_: str,
+    *,
+    conditions: Iterable | None = None,
+    else_=None,
+    name: str | None = None,
+    description: str | None = None,
+) -> ComposeSelect:
+    """Build an operation that copies an input band into the output grid.
+
+    Parameters
+    ----------
+    output : str
+        Key for the output band.
+    from_ : str
+        Alias-qualified source band, such as ``"base.fbfm"``.
+    conditions : iterable, optional
+        Attribute or spatial conditions, all of which must match. Attribute
+        conditions can be built with :func:`condition`.
+    else_ : optional
+        Fallback band reference, number, typed :func:`literal`, fuel-model
+        label, or :func:`inline_compute`. Required when conditions are given.
+    name, description : str, optional
+        Display metadata for the output band.
+
+    Returns
+    -------
+    ComposeSelect
+        A select operation for
+        :func:`fastfuels_sdk.v2.grids.create_grid_from_compose`.
+    """
+    _require_text(output, "output")
+    _require_band_reference(from_, "from_")
+    condition_list = _condition_list(conditions)
+    _validate_conditional_fallback(condition_list, else_)
+    return ComposeSelect(
+        output=output,
+        from_=from_,
+        conditions=condition_list,
+        else_=_else_value(else_),
+        name=_optional(name),
+        description=_optional(description),
+    )
+
+
+def compute(
+    output: str,
+    operator,
+    operands: Iterable,
+    *,
+    conditions: Iterable | None = None,
+    else_=None,
+    unit: str | None = None,
+    name: str | None = None,
+    description: str | None = None,
+) -> ComposeCompute:
+    """Build an operation that computes an output band.
+
+    Parameters
+    ----------
+    output : str
+        Key for the output band.
+    operator : str or ComposeOperator
+        ``"add"``, ``"subtract"``, ``"multiply"``, ``"divide"``,
+        ``"min"``, ``"max"``, or ``"average"``.
+    operands : iterable
+        Alias-qualified band references, bare numbers, or typed literals.
+        At least one operand must be a band reference.
+    conditions : iterable, optional
+        Attribute or spatial conditions, all of which must match.
+    else_ : optional
+        Fallback value. Required when conditions are given.
+    unit : str, optional
+        Canonical unit in which to express the computed output.
+    name, description : str, optional
+        Display metadata for the output band.
+
+    Returns
+    -------
+    ComposeCompute
+        A compute operation for
+        :func:`fastfuels_sdk.v2.grids.create_grid_from_compose`.
+    """
+    _require_text(output, "output")
+    operator = _operator(operator)
+    operand_list = _operands(operator, operands)
+    condition_list = _condition_list(conditions)
+    _validate_conditional_fallback(condition_list, else_)
+    return ComposeCompute(
+        output=output,
+        operator=operator,
+        operands=operand_list,
+        conditions=condition_list,
+        else_=_else_value(else_),
+        unit=_optional(unit),
+        name=_optional(name),
+        description=_optional(description),
+    )
+
+
+def condition(band: str, operator, value) -> ComposeAttributeCondition:
+    """Build an attribute condition for a compose operation.
+
+    Parameters
+    ----------
+    band : str
+        Alias-qualified input band to test.
+    operator : str or ComposeComparisonOperator
+        ``"eq"``, ``"ne"``, ``"gt"``, ``"lt"``, ``"ge"``, ``"le"``,
+        or ``"in"``.
+    value : int, float, str, or list
+        Comparison value. ``"in"`` requires a list; ordering comparisons
+        require a scalar.
+
+    Returns
+    -------
+    ComposeAttributeCondition
+        A condition for :func:`select` or :func:`compute`.
+    """
+    _require_band_reference(band, "band")
+    try:
+        operator = ComposeComparisonOperator(operator)
+    except (TypeError, ValueError):
+        choices = [item.value for item in ComposeComparisonOperator]
+        raise ValueError(
+            f"Unknown compose comparison operator {operator!r}. Use one of {choices}."
+        ) from None
+
+    is_list = isinstance(value, list)
+    values = value if is_list else [value]
+    if not all(_is_scalar(item) for item in values):
+        raise TypeError("Compose condition values must be numbers or strings.")
+    if operator == ComposeComparisonOperator.IN and not is_list:
+        raise ValueError("The 'in' compose condition requires a list value.")
+    if operator in _ORDERING_OPERATORS and is_list:
+        raise ValueError(f"The {operator.value!r} condition requires a scalar value.")
+    return ComposeAttributeCondition(band=band, operator=operator, value=value)
+
+
+def literal(value, unit: str | None = None) -> ComposeLiteral:
+    """Build a typed literal for a compose operand or fallback.
+
+    Parameters
+    ----------
+    value : int, float, or str
+        Literal value.
+    unit : str, optional
+        Canonical unit for a numeric literal. String literals are unitless.
+
+    Returns
+    -------
+    ComposeLiteral
+        A typed compose literal.
+    """
+    if not _is_scalar(value):
+        raise TypeError("Compose literal values must be numbers or strings.")
+    if isinstance(value, str) and unit is not None:
+        raise ValueError("String compose literals cannot carry a unit.")
+    if unit is not None and not isinstance(unit, str):
+        raise TypeError("unit must be a string or None.")
+    return ComposeLiteral(value=value, unit=_optional(unit))
+
+
+def inline_compute(operator, operands: Iterable) -> InlineCompute:
+    """Build a computation for the fallback branch of a compose operation.
+
+    Parameters
+    ----------
+    operator : str or ComposeOperator
+        Arithmetic operator.
+    operands : iterable
+        Alias-qualified band references, bare numbers, or typed literals.
+
+    Returns
+    -------
+    InlineCompute
+        A computed fallback for ``else_=``.
+    """
+    operator = _operator(operator)
+    return InlineCompute(operator=operator, operands=_operands(operator, operands))
+
+
+def _optional(value):
+    return UNSET if value is None else value
+
+
+def _require_text(value, name: str) -> None:
+    if not isinstance(value, str) or not value:
+        raise TypeError(f"{name} must be a nonempty string.")
+
+
+def _require_band_reference(value, name: str) -> None:
+    _require_text(value, name)
+    alias, separator, band = value.partition(".")
+    if not separator or not alias or not band:
+        raise ValueError(
+            f"{name} must be an alias-qualified band reference such as "
+            "'base.fuel_load.1hr'."
+        )
+
+
+def _operator(value) -> ComposeOperator:
+    try:
+        return ComposeOperator(value)
+    except (TypeError, ValueError):
+        choices = [item.value for item in ComposeOperator]
+        raise ValueError(
+            f"Unknown compose operator {value!r}. Use one of {choices}."
+        ) from None
+
+
+def _operands(operator: ComposeOperator, values: Iterable) -> list:
+    if isinstance(values, (str, bytes)):
+        raise TypeError("operands must be an iterable of compose operands.")
+    try:
+        operands = list(values)
+    except TypeError:
+        raise TypeError("operands must be an iterable of compose operands.") from None
+
+    expected = "at least two" if operator in _VARIADIC_OPERATORS else "exactly two"
+    valid_arity = (
+        len(operands) >= 2 if operator in _VARIADIC_OPERATORS else len(operands) == 2
+    )
+    if not valid_arity:
+        raise ValueError(
+            f"The {operator.value!r} operator requires {expected} operands."
+        )
+    for operand in operands:
+        if isinstance(operand, str):
+            _require_band_reference(operand, "operand")
+        elif isinstance(operand, ComposeLiteral):
+            if isinstance(operand.value, str):
+                raise ValueError("String literals are not valid compute operands.")
+        elif not _is_number(operand):
+            raise TypeError(
+                "Compose operands must be band references, numbers, or typed literals."
+            )
+    if not any(isinstance(operand, str) for operand in operands):
+        raise ValueError("A compute operation must include at least one band operand.")
+    return operands
+
+
+def _condition_list(values: Iterable | None):
+    if values is None:
+        return UNSET
+    if isinstance(values, _CONDITION_TYPES):
+        raise TypeError("conditions must be an iterable of compose conditions.")
+    try:
+        conditions = list(values)
+    except TypeError:
+        raise TypeError(
+            "conditions must be an iterable of compose conditions."
+        ) from None
+    if not all(isinstance(item, _CONDITION_TYPES) for item in conditions):
+        raise TypeError(
+            "conditions must contain compose attribute or grid spatial conditions."
+        )
+    return conditions
+
+
+def _validate_conditional_fallback(conditions, else_) -> None:
+    has_conditions = conditions is not UNSET and bool(conditions)
+    if has_conditions and else_ is None:
+        raise ValueError("else_ is required when compose conditions are provided.")
+    if not has_conditions and else_ is not None:
+        raise ValueError("else_ requires at least one compose condition.")
+
+
+def _else_value(value):
+    if value is None:
+        return UNSET
+    if isinstance(value, bool) or not isinstance(value, _ELSE_TYPES):
+        raise TypeError(
+            "else_ must be a band reference, number, fuel-model label, typed "
+            "literal, or inline compute."
+        )
+    return value
+
+
+def _is_number(value) -> bool:
+    return not isinstance(value, bool) and isinstance(value, (int, float))
+
+
+def _is_scalar(value) -> bool:
+    return _is_number(value) or isinstance(value, str)

--- a/fastfuels_sdk/v2/domains.py
+++ b/fastfuels_sdk/v2/domains.py
@@ -101,8 +101,8 @@ class Domain(DomainModel):
     type_ : str
         Always "FeatureCollection".
     features : List[GeoJsonFeature]
-        Two named GeoJSON features: "domain" (the working extent /
-        bounding box) and "input" (the original geometry).
+        One GeoJSON feature named "domain": the projected working extent /
+        bounding box.
     bbox : List[float]
         Bounding box of the "domain" feature.
     crs : GeoJsonCRS
@@ -583,9 +583,8 @@ class Domain(DomainModel):
     def to_geodataframe(self) -> gpd.GeoDataFrame:
         """Convert the Domain to a GeoPandas GeoDataFrame.
 
-        The v2 API returns two named features: "domain" (the working
-        extent / bounding box) and "input" (the original geometry), so the
-        GeoDataFrame has one row per feature.
+        The v2 API returns one named feature, "domain": the projected working
+        extent / bounding box. The GeoDataFrame therefore has one row.
 
         Returns
         -------
@@ -596,7 +595,8 @@ class Domain(DomainModel):
         Examples
         --------
         >>> gdf = domain.to_geodataframe()
-        >>> gdf[gdf["name"] == "input"].geometry  # the original geometry
+        >>> gdf.loc[0, "name"]
+        'domain'
         """
         feature_collection: dict[str, Any] = {
             "type": "FeatureCollection",

--- a/fastfuels_sdk/v2/domains.py
+++ b/fastfuels_sdk/v2/domains.py
@@ -23,10 +23,10 @@ from fastfuels_sdk.v2.client_library.api.domains import (
 )
 from fastfuels_sdk.v2.client_library.models import (
     Domain as DomainModel,
-    CreateDomainRequestBody,
     DomainLattice,
     DomainSortField,
     DomainSortOrder,
+    GeoJsonFeatureCollection,
     ListDomainsResponse,
     UpdateDomainRequestBody,
 )
@@ -43,7 +43,7 @@ def _build_create_request_body(
     description: str,
     tags: Optional[List[str]],
     pad_to_resolution: Optional[float],
-) -> CreateDomainRequestBody:
+) -> GeoJsonFeatureCollection:
     """Build a domain creation request body from GeoJSON input.
 
     The v2 API accepts FeatureCollection input only; a single Feature is
@@ -62,7 +62,7 @@ def _build_create_request_body(
             f"got {geojson_type!r}"
         )
 
-    return CreateDomainRequestBody.from_dict(
+    return GeoJsonFeatureCollection.from_dict(
         {
             **geojson,
             "name": name,

--- a/fastfuels_sdk/v2/exceptions.py
+++ b/fastfuels_sdk/v2/exceptions.py
@@ -12,8 +12,11 @@ from collections.abc import Mapping
 from http import HTTPStatus
 from typing import Any, NoReturn
 
-from fastfuels_sdk.v2.client_library.models import HTTPValidationError
-from fastfuels_sdk.v2.client_library.types import Response
+from fastfuels_sdk.v2.client_library.models import (
+    HTTPValidationError,
+    QuotaExceededDetail,
+)
+from fastfuels_sdk.v2.client_library.types import UNSET, Response
 
 # Implementation note: the generated client (openapi-python-client) does
 # not raise per-status exceptions — documented error responses are
@@ -31,6 +34,7 @@ from fastfuels_sdk.v2.client_library.types import Response
 # so wrap it to tolerate undocumented body shapes; the actual detail is
 # re-read from ``response.content`` in ``raise_for_response()``.
 _generated_from_dict = HTTPValidationError.from_dict.__func__
+_generated_quota_from_dict = QuotaExceededDetail.from_dict.__func__
 
 
 def _tolerant_from_dict(cls, src_dict):
@@ -44,6 +48,16 @@ def _tolerant_from_dict(cls, src_dict):
 
 
 HTTPValidationError.from_dict = classmethod(_tolerant_from_dict)
+
+
+def _quota_from_dict(cls, src_dict):
+    """Unwrap FastAPI's ``detail`` envelope before generated parsing."""
+    if isinstance(src_dict, Mapping) and isinstance(src_dict.get("detail"), Mapping):
+        src_dict = src_dict["detail"]
+    return _generated_quota_from_dict(cls, src_dict)
+
+
+QuotaExceededDetail.from_dict = classmethod(_quota_from_dict)
 
 
 class ApiException(Exception):
@@ -92,6 +106,57 @@ class UnprocessableEntityException(ApiException):
     """
 
 
+class QuotaExceededException(ApiException):
+    """Raised when the API returns 429 Too Many Requests.
+
+    Attributes
+    ----------
+    quota : str or None
+        The quota field that was exceeded.
+    current : int or None
+        The owner's current usage for the quota.
+    limit : int or None
+        The quota limit that was reached.
+    window_reset_on : datetime.datetime or None
+        When a windowed quota resets, if applicable.
+    message : str or None
+        A human-readable explanation and suggested next steps.
+    reason : str or None
+        The machine-readable error reason.
+    retry_after : int or None
+        Seconds the API recommends waiting before retrying. Present only for
+        active-job quota rejections.
+    """
+
+    def __init__(
+        self,
+        status_code: int,
+        detail: Any = None,
+        retry_after: int | None = None,
+    ):
+        self.quota = None
+        self.current = None
+        self.limit = None
+        self.window_reset_on = None
+        self.message = None
+        self.reason = None
+        self.retry_after = retry_after
+
+        if isinstance(detail, QuotaExceededDetail):
+            self.quota = detail.quota
+            self.current = detail.current
+            self.limit = detail.limit
+            if detail.window_reset_on is not UNSET:
+                self.window_reset_on = detail.window_reset_on
+            self.message = detail.message
+            if detail.reason is not UNSET:
+                self.reason = detail.reason
+
+        self.status_code = status_code
+        self.detail = detail
+        Exception.__init__(self, f"({status_code}) {self.message or detail}")
+
+
 class ServiceException(ApiException):
     """Raised when the API returns a 5xx server error."""
 
@@ -101,6 +166,7 @@ _STATUS_TO_EXCEPTION = {
     HTTPStatus.UNAUTHORIZED: UnauthorizedException,
     HTTPStatus.FORBIDDEN: ForbiddenException,
     HTTPStatus.NOT_FOUND: NotFoundException,
+    HTTPStatus.TOO_MANY_REQUESTS: QuotaExceededException,
     HTTPStatus.UNPROCESSABLE_ENTITY: UnprocessableEntityException,
 }
 
@@ -114,6 +180,32 @@ def _extract_detail(response: Response) -> Any:
             response.content.decode(errors="ignore")
             or HTTPStatus(response.status_code).phrase
         )
+
+
+def _extract_quota_detail(response: Response) -> Any:
+    """Return a typed quota detail, falling back to the generic detail."""
+    if isinstance(response.parsed, QuotaExceededDetail):
+        return response.parsed
+
+    try:
+        payload = json.loads(response.content)
+        if isinstance(payload, Mapping) and isinstance(payload.get("detail"), Mapping):
+            payload = payload["detail"]
+        if isinstance(payload, Mapping):
+            return QuotaExceededDetail.from_dict(payload)
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        pass
+
+    return _extract_detail(response)
+
+
+def _extract_retry_after(response: Response) -> int | None:
+    """Return the delta-seconds value from ``Retry-After``, when present."""
+    value = response.headers.get("Retry-After")
+    try:
+        return int(value) if value is not None else None
+    except ValueError:
+        return None
 
 
 def raise_for_response(response: Response) -> NoReturn:
@@ -134,6 +226,8 @@ def raise_for_response(response: Response) -> NoReturn:
         If the response status is 403.
     NotFoundException
         If the response status is 404.
+    QuotaExceededException
+        If the response status is 429.
     UnprocessableEntityException
         If the response status is 422.
     ServiceException
@@ -145,7 +239,18 @@ def raise_for_response(response: Response) -> NoReturn:
     exception_class = _STATUS_TO_EXCEPTION.get(response.status_code)
     if exception_class is None:
         exception_class = ServiceException if status_code >= 500 else ApiException
-    raise exception_class(status_code, _extract_detail(response))
+    detail = (
+        _extract_quota_detail(response)
+        if response.status_code == HTTPStatus.TOO_MANY_REQUESTS
+        else _extract_detail(response)
+    )
+    if exception_class is QuotaExceededException:
+        raise exception_class(
+            status_code,
+            detail,
+            retry_after=_extract_retry_after(response),
+        )
+    raise exception_class(status_code, detail)
 
 
 def expect(response: Response, expected_status: HTTPStatus = HTTPStatus.OK) -> Any:

--- a/fastfuels_sdk/v2/exports.py
+++ b/fastfuels_sdk/v2/exports.py
@@ -20,6 +20,7 @@ from fastfuels_sdk.v2.client_library.api.exports import (
     update_export,
 )
 from fastfuels_sdk.v2.client_library.api.grids import (
+    create_landscape_export as create_landscape_export_endpoint,
     create_quicfire_export as create_quicfire_export_endpoint,
 )
 from fastfuels_sdk.v2.client_library.models import (
@@ -27,6 +28,11 @@ from fastfuels_sdk.v2.client_library.models import (
     ExportSortField,
     FieldSource,
     JobStatus,
+    LandscapeExportAlignmentDomainTarget,
+    LandscapeExportAlignmentGridTarget,
+    LandscapeExportRequest,
+    LandscapeExportRequestFireBehaviorFuelModel,
+    LandscapeFieldSource,
     ListExportsResponse,
     QuicfireExportRequest,
     QuicfireExportRequestMoistMerge,
@@ -43,6 +49,7 @@ import requests
 
 __all__ = [
     "Export",
+    "create_landscape_export",
     "create_quicfire_export",
     "list_exports",
     "get_export",
@@ -70,6 +77,19 @@ def _field_source(value, role: str) -> FieldSource:
         return FieldSource(grid_id=_domain_id(grid), band=band)
     raise ValueError(
         f"{role} must be a (grid, band) tuple or a FieldSource, got {value!r}"
+    )
+
+
+def _landscape_field_source(value, role: str) -> LandscapeFieldSource:
+    """Build a landscape field source from a ``(grid, band)`` pair."""
+    if isinstance(value, LandscapeFieldSource):
+        return value
+    if isinstance(value, (tuple, list)) and len(value) == 2:
+        grid, band = value
+        return LandscapeFieldSource(grid_id=_domain_id(grid), band=band)
+    raise ValueError(
+        f"{role} must be a (grid, band) tuple or a LandscapeFieldSource, "
+        f"got {value!r}"
     )
 
 
@@ -122,6 +142,7 @@ class Export(ExportModel):
 
     See Also
     --------
+    create_landscape_export : Assemble an 8-band fire-behavior landscape.
     create_quicfire_export : Bundle fuel grids into a QUIC-Fire archive.
     list_exports : List your exports.
     """
@@ -325,6 +346,136 @@ class Export(ExportModel):
 # ---------------------------------------------------------------------------
 
 
+def create_landscape_export(
+    domain,
+    *,
+    fire_behavior_fuel_model: str,
+    elevation: Tuple,
+    slope: Tuple,
+    aspect: Tuple,
+    fuel_model: Tuple,
+    canopy_cover: Tuple,
+    canopy_height: Tuple,
+    canopy_base_height: Tuple,
+    canopy_bulk_density: Tuple,
+    resolution_m: Optional[float] = None,
+    align_to=None,
+    expiration_days: int = 7,
+    name: str = "",
+    description: str = "",
+    tags: Optional[List[str]] = None,
+) -> Export:
+    """Assemble terrain, fuel-model, and canopy grids into a landscape export.
+
+    Produces an 8-band LANDFIRE-style GeoTIFF for FlamMap, IFTDSS, and WFDSS.
+    Every role is a ``(grid, band)`` pair. Role grids must already share the
+    selected 2D lattice and cover its full extent; the exporter never
+    resamples or reprojects them.
+
+    Parameters
+    ----------
+    domain : Domain or str
+        The domain (or its id) the source grids belong to.
+    fire_behavior_fuel_model : {"fbfm40", "fbfm13"}
+        How codes in ``fuel_model`` should be interpreted.
+    elevation, slope, aspect : tuple
+        ``(grid, band)`` roles for terrain elevation (m), slope (degrees), and
+        aspect (degrees).
+    fuel_model : tuple
+        ``(grid, band)`` for categorical FBFM40 or FBFM13 codes.
+    canopy_cover : tuple
+        ``(grid, band)`` for canopy cover (%).
+    canopy_height : tuple
+        ``(grid, band)`` for canopy height (m).
+    canopy_base_height : tuple
+        ``(grid, band)`` for canopy base height (m).
+    canopy_bulk_density : tuple
+        ``(grid, band)`` for canopy bulk density (kg/m³).
+    resolution_m : float, optional
+        Domain-anchored landscape cell size. Defaults to 30 m. Mutually
+        exclusive with ``align_to``.
+    align_to : Grid or str, optional
+        Match an existing grid's CRS, transform, and shape. Mutually exclusive
+        with ``resolution_m``.
+    expiration_days : int, optional
+        Days until the signed download URL expires (1-7, default 7).
+    name, description : str, optional
+        Metadata for the export.
+    tags : List[str], optional
+        Tags for the export.
+
+    Returns
+    -------
+    Export
+        The new pending Export. Call :meth:`Export.wait` and then
+        :meth:`Export.to_file` to download ``landscape.tif``.
+
+    Raises
+    ------
+    ValueError
+        If ``align_to`` and ``resolution_m`` are combined, a role is not a
+        field-source pair, or the fuel-model declaration is invalid.
+    UnprocessableEntityException
+        If a source band has the wrong unit or dimensionality, or a role grid
+        is not aligned with or does not cover the landscape lattice.
+
+    Examples
+    --------
+    >>> export = ff.exports.create_landscape_export(
+    ...     domain,
+    ...     fire_behavior_fuel_model="fbfm40",
+    ...     elevation=(topography, "elevation"),
+    ...     slope=(topography, "slope"),
+    ...     aspect=(topography, "aspect"),
+    ...     fuel_model=(fuel_models, "fbfm"),
+    ...     canopy_cover=(canopy, "cc"),
+    ...     canopy_height=(canopy, "chm"),
+    ...     canopy_base_height=(canopy, "cbh"),
+    ...     canopy_bulk_density=(canopy, "cbd"),
+    ... )
+    >>> export.wait().to_file("landscape.tif")
+    """
+    if align_to is not None and resolution_m is not None:
+        raise ValueError("Specify either align_to or resolution_m, not both.")
+    if align_to is not None:
+        alignment = LandscapeExportAlignmentGridTarget(
+            target="grid", grid_id=_domain_id(align_to)
+        )
+    elif resolution_m is not None:
+        alignment = LandscapeExportAlignmentDomainTarget(
+            target="domain", resolution=resolution_m
+        )
+    else:
+        alignment = UNSET
+
+    request_body = LandscapeExportRequest(
+        fire_behavior_fuel_model=LandscapeExportRequestFireBehaviorFuelModel(
+            fire_behavior_fuel_model
+        ),
+        elevation=_landscape_field_source(elevation, "elevation"),
+        slope=_landscape_field_source(slope, "slope"),
+        aspect=_landscape_field_source(aspect, "aspect"),
+        fuel_model=_landscape_field_source(fuel_model, "fuel_model"),
+        canopy_cover=_landscape_field_source(canopy_cover, "canopy_cover"),
+        canopy_height=_landscape_field_source(canopy_height, "canopy_height"),
+        canopy_base_height=_landscape_field_source(
+            canopy_base_height, "canopy_base_height"
+        ),
+        canopy_bulk_density=_landscape_field_source(
+            canopy_bulk_density, "canopy_bulk_density"
+        ),
+        alignment=alignment,
+        expiration_days=expiration_days,
+        name=name,
+        description=description,
+        tags=_opt(tags),
+    )
+    response = create_landscape_export_endpoint.sync_detailed(
+        _domain_id(domain), client=ensure_client(), body=request_body
+    )
+    return Export._from_model(expect(response, HTTPStatus.CREATED))
+
+
 def create_quicfire_export(
     domain,
     canopy_bulk_density: Tuple,
@@ -503,8 +654,8 @@ def list_exports(
         Sort direction: "ascending" or "descending".
     source : str, optional
         Only return exports with this source name — the format for
-        single-resource exports (e.g. "geotiff", "csv") or "quicfire"
-        for bundles.
+        single-resource exports (e.g. "geotiff", "csv"), "landscape" for
+        landscape GeoTIFFs, or "quicfire" for bundles.
     tag : str, optional
         Only return exports carrying this tag.
 

--- a/fastfuels_sdk/v2/generate_client.sh
+++ b/fastfuels_sdk/v2/generate_client.sh
@@ -18,16 +18,22 @@ PATCHED=$(mktemp /tmp/v2_openapi_patched.XXXXXX.json)
 
 curl -s "$URL/openapi.json" > "$SPEC"
 
-# The spec contains two schemas titled "Feature": the FastFuels feature
-# resource and geojson_pydantic's GeoJSON Feature (auto-namespaced by
-# FastAPI as geojson_pydantic__features__Feature, but with title "Feature").
-# openapi-python-client names classes from titles and refuses duplicates,
-# so re-title the GeoJSON one. Long-term fix: re-title the model in the
-# FastFuels-API-v2 repo so the spec has no collision.
+# openapi-python-client names classes from schema titles and refuses
+# duplicates, dropping the endpoints that reference the loser. The spec has
+# two such collisions, so re-title one side of each. Long-term fix: re-title
+# the models in the FastFuels-API-v2 repo so the spec has no collision.
+#
+#   "Feature" — the FastFuels feature resource vs geojson_pydantic's GeoJSON
+#   Feature (auto-namespaced by FastAPI, but still titled "Feature").
+#
+#   "ThreeDepCoverageResponse" — the point cloud 3DEP pre-flight check
+#   (point count / budget) vs the topography one (tiles / resolution).
 python3 - "$SPEC" "$PATCHED" <<'EOF'
 import json, sys
 spec = json.load(open(sys.argv[1]))
-spec["components"]["schemas"]["geojson_pydantic__features__Feature"]["title"] = "GeoJsonFeature"
+schemas = spec["components"]["schemas"]
+schemas["geojson_pydantic__features__Feature"]["title"] = "GeoJsonFeature"
+schemas["ThreeDepCoverageResponse"]["title"] = "PointCloudThreeDepCoverageResponse"
 json.dump(spec, open(sys.argv[2], "w"))
 EOF
 

--- a/fastfuels_sdk/v2/generate_client.sh
+++ b/fastfuels_sdk/v2/generate_client.sh
@@ -14,31 +14,11 @@ OPC_VERSION="0.29.0"
 
 URL="https://api-v2-prod-782971006568.us-west1.run.app"
 SPEC=$(mktemp /tmp/v2_openapi.XXXXXX.json)
-PATCHED=$(mktemp /tmp/v2_openapi_patched.XXXXXX.json)
 
-curl -s "$URL/openapi.json" > "$SPEC"
-
-# openapi-python-client names classes from schema titles and refuses
-# duplicates, dropping the endpoints that reference the loser. The spec has
-# two such collisions, so re-title one side of each. Long-term fix: re-title
-# the models in the FastFuels-API-v2 repo so the spec has no collision.
-#
-#   "Feature" — the FastFuels feature resource vs geojson_pydantic's GeoJSON
-#   Feature (auto-namespaced by FastAPI, but still titled "Feature").
-#
-#   "ThreeDepCoverageResponse" — the point cloud 3DEP pre-flight check
-#   (point count / budget) vs the topography one (tiles / resolution).
-python3 - "$SPEC" "$PATCHED" <<'EOF'
-import json, sys
-spec = json.load(open(sys.argv[1]))
-schemas = spec["components"]["schemas"]
-schemas["geojson_pydantic__features__Feature"]["title"] = "GeoJsonFeature"
-schemas["ThreeDepCoverageResponse"]["title"] = "PointCloudThreeDepCoverageResponse"
-json.dump(spec, open(sys.argv[2], "w"))
-EOF
+curl -fsS "$URL/openapi.json" > "$SPEC"
 
 uvx "openapi-python-client@${OPC_VERSION}" generate \
-  --path "$PATCHED" \
+  --path "$SPEC" \
   --meta none \
   --output-path client_library \
   --overwrite
@@ -59,5 +39,5 @@ the regen script records the URL alongside the client it generates).
 DEFAULT_BASE_URL = "$URL"
 EOF
 
-rm -f "$SPEC" "$PATCHED"
+rm -f "$SPEC"
 echo "Done."

--- a/fastfuels_sdk/v2/grids.py
+++ b/fastfuels_sdk/v2/grids.py
@@ -17,6 +17,7 @@ from fastfuels_sdk.v2.client_library.api.grids import (
     check_3dep_coverage as check_3dep_coverage_endpoint,
     create_3dep_topography,
     create_duet_grid,
+    create_fccs_lookup,
     create_fbfm13_lookup,
     create_fbfm40_lookup,
     create_geotiff_upload,
@@ -45,6 +46,7 @@ from fastfuels_sdk.v2.client_library.models import (
     Grid as GridModel,
     ApplyGridModificationsRequest,
     CreateDuetRequest,
+    CreateFccsLookupRequest,
     CreateFbfm13LookupRequest,
     CreateFbfm40LookupRequest,
     CreateGeoTIFFUploadRequest,
@@ -65,6 +67,7 @@ from fastfuels_sdk.v2.client_library.models import (
     DuetBand,
     DuetCalibration,
     ExportGridRequest,
+    FccsLookupBand,
     Fbfm13LookupBand,
     Fbfm40LookupBand,
     GridAlignmentDomainTarget,
@@ -119,6 +122,7 @@ __all__ = [
     "create_grid_from_netcdf",
     "create_uniform_grid",
     "create_surface_fuel_grid_from_duet",
+    "create_fuel_grid_from_fccs_lookup",
     "create_fuel_grid_from_fbfm13_lookup",
     "create_fuel_grid_from_fbfm40_lookup",
     "list_grids",
@@ -1680,6 +1684,71 @@ def create_uniform_grid(
 # (``resample``, ``export``). Transforms that only make sense for a particular
 # kind of grid are functions here instead — keeping them off ``Grid`` so they
 # never appear on a grid that cannot perform them.
+
+
+def create_fuel_grid_from_fccs_lookup(
+    source_grid: "Grid",
+    bands: list,
+    source_band: str = "fccs",
+    name: str = "",
+    description: str = "",
+    tags: Optional[List[str]] = None,
+    modifications: Optional[list] = None,
+) -> Grid:
+    """Create a fuel-parameter grid by looking up FCCS codes in a grid.
+
+    Parameters
+    ----------
+    source_grid : Grid
+        A completed grid carrying FCCS codes (produced by
+        :func:`create_fuel_model_grid_from_landfire_fccs`).
+    bands : list
+        The FCCS lookup bands to produce (``FccsLookupBand`` members or
+        string keys such as ``"fuel_load.duff"``, ``"duff_depth"``, and
+        ``"fuel_load.live_shrub"``).
+    source_band : str, optional
+        The band in ``source_grid`` that holds FCCS codes (default ``"fccs"``).
+    name, description : str, optional
+        Metadata for the new grid.
+    tags : List[str], optional
+        Tags for the new grid.
+    modifications : list, optional
+        Modification rules applied after the grid is built.
+
+    Returns
+    -------
+    Grid
+        The new pending fuel-parameter Grid.
+
+    Raises
+    ------
+    ValueError
+        If ``source_grid`` is not completed or has no ``source_band`` band.
+    """
+    source_grid._require_completed("look up fuel parameters from")
+    band_keys = [band.key for band in source_grid.bands]
+    if source_band not in band_keys:
+        raise ValueError(
+            f"Grid {source_grid.id} has no {source_band!r} band to look up; pass "
+            "an FCCS fuel model grid (see "
+            f"create_fuel_model_grid_from_landfire_fccs). Available bands: "
+            f"{band_keys}."
+        )
+    request_body = CreateFccsLookupRequest(
+        source_grid_id=source_grid.id,
+        bands=_enum_list(bands, FccsLookupBand),
+        source_band=source_band,
+        name=name,
+        description=description,
+        tags=_opt(tags),
+        modifications=_opt(modifications),
+    )
+    response = create_fccs_lookup.sync_detailed(
+        source_grid.domain_id,
+        client=ensure_client(),
+        body=request_body,
+    )
+    return Grid._from_model(expect(response, HTTPStatus.CREATED))
 
 
 def create_fuel_grid_from_fbfm13_lookup(

--- a/fastfuels_sdk/v2/grids.py
+++ b/fastfuels_sdk/v2/grids.py
@@ -4,6 +4,8 @@ fastfuels_sdk/v2/grids.py
 
 # Core imports
 import json
+import re
+from collections.abc import Mapping
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
@@ -16,6 +18,7 @@ from fastfuels_sdk.v2.client_library.api.grids import (
     apply_grid_modifications as apply_grid_modifications_endpoint,
     check_3dep_coverage as check_3dep_coverage_endpoint,
     create_3dep_topography,
+    create_compose_grid,
     create_duet_grid,
     create_fccs_lookup,
     create_fbfm13_lookup,
@@ -45,7 +48,13 @@ from fastfuels_sdk.v2.client_library.api.grids import (
 from fastfuels_sdk.v2.client_library.models import (
     Grid as GridModel,
     ApplyGridModificationsRequest,
+    ComposeAttributeCondition,
+    ComposeCompute,
+    ComposeInput,
+    ComposeLiteral,
+    ComposeSelect,
     CreateDuetRequest,
+    CreateComposeRequest,
     CreateFccsLookupRequest,
     CreateFbfm13LookupRequest,
     CreateFbfm40LookupRequest,
@@ -77,6 +86,7 @@ from fastfuels_sdk.v2.client_library.models import (
     GridDataOrder,
     GridExportFormat,
     GridSortField,
+    InlineCompute,
     JobStatus,
     LandfireCanopyFuelBand,
     LandfireCanopyVersion,
@@ -120,6 +130,7 @@ __all__ = [
     "create_pim_grid_from_treemap",
     "create_grid_from_geotiff",
     "create_grid_from_netcdf",
+    "create_grid_from_compose",
     "create_uniform_grid",
     "create_surface_fuel_grid_from_duet",
     "create_fuel_grid_from_fccs_lookup",
@@ -1674,6 +1685,191 @@ def create_uniform_grid(
         _domain_id(domain), client=ensure_client(), body=request_body
     )
     return Grid._from_model(expect(response, HTTPStatus.CREATED))
+
+
+def create_grid_from_compose(
+    inputs: Mapping[str, "Grid"],
+    *,
+    select: Optional[list] = None,
+    compute: Optional[list] = None,
+    name: str = "",
+    description: str = "",
+    tags: Optional[List[str]] = None,
+    modifications: Optional[list] = None,
+) -> Grid:
+    """Create a grid by selecting and computing bands from aligned grids.
+
+    Parameters
+    ----------
+    inputs : mapping of str to Grid
+        Alias-to-grid mapping for completed, aligned 2D grids in one domain.
+        Operations refer to their bands as ``"alias.band_key"``.
+    select : list of ComposeSelect, optional
+        Bands to copy, built with :func:`fastfuels_sdk.v2.compose.select`.
+    compute : list of ComposeCompute, optional
+        Bands to calculate, built with
+        :func:`fastfuels_sdk.v2.compose.compute`.
+    name, description : str, optional
+        Metadata for the new grid.
+    tags : List[str], optional
+        Tags for the new grid.
+    modifications : list, optional
+        Modification rules applied after the grid is composed.
+
+    Returns
+    -------
+    Grid
+        The new pending composed Grid.
+
+    Raises
+    ------
+    TypeError
+        If inputs or operations have the wrong shape.
+    ValueError
+        If inputs are empty, incomplete, duplicated, or from different
+        domains; if aliases or band references are invalid; or if operation
+        outputs are empty or duplicated.
+
+    Examples
+    --------
+    >>> import fastfuels_sdk.v2 as ff
+    >>> composed = ff.grids.create_grid_from_compose(
+    ...     {"fuels": fuel_grid},
+    ...     select=[ff.compose.select("fuel_depth", "fuels.fuel_depth")],
+    ...     compute=[
+    ...         ff.compose.compute(
+    ...             "fuel_load.1hr",
+    ...             "multiply",
+    ...             ["fuels.fuel_load.1hr", 0.5],
+    ...         )
+    ...     ],
+    ... )
+    >>> composed.wait()
+    """
+    if not isinstance(inputs, Mapping):
+        raise TypeError("inputs must be an alias-to-Grid mapping.")
+    if not inputs:
+        raise ValueError("inputs must contain at least one aliased Grid.")
+
+    compose_inputs = []
+    grids_by_alias = {}
+    seen_grid_ids = set()
+    domain_id = None
+    for alias, grid in inputs.items():
+        if (
+            not isinstance(alias, str)
+            or re.fullmatch(r"[A-Za-z][A-Za-z0-9_]*", alias) is None
+        ):
+            raise ValueError(
+                f"Invalid compose alias {alias!r}; aliases must start with a "
+                "letter and contain only letters, numbers, and underscores."
+            )
+        if not isinstance(grid, Grid):
+            raise TypeError(f"Compose input {alias!r} must be a Grid object.")
+        grid._require_completed("compose")
+        if grid.id in seen_grid_ids:
+            raise ValueError(f"Grid {grid.id!r} is assigned more than one alias.")
+        if domain_id is None:
+            domain_id = grid.domain_id
+        elif grid.domain_id != domain_id:
+            raise ValueError("All compose input grids must belong to the same domain.")
+        seen_grid_ids.add(grid.id)
+        grids_by_alias[alias] = grid
+        compose_inputs.append(ComposeInput(grid_id=grid.id, alias=alias))
+
+    select_operations = _compose_operations(select, ComposeSelect, "select")
+    compute_operations = _compose_operations(compute, ComposeCompute, "compute")
+    operations = [*select_operations, *compute_operations]
+    if not operations:
+        raise ValueError("At least one select or compute operation is required.")
+    outputs = [operation.output for operation in operations]
+    if any(not isinstance(output, str) or not output for output in outputs):
+        raise ValueError("Every compose operation requires a nonempty output band.")
+    duplicates = sorted({output for output in outputs if outputs.count(output) > 1})
+    if duplicates:
+        raise ValueError(f"Compose output bands must be unique: {duplicates}.")
+    for operation in operations:
+        _validate_compose_references(operation, grids_by_alias)
+
+    request_body = CreateComposeRequest(
+        inputs=compose_inputs,
+        select=select_operations if select_operations else UNSET,
+        compute=compute_operations if compute_operations else UNSET,
+        name=name,
+        description=description,
+        tags=_opt(tags),
+        modifications=_opt(modifications),
+    )
+    response = create_compose_grid.sync_detailed(
+        domain_id,
+        client=ensure_client(),
+        body=request_body,
+    )
+    return Grid._from_model(expect(response, HTTPStatus.CREATED))
+
+
+def _compose_operations(value, model_type, name: str) -> list:
+    """Normalize and type-check one compose operation collection."""
+    if value is None:
+        return []
+    if isinstance(value, model_type):
+        raise TypeError(f"{name} must be a list of {model_type.__name__} objects.")
+    try:
+        operations = list(value)
+    except TypeError:
+        raise TypeError(
+            f"{name} must be a list of {model_type.__name__} objects."
+        ) from None
+    if not all(isinstance(operation, model_type) for operation in operations):
+        raise TypeError(f"{name} must contain only {model_type.__name__} objects.")
+    return operations
+
+
+def _validate_compose_references(operation, grids_by_alias) -> None:
+    """Catch alias and band typos before dispatching a compose request."""
+    if isinstance(operation, ComposeSelect):
+        _validate_compose_reference(operation.from_, grids_by_alias)
+    else:
+        _validate_compose_operands(operation.operands, grids_by_alias)
+
+    conditions = operation.conditions
+    if conditions is not UNSET and conditions is not None:
+        for condition in conditions:
+            if isinstance(condition, ComposeAttributeCondition):
+                _validate_compose_reference(condition.band, grids_by_alias)
+
+    else_value = operation.else_
+    if (
+        else_value is UNSET
+        or else_value is None
+        or isinstance(else_value, ComposeLiteral)
+    ):
+        return
+    if isinstance(else_value, InlineCompute):
+        _validate_compose_operands(else_value.operands, grids_by_alias)
+    elif isinstance(else_value, str) and "." in else_value:
+        _validate_compose_reference(else_value, grids_by_alias)
+
+
+def _validate_compose_operands(operands, grids_by_alias) -> None:
+    for operand in operands:
+        if isinstance(operand, str):
+            _validate_compose_reference(operand, grids_by_alias)
+
+
+def _validate_compose_reference(reference: str, grids_by_alias) -> None:
+    alias, separator, band_key = reference.partition(".")
+    if not separator or alias not in grids_by_alias or not band_key:
+        raise ValueError(
+            f"Unknown compose band reference {reference!r}; use "
+            "'alias.band_key' with an alias from inputs."
+        )
+    available = [band.key for band in grids_by_alias[alias].bands]
+    if band_key not in available:
+        raise ValueError(
+            f"Grid {grids_by_alias[alias].id} has no {band_key!r} band for "
+            f"compose alias {alias!r}. Available bands: {available}."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/fastfuels_sdk/v2/grids.py
+++ b/fastfuels_sdk/v2/grids.py
@@ -16,6 +16,7 @@ from fastfuels_sdk.v2.client_library.api.grids import (
     apply_grid_modifications as apply_grid_modifications_endpoint,
     check_3dep_coverage as check_3dep_coverage_endpoint,
     create_3dep_topography,
+    create_duet_grid,
     create_fbfm40_lookup,
     create_geotiff_upload,
     create_grid_export,
@@ -41,6 +42,7 @@ from fastfuels_sdk.v2.client_library.api.grids import (
 from fastfuels_sdk.v2.client_library.models import (
     Grid as GridModel,
     ApplyGridModificationsRequest,
+    CreateDuetRequest,
     CreateFbfm40LookupRequest,
     CreateGeoTIFFUploadRequest,
     CreateLandfireCanopyRequest,
@@ -56,6 +58,8 @@ from fastfuels_sdk.v2.client_library.models import (
     CreateTreeMapRequest,
     CreateUniformRequest,
     DuplicateGridRequest,
+    DuetBand,
+    DuetCalibration,
     ExportGridRequest,
     Fbfm40LookupBand,
     GridAlignmentDomainTarget,
@@ -107,6 +111,7 @@ __all__ = [
     "create_grid_from_geotiff",
     "create_grid_from_netcdf",
     "create_uniform_grid",
+    "create_surface_fuel_grid_from_duet",
     "create_fuel_grid_from_fbfm40_lookup",
     "list_grids",
     "get_grid",
@@ -1672,6 +1677,114 @@ def create_fuel_grid_from_fbfm40_lookup(
         source_grid.domain_id, client=ensure_client(), body=request_body
     )
     return Grid._from_model(expect(response, HTTPStatus.CREATED))
+
+
+def create_surface_fuel_grid_from_duet(
+    source_grid: "Grid",
+    years_since_burn: int,
+    wind_direction: int = 270,
+    wind_variability: int = 30,
+    bands: Optional[list] = None,
+    calibration: Optional[DuetCalibration] = None,
+    name: str = "",
+    description: str = "",
+    tags: Optional[List[str]] = None,
+) -> Grid:
+    """Create a 2D DUET surface-fuel grid from a 3D tree grid.
+
+    Parameters
+    ----------
+    source_grid : Grid
+        A completed 3D tree grid carrying ``bulk_density.foliage.live``,
+        ``spcd``, and ``fuel_moisture.live`` bands.
+    years_since_burn : int
+        Years of litter accumulation to simulate, from 1 through 100.
+    wind_direction : int, optional
+        Prevailing wind direction in whole degrees clockwise from north
+        (0-359, default 270).
+    wind_variability : int, optional
+        Angular spread of wind direction in whole degrees (0-180, default 30).
+    bands : list, optional
+        DUET output bands (``DuetBand`` members or string keys). Defaults to
+        ``fuel_load.grass`` and ``fuel_load.litter``.
+    calibration : DuetCalibration, optional
+        Per-parameter and per-fuel-type targets from
+        :func:`fastfuels_sdk.v2.calibrations.duet_calibration`. If omitted,
+        the grid stores raw DUET values.
+    name, description : str, optional
+        Metadata for the new grid.
+    tags : List[str], optional
+        Tags for the new grid.
+
+    Returns
+    -------
+    Grid
+        The new pending DUET surface-fuel Grid.
+
+    Raises
+    ------
+    TypeError
+        If a DUET time or wind parameter is not a whole number.
+    ValueError
+        If a parameter is out of range, the source is not completed, or the
+        source lacks a required tree band.
+    """
+    source_grid._require_completed("create a DUET surface fuel grid from")
+    required_bands = {
+        "bulk_density.foliage.live",
+        "spcd",
+        "fuel_moisture.live",
+    }
+    band_keys = {band.key for band in source_grid.bands}
+    missing = sorted(required_bands - band_keys)
+    if missing:
+        raise ValueError(
+            f"Grid {source_grid.id} lacks DUET source bands: {missing}. "
+            f"Available bands: {sorted(band_keys)}."
+        )
+
+    years_since_burn = _duet_integer(
+        "years_since_burn", years_since_burn, minimum=1, maximum=100
+    )
+    wind_direction = _duet_integer(
+        "wind_direction", wind_direction, minimum=0, maximum=359
+    )
+    wind_variability = _duet_integer(
+        "wind_variability", wind_variability, minimum=0, maximum=180
+    )
+    requested_bands = _enum_list(bands, DuetBand)
+    if requested_bands is not UNSET:
+        if not requested_bands:
+            raise ValueError("bands must contain at least one DUET band.")
+        if len(set(requested_bands)) != len(requested_bands):
+            raise ValueError("bands contains duplicate DUET bands.")
+
+    request_body = CreateDuetRequest(
+        source_grid_id=source_grid.id,
+        years_since_burn=years_since_burn,
+        wind_direction=wind_direction,
+        wind_variability=wind_variability,
+        bands=requested_bands,
+        calibration=_opt(calibration),
+        name=name,
+        description=description,
+        tags=_opt(tags),
+    )
+    response = create_duet_grid.sync_detailed(
+        source_grid.domain_id,
+        client=ensure_client(),
+        body=request_body,
+    )
+    return Grid._from_model(expect(response, HTTPStatus.CREATED))
+
+
+def _duet_integer(name: str, value, *, minimum: int, maximum: int) -> int:
+    """Validate a bounded whole-number DUET parameter."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be a whole number.")
+    if not minimum <= value <= maximum:
+        raise ValueError(f"{name} must be between {minimum} and {maximum}.")
+    return value
 
 
 # ---------------------------------------------------------------------------

--- a/fastfuels_sdk/v2/grids.py
+++ b/fastfuels_sdk/v2/grids.py
@@ -17,10 +17,12 @@ from fastfuels_sdk.v2.client_library.api.grids import (
     check_3dep_coverage as check_3dep_coverage_endpoint,
     create_3dep_topography,
     create_duet_grid,
+    create_fbfm13_lookup,
     create_fbfm40_lookup,
     create_geotiff_upload,
     create_grid_export,
     create_landfire_canopy,
+    create_landfire_fbfm13,
     create_landfire_fbfm40,
     create_landfire_fccs,
     create_landfire_topography,
@@ -43,9 +45,11 @@ from fastfuels_sdk.v2.client_library.models import (
     Grid as GridModel,
     ApplyGridModificationsRequest,
     CreateDuetRequest,
+    CreateFbfm13LookupRequest,
     CreateFbfm40LookupRequest,
     CreateGeoTIFFUploadRequest,
     CreateLandfireCanopyRequest,
+    CreateLandfireFbfm13Request,
     CreateLandfireFbfm40Request,
     CreateLandfireFccsRequest,
     CreateLandfireTopographyRequest,
@@ -61,6 +65,7 @@ from fastfuels_sdk.v2.client_library.models import (
     DuetBand,
     DuetCalibration,
     ExportGridRequest,
+    Fbfm13LookupBand,
     Fbfm40LookupBand,
     GridAlignmentDomainTarget,
     GridAlignmentGridTarget,
@@ -72,6 +77,7 @@ from fastfuels_sdk.v2.client_library.models import (
     JobStatus,
     LandfireCanopyFuelBand,
     LandfireCanopyVersion,
+    LandfireFbfm13Version,
     LandfireFbfm40Version,
     LandfireFccsVersion,
     LandfireTopographyVersion,
@@ -105,6 +111,7 @@ __all__ = [
     "create_canopy_height_grid_from_meta",
     "create_canopy_height_grid_from_naip_chm",
     "create_canopy_height_grid_from_point_cloud",
+    "create_fuel_model_grid_from_landfire_fbfm13",
     "create_fuel_model_grid_from_landfire_fbfm40",
     "create_fuel_model_grid_from_landfire_fccs",
     "create_pim_grid_from_treemap",
@@ -112,6 +119,7 @@ __all__ = [
     "create_grid_from_netcdf",
     "create_uniform_grid",
     "create_surface_fuel_grid_from_duet",
+    "create_fuel_grid_from_fbfm13_lookup",
     "create_fuel_grid_from_fbfm40_lookup",
     "list_grids",
     "get_grid",
@@ -1245,6 +1253,70 @@ def create_canopy_height_grid_from_point_cloud(
     return Grid._from_model(expect(response, HTTPStatus.CREATED))
 
 
+def create_fuel_model_grid_from_landfire_fbfm13(
+    domain,
+    version: Optional[str] = None,
+    remove_non_burnable: Optional[list] = None,
+    output_resolution_m: Optional[float] = None,
+    align_to=None,
+    align: Optional[str] = None,
+    resampling: Optional[str] = None,
+    extent_buffer_cells: int = 0,
+    name: str = "",
+    description: str = "",
+    tags: Optional[List[str]] = None,
+    modifications: Optional[list] = None,
+) -> Grid:
+    """Create a fuel model grid from LANDFIRE Anderson 13 fuel models.
+
+    Parameters
+    ----------
+    domain : Domain or str
+        The domain (or its id) to create the grid in.
+    version : str, optional
+        LANDFIRE version (``"2023"`` or ``"2024"``). Defaults to the API's
+        current version.
+    remove_non_burnable : list, optional
+        Non-burnable fuel models to drop (``NonBurnableFuelModel`` members or
+        their string keys, e.g. ``"NB1"``, ``"NB2"``).
+    output_resolution_m : float, optional
+        Output cell size in meters, anchored to the domain origin.
+    align_to : Grid or str, optional
+        Match the lattice of an existing grid (or its id).
+    align : str, optional
+        Pass ``"native"`` to keep the source raster's pixel anchor.
+    resampling : str, optional
+        Resampling method (e.g. ``"nearest"`` for categorical fuel models).
+    extent_buffer_cells : int, optional
+        Result-grid cells to buffer around the domain extent (0-10, default 0).
+    name, description : str, optional
+        Metadata for the grid.
+    tags : List[str], optional
+        Tags for the grid.
+    modifications : list, optional
+        Modification rules applied after the grid is built.
+
+    Returns
+    -------
+    Grid
+        The created Grid object (job status ``"pending"`` or ``"running"``).
+    """
+    request_body = CreateLandfireFbfm13Request(
+        version=LandfireFbfm13Version(version) if version is not None else UNSET,
+        remove_non_burnable=_enum_list(remove_non_burnable, NonBurnableFuelModel),
+        alignment=_build_alignment(output_resolution_m, align_to, align, resampling),
+        extent_buffer_cells=extent_buffer_cells,
+        name=name,
+        description=description,
+        tags=_opt(tags),
+        modifications=_opt(modifications),
+    )
+    response = create_landfire_fbfm13.sync_detailed(
+        _domain_id(domain), client=ensure_client(), body=request_body
+    )
+    return Grid._from_model(expect(response, HTTPStatus.CREATED))
+
+
 def create_fuel_model_grid_from_landfire_fbfm40(
     domain,
     version: Optional[str] = None,
@@ -1608,6 +1680,71 @@ def create_uniform_grid(
 # (``resample``, ``export``). Transforms that only make sense for a particular
 # kind of grid are functions here instead — keeping them off ``Grid`` so they
 # never appear on a grid that cannot perform them.
+
+
+def create_fuel_grid_from_fbfm13_lookup(
+    source_grid: "Grid",
+    bands: list,
+    source_band: str = "fbfm13",
+    name: str = "",
+    description: str = "",
+    tags: Optional[List[str]] = None,
+    modifications: Optional[list] = None,
+) -> Grid:
+    """Create a fuel-parameter grid by looking up FBFM13 codes in a grid.
+
+    Parameters
+    ----------
+    source_grid : Grid
+        A completed grid carrying FBFM13 codes (produced by
+        :func:`create_fuel_model_grid_from_landfire_fbfm13`).
+    bands : list
+        The FBFM13 lookup bands to produce (``Fbfm13LookupBand`` members or
+        string keys such as ``"fuel_load.1hr"`` and ``"fuel_depth"``).
+    source_band : str, optional
+        The band in ``source_grid`` that holds FBFM13 codes (default
+        ``"fbfm13"``).
+    name, description : str, optional
+        Metadata for the new grid.
+    tags : List[str], optional
+        Tags for the new grid.
+    modifications : list, optional
+        Modification rules applied after the grid is built.
+
+    Returns
+    -------
+    Grid
+        The new pending fuel-parameter Grid.
+
+    Raises
+    ------
+    ValueError
+        If ``source_grid`` is not completed or has no ``source_band`` band.
+    """
+    source_grid._require_completed("look up fuel parameters from")
+    band_keys = [band.key for band in source_grid.bands]
+    if source_band not in band_keys:
+        raise ValueError(
+            f"Grid {source_grid.id} has no {source_band!r} band to look up; pass "
+            "an FBFM13 fuel model grid (see "
+            f"create_fuel_model_grid_from_landfire_fbfm13). Available bands: "
+            f"{band_keys}."
+        )
+    request_body = CreateFbfm13LookupRequest(
+        source_grid_id=source_grid.id,
+        bands=_enum_list(bands, Fbfm13LookupBand),
+        source_band=source_band,
+        name=name,
+        description=description,
+        tags=_opt(tags),
+        modifications=_opt(modifications),
+    )
+    response = create_fbfm13_lookup.sync_detailed(
+        source_grid.domain_id,
+        client=ensure_client(),
+        body=request_body,
+    )
+    return Grid._from_model(expect(response, HTTPStatus.CREATED))
 
 
 def create_fuel_grid_from_fbfm40_lookup(

--- a/fastfuels_sdk/v2/grids.py
+++ b/fastfuels_sdk/v2/grids.py
@@ -101,6 +101,7 @@ from fastfuels_sdk.v2.client_library.models import (
     SortOrder,
     ThreeDepResolution,
     TopographyBand,
+    TopographyThreeDepCoverageResponse,
     TreeMapBand,
     TreeMapVersion,
     UniformBand,
@@ -2273,7 +2274,9 @@ def get_grid(domain, grid_id: str) -> Grid:
     return Grid.from_id(_domain_id(domain), grid_id)
 
 
-def check_3dep_coverage(domain, resolution_m: Optional[int] = None):
+def check_3dep_coverage(
+    domain, resolution_m: Optional[int] = None
+) -> TopographyThreeDepCoverageResponse:
     """Check USGS 3DEP tile coverage for a domain before creating a grid.
 
     Parameters
@@ -2285,7 +2288,7 @@ def check_3dep_coverage(domain, resolution_m: Optional[int] = None):
 
     Returns
     -------
-    ThreeDepCoverageResponse
+    TopographyThreeDepCoverageResponse
         Tile availability, count, URLs, and (for 1 m) acquisition dates.
     """
     response = check_3dep_coverage_endpoint.sync_detailed(

--- a/fastfuels_sdk/v2/grids.py
+++ b/fastfuels_sdk/v2/grids.py
@@ -5,7 +5,7 @@ fastfuels_sdk/v2/grids.py
 # Core imports
 import json
 from http import HTTPStatus
-from typing import Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 # Internal imports
 from fastfuels_sdk.v2._jobs import wait as _wait
@@ -26,6 +26,7 @@ from fastfuels_sdk.v2.client_library.api.grids import (
     create_meta_chm,
     create_naip_chm,
     create_netcdf_upload,
+    create_point_cloud_chm,
     create_resample,
     create_treemap,
     create_uniform_grid as create_uniform_grid_endpoint,
@@ -49,6 +50,7 @@ from fastfuels_sdk.v2.client_library.models import (
     CreateMetaChmRequest,
     CreateNaipChmRequest,
     CreateNetcdfUploadRequest,
+    CreatePointCloudChmRequest,
     CreateResampleRequest,
     CreateThreeDepTopographyRequest,
     CreateTreeMapRequest,
@@ -88,6 +90,9 @@ from fastfuels_sdk.v2.client_library.types import UNSET, Response
 import attrs
 import numpy as np
 
+if TYPE_CHECKING:
+    from fastfuels_sdk.v2.point_clouds import PointCloud
+
 __all__ = [
     "Grid",
     "create_topography_grid_from_3dep",
@@ -95,6 +100,7 @@ __all__ = [
     "create_canopy_fuel_grid_from_landfire",
     "create_canopy_height_grid_from_meta",
     "create_canopy_height_grid_from_naip_chm",
+    "create_canopy_height_grid_from_point_cloud",
     "create_fuel_model_grid_from_landfire_fbfm40",
     "create_fuel_model_grid_from_landfire_fccs",
     "create_pim_grid_from_treemap",
@@ -1155,6 +1161,81 @@ def create_canopy_height_grid_from_naip_chm(
     )
     response = create_naip_chm.sync_detailed(
         _domain_id(domain), client=ensure_client(), body=request_body
+    )
+    return Grid._from_model(expect(response, HTTPStatus.CREATED))
+
+
+def create_canopy_height_grid_from_point_cloud(
+    point_cloud: "PointCloud",
+    output_resolution_m: Optional[float] = None,
+    align_to=None,
+    resampling: Optional[str] = None,
+    extent_buffer_cells: int = 0,
+    name: str = "",
+    description: str = "",
+    tags: Optional[List[str]] = None,
+    modifications: Optional[list] = None,
+) -> Grid:
+    """Create a canopy height grid from a completed airborne point cloud.
+
+    Parameters
+    ----------
+    point_cloud : PointCloud
+        The completed airborne point cloud to rasterize.
+    output_resolution_m : float, optional
+        Output cell size in meters, anchored to the domain origin. Defaults to
+        1 meter when no alignment target is provided.
+    align_to : Grid or str, optional
+        Match the lattice of an existing grid (or its id).
+    resampling : str, optional
+        Resampling method for the continuous canopy-height band.
+    extent_buffer_cells : int, optional
+        Result-grid cells to buffer around the domain extent (0-10, default 0).
+    name, description : str, optional
+        Metadata for the grid.
+    tags : List[str], optional
+        Tags for the grid.
+    modifications : list, optional
+        Modification rules applied after the grid is built.
+
+    Returns
+    -------
+    Grid
+        The created canopy-height Grid (job status "pending" or "running").
+
+    Raises
+    ------
+    ValueError
+        If the point cloud is not completed or is not airborne.
+    """
+    if point_cloud.status != JobStatus.COMPLETED:
+        raise ValueError(
+            f"Point cloud {point_cloud.id} must be completed before creating "
+            f"a canopy height grid (current status: {point_cloud.status.value})."
+        )
+    if point_cloud.type_.value != "als":
+        raise ValueError(
+            f"Point cloud {point_cloud.id} must be airborne (ALS) to create a "
+            f"canopy height grid (got {point_cloud.type_.value!r})."
+        )
+
+    request_body = CreatePointCloudChmRequest(
+        source_point_cloud_id=point_cloud.id,
+        alignment=_build_alignment(
+            output_resolution_m,
+            align_to,
+            resampling=resampling,
+        ),
+        extent_buffer_cells=extent_buffer_cells,
+        name=name,
+        description=description,
+        tags=_opt(tags),
+        modifications=_opt(modifications),
+    )
+    response = create_point_cloud_chm.sync_detailed(
+        point_cloud.domain_id,
+        client=ensure_client(),
+        body=request_body,
     )
     return Grid._from_model(expect(response, HTTPStatus.CREATED))
 

--- a/fastfuels_sdk/v2/inventories.py
+++ b/fastfuels_sdk/v2/inventories.py
@@ -393,11 +393,12 @@ class Inventory(InventoryModel):
     def apply_modifications(self, modifications: list) -> "Inventory":
         """Apply modification rules to this inventory in place.
 
-        The inventory keeps its ID; the submitted rules are appended to its
-        cumulative ``modifications`` list and the tree data is re-derived as
-        a background job — the inventory returns to "pending" status, so
-        call :meth:`wait` before using its data. To keep the original data,
-        :meth:`duplicate` first and modify the copy.
+        The inventory keeps its ID; the submitted rules are queued while the
+        tree data is re-derived as a background job. The inventory returns to
+        "pending" status, and the rules are appended to its cumulative
+        ``modifications`` list once processing completes. Call :meth:`wait`
+        before using its data. To keep the original data, :meth:`duplicate`
+        first and modify the copy.
 
         Parameters
         ----------

--- a/fastfuels_sdk/v2/inventories.py
+++ b/fastfuels_sdk/v2/inventories.py
@@ -5,6 +5,7 @@ fastfuels_sdk/v2/inventories.py
 # Core imports
 import json
 from http import HTTPStatus
+from io import StringIO
 from pathlib import Path
 from typing import List, Optional
 
@@ -24,6 +25,7 @@ from fastfuels_sdk.v2.client_library.api.inventories import (
     delete_inventory,
     duplicate_inventory as duplicate_inventory_endpoint,
     get_inventory as get_inventory_endpoint,
+    get_inventory_data_csv,
     get_inventory_data_json,
     get_inventory_data_metadata,
     list_inventories as list_inventories_endpoint,
@@ -47,6 +49,7 @@ from fastfuels_sdk.v2.client_library.models import (
     InventoryDataMetadata,
     InventoryDataResponse,
     InventoryExportFormat,
+    InventoryJsonOrientation,
     InventorySortField,
     InventoryUploadFormat,
     JobStatus,
@@ -702,7 +705,10 @@ class Inventory(InventoryModel):
         return None if summary is UNSET else summary
 
     def get_data_partition(
-        self, partition_index: int, columns: Optional[List[str]] = None
+        self,
+        partition_index: int,
+        columns: Optional[List[str]] = None,
+        json_orientation: str = "split",
     ) -> InventoryDataResponse:
         """Get one partition of the inventory's tree records.
 
@@ -713,13 +719,17 @@ class Inventory(InventoryModel):
             ``num_partitions`` reported by :meth:`get_data_metadata`.
         columns : List[str], optional
             Column subset to retrieve (default: all columns).
+        json_orientation : {"split", "records"}, optional
+            JSON layout. ``"split"`` (default) returns rows as lists of
+            values in ``partition.columns`` order; ``"records"`` returns
+            self-describing row mappings.
 
         Returns
         -------
         InventoryDataResponse
             With attributes ``partition``, ``num_rows``, ``columns``
-            (column names), and ``data`` (rows as lists of values, in
-            column order).
+            (column names), and ``data`` (row lists for ``"split"`` or row
+            mappings for ``"records"``).
 
         Raises
         ------
@@ -728,6 +738,8 @@ class Inventory(InventoryModel):
         UnprocessableEntityException
             If ``partition_index`` is past the last partition, or the
             inventory is not in "completed" status.
+        ValueError
+            If ``json_orientation`` is not ``"split"`` or ``"records"``.
 
         Examples
         --------
@@ -735,11 +747,13 @@ class Inventory(InventoryModel):
         >>> partition.num_rows
         1392
         """
+        orientation = InventoryJsonOrientation(json_orientation)
         response = get_inventory_data_json.sync_detailed(
             self.domain_id,
             self.id,
             partition_index,
             client=ensure_client(),
+            json_orientation=orientation,
             columns=",".join(columns) if columns is not None else UNSET,
         )
         return expect(response)
@@ -747,8 +761,9 @@ class Inventory(InventoryModel):
     def to_dataframe(self, columns: Optional[List[str]] = None) -> pd.DataFrame:
         """Retrieve the inventory's tree records as a pandas DataFrame.
 
-        Retrieves every partition and concatenates them into a single
-        DataFrame with one row per tree, preserving source order.
+        Retrieves every partition as CSV, parses it with :func:`pandas.read_csv`,
+        and concatenates the partitions into a single DataFrame with one row
+        per tree, preserving source order.
 
         Parameters
         ----------
@@ -776,8 +791,14 @@ class Inventory(InventoryModel):
         metadata = self.get_data_metadata()
         frames = []
         for partition_index in range(metadata.num_partitions):
-            partition = self.get_data_partition(partition_index, columns=columns)
-            frames.append(pd.DataFrame(partition.data, columns=partition.columns))
+            response = get_inventory_data_csv.sync_detailed(
+                self.domain_id,
+                self.id,
+                partition_index,
+                client=ensure_client(),
+                columns=",".join(columns) if columns is not None else UNSET,
+            )
+            frames.append(pd.read_csv(StringIO(expect(response))))
         if not frames:
             return pd.DataFrame(columns=columns or metadata.columns)
         return pd.concat(frames, ignore_index=True)

--- a/fastfuels_sdk/v2/inventories.py
+++ b/fastfuels_sdk/v2/inventories.py
@@ -24,7 +24,7 @@ from fastfuels_sdk.v2.client_library.api.inventories import (
     delete_inventory,
     duplicate_inventory as duplicate_inventory_endpoint,
     get_inventory as get_inventory_endpoint,
-    get_inventory_data,
+    get_inventory_data_json,
     get_inventory_data_metadata,
     list_inventories as list_inventories_endpoint,
     list_inventories_cross_domain,
@@ -679,7 +679,7 @@ class Inventory(InventoryModel):
         >>> partition.num_rows
         1392
         """
-        response = get_inventory_data.sync_detailed(
+        response = get_inventory_data_json.sync_detailed(
             self.domain_id,
             self.id,
             partition_index,

--- a/fastfuels_sdk/v2/inventories.py
+++ b/fastfuels_sdk/v2/inventories.py
@@ -207,6 +207,17 @@ class Inventory(InventoryModel):
                 "Call .wait() until it completes first."
             )
 
+    def _column(self, column: str):
+        """Return the :class:`Column` with key ``column``, or raise if absent."""
+        columns = [] if self.columns is UNSET or self.columns is None else self.columns
+        for inventory_column in columns:
+            if inventory_column.key == column:
+                return inventory_column
+        keys = [inventory_column.key for inventory_column in columns]
+        raise ValueError(
+            f"Inventory has no column {column!r}. Available columns: {keys}."
+        )
+
     @classmethod
     def from_id(cls, domain_id: str, inventory_id: str) -> "Inventory":
         """Retrieve an existing Inventory resource by its ID.
@@ -653,6 +664,42 @@ class Inventory(InventoryModel):
             self.domain_id, self.id, client=ensure_client()
         )
         return expect(response)
+
+    def column_summary(self, column: str):
+        """Return summary statistics for one column without downloading records.
+
+        The server computes a per-column summary when an inventory completes,
+        so this provides a cheap overview without fetching the inventory's tree
+        records (unlike :meth:`to_dataframe`).
+
+        Parameters
+        ----------
+        column : str
+            The column key to summarize (see :attr:`columns` for available
+            keys).
+
+        Returns
+        -------
+        ContinuousColumnSummary or CategoricalColumnSummary or None
+            The column's summary, discriminated by its ``type_``:
+            ``"continuous"`` carries ``count``, ``null_count``, ``min_``,
+            ``max_``, ``mean``, and ``std``; ``"categorical"`` carries
+            ``count``, ``null_count``, and ``unique_count``. ``None`` until
+            the inventory completes (call :meth:`wait` first).
+
+        Raises
+        ------
+        ValueError
+            If ``column`` is not one of the inventory's columns.
+
+        Examples
+        --------
+        >>> inventory = ff.get_inventory(domain, "abc123").wait()
+        >>> inventory.column_summary("dbh").type_
+        'continuous'
+        """
+        summary = self._column(column).summary
+        return None if summary is UNSET else summary
 
     def get_data_partition(
         self, partition_index: int, columns: Optional[List[str]] = None

--- a/fastfuels_sdk/v2/inventories.py
+++ b/fastfuels_sdk/v2/inventories.py
@@ -428,11 +428,12 @@ class Inventory(InventoryModel):
     def apply_treatments(self, treatments: list) -> "Inventory":
         """Apply silvicultural treatments to this inventory in place.
 
-        The inventory keeps its ID; the submitted treatments are appended to
-        its cumulative ``treatments`` list and the tree data is re-derived as a
-        background job — the inventory returns to "pending" status, so call
-        :meth:`wait` before using its data. To keep the original data,
-        :meth:`duplicate` first and treat the copy.
+        The inventory keeps its ID; the submitted treatments are queued while
+        the tree data is re-derived as a background job. The inventory returns
+        to "pending" status, and the treatments are appended to its cumulative
+        ``treatments`` list once processing completes. Call :meth:`wait` before
+        using its data. To keep the original data, :meth:`duplicate` first and
+        treat the copy.
 
         Parameters
         ----------

--- a/fastfuels_sdk/v2/inventories.py
+++ b/fastfuels_sdk/v2/inventories.py
@@ -140,6 +140,10 @@ class Inventory(InventoryModel):
         Silvicultural treatments applied to the inventory.
     columns : List[Column], optional
         The columns of the inventory's tabular data.
+    forestry_metrics : TreeForestryMetrics, optional
+        Stand-level tree count, basal area per acre, trees per acre,
+        quadratic mean diameter, and dominant FIA species groups. Populated
+        when a tree inventory completes; ``None`` when unavailable.
     georeference : InventoryGeoreference, optional
         Spatial reference of the generated data; populated when the job
         completes.
@@ -180,13 +184,18 @@ class Inventory(InventoryModel):
         Round-trips through the generated to_dict/from_dict — from_dict
         constructs ``cls``, i.e. this subclass.
         """
-        return cls.from_dict(model.to_dict())
+        inventory = cls.from_dict(model.to_dict())
+        if inventory.forestry_metrics is UNSET:
+            inventory.forestry_metrics = None
+        return inventory
 
     def _copy_fields_from(self, model: InventoryModel) -> "Inventory":
         """Copy all generated-model fields from `model` onto self (in-place)."""
         for field in attrs.fields(InventoryModel):
             if field.init:
                 setattr(self, field.name, getattr(model, field.name))
+        if self.forestry_metrics is UNSET:
+            self.forestry_metrics = None
         self.additional_properties = dict(model.additional_properties)
         return self
 

--- a/fastfuels_sdk/v2/point_clouds.py
+++ b/fastfuels_sdk/v2/point_clouds.py
@@ -13,6 +13,8 @@ from fastfuels_sdk.v2._uploads import put_upload
 from fastfuels_sdk.v2.api import ensure_client
 from fastfuels_sdk.v2.exceptions import expect
 from fastfuels_sdk.v2.client_library.api.point_clouds import (
+    check_3dep_point_cloud_coverage,
+    create_3dep_point_cloud as create_3dep_point_cloud_endpoint,
     create_point_cloud_upload,
     delete_point_cloud,
     get_point_cloud as get_point_cloud_endpoint,
@@ -23,7 +25,9 @@ from fastfuels_sdk.v2.client_library.api.point_clouds import (
 from fastfuels_sdk.v2.client_library.models import (
     PointCloud as PointCloudModel,
     CreatePointCloudUploadRequest,
+    CreateThreeDepPointCloudRequest,
     ListPointCloudsResponse,
+    PointCloudThreeDepCoverageResponse,
     PointCloudSortField,
     PointCloudType,
     SortOrder,
@@ -36,6 +40,8 @@ import attrs
 
 __all__ = [
     "PointCloud",
+    "check_3dep_coverage",
+    "create_point_cloud_from_3dep",
     "create_point_cloud_from_file",
     "list_point_clouds",
     "get_point_cloud",
@@ -60,10 +66,11 @@ def _point_cloud_type(value) -> PointCloudType:
 class PointCloud(PointCloudModel):
     """Point cloud resource for the FastFuels v2 API.
 
-    A point cloud is a 3D LiDAR dataset within a domain, uploaded from your own
-    ALS (airborne) or TLS (terrestrial) scan. Point clouds are asynchronous job
-    resources — creation starts a background job and returns a *pending* record;
-    call :meth:`wait` to block until the uploaded file is processed.
+    A point cloud is a 3D LiDAR dataset within a domain, either fetched from
+    USGS 3DEP or uploaded from your own ALS (airborne) or TLS (terrestrial)
+    scan. Point clouds are asynchronous job resources — creation starts a
+    background job and returns a *pending* record; call :meth:`wait` to block
+    until the data is processed.
 
     Attributes
     ----------
@@ -102,7 +109,7 @@ class PointCloud(PointCloudModel):
     Examples
     --------
     Upload a point cloud and wait for it to process:
-    >>> import fastfuels_sdk as ff
+    >>> import fastfuels_sdk.v2 as ff
     >>> pc = ff.point_clouds.create_point_cloud_from_file(
     ...     domain, "scan.laz", point_cloud_type="als"
     ... )
@@ -113,6 +120,7 @@ class PointCloud(PointCloudModel):
 
     See Also
     --------
+    create_point_cloud_from_3dep : Fetch public airborne LiDAR from USGS 3DEP.
     create_point_cloud_from_file : Upload a local LiDAR file.
     list_point_clouds : List point clouds in a domain or across all domains.
     """
@@ -271,8 +279,70 @@ class PointCloud(PointCloudModel):
 
 
 # ---------------------------------------------------------------------------
-# Create a point cloud from your own file
+# Create point clouds
 # ---------------------------------------------------------------------------
+
+
+def check_3dep_coverage(domain) -> PointCloudThreeDepCoverageResponse:
+    """Check USGS 3DEP LiDAR coverage before creating a point cloud.
+
+    Parameters
+    ----------
+    domain : Domain or str
+        The domain (or its id) to check.
+
+    Returns
+    -------
+    PointCloudThreeDepCoverageResponse
+        Availability, coverage fraction, estimated point count and budget,
+        and the contributing acquisitions.
+    """
+    response = check_3dep_point_cloud_coverage.sync_detailed(
+        _domain_id(domain),
+        client=ensure_client(),
+    )
+    return expect(response)
+
+
+def create_point_cloud_from_3dep(
+    domain,
+    datasets: Optional[List[str]] = None,
+    name: str = "",
+    description: str = "",
+    tags: Optional[List[str]] = None,
+) -> PointCloud:
+    """Create an airborne point cloud from USGS 3DEP LiDAR.
+
+    Parameters
+    ----------
+    domain : Domain or str
+        The domain (or its id) to create the point cloud in.
+    datasets : List[str], optional
+        Acquisition names to read, in priority order. Use
+        :func:`check_3dep_coverage` to discover names. If omitted, the API
+        selects acquisitions automatically.
+    name, description : str, optional
+        Metadata for the point cloud.
+    tags : List[str], optional
+        Tags for the point cloud.
+
+    Returns
+    -------
+    PointCloud
+        The created airborne PointCloud (job status "pending" or "running").
+    """
+    request_body = CreateThreeDepPointCloudRequest(
+        datasets=_opt(datasets),
+        name=name,
+        description=description,
+        tags=_opt(tags),
+    )
+    response = create_3dep_point_cloud_endpoint.sync_detailed(
+        _domain_id(domain),
+        client=ensure_client(),
+        body=request_body,
+    )
+    return PointCloud._from_model(expect(response, HTTPStatus.CREATED))
 
 
 def create_point_cloud_from_file(

--- a/fastfuels_sdk/v2/v2_api_design.md
+++ b/fastfuels_sdk/v2/v2_api_design.md
@@ -341,8 +341,20 @@ operations have no SDK surface. Ordered by what unblocks a user workflow.
 - `get_chunk_metadata` / `get_grid_data_json` stay unwrapped — the binary
   chunk path already covers `to_numpy`/`to_xarray`.
 
-### Account management (unwrapped, lowest priority)
+### Account management (deliberately generated-client only)
 
-`applications` (6) and `keys` (4) are entirely unwrapped. These are console
-concerns; wrap only if the SDK is meant to provision its own credentials.
-`Application` gained `tier`/`quota_overrides`.
+**Decision (2026-08-04): do not add high-level wrappers for `applications`
+or `keys`.** The public SDK consumes an existing API key; application and key
+provisioning remain account-console concerns.
+
+The ten generated endpoints remain available in `client_library`, including
+the new `Application.tier`/`quota_overrides` fields, but they are not exported
+through `fastfuels_sdk.v2`. This keeps one-time key secrets, credential
+rotation/revocation, and destructive account operations out of ordinary data
+workflows. It also matches v1, where these endpoints exist only in the
+generated client and never gained a high-level wrapper.
+
+Revisit this boundary only if programmatic credential provisioning becomes a
+supported SDK use case. That work should be designed as a dedicated account
+module with explicit secret-handling requirements rather than added piecemeal
+to the resource wrappers.

--- a/fastfuels_sdk/v2/v2_api_design.md
+++ b/fastfuels_sdk/v2/v2_api_design.md
@@ -240,8 +240,9 @@ later merges). Each new resource/endpoint kept to the settled rules above.
   point_cloud_type=)`, `list_point_clouds`/`get_point_cloud`. Nothing else
   sources from a point cloud yet.
 - **Inventory treatments** — `Inventory.apply_treatments([...])` (in-place
-  re-derive; unlike `apply_modifications` it does *not* hit #333) + the
-  `ff.basal_area_treatment`/`ff.diameter_treatment` builders (`treatments.py`).
+  re-derive) + the `ff.basal_area_treatment`/`ff.diameter_treatment` builders
+  (`treatments.py`). The former #333 fork-safety blocker for both in-place
+  processing paths is fixed.
 - **GDAM** — `create_tree_inventory_from_gdam(domain, source_inventory,
   impute_columns=)`. A *create* (new inventory) → a function in the
   `create_tree_inventory_from_*` family, **not** a method — same call as the

--- a/fastfuels_sdk/v2/v2_api_design.md
+++ b/fastfuels_sdk/v2/v2_api_design.md
@@ -255,3 +255,94 @@ later merges). Each new resource/endpoint kept to the settled rules above.
 - **Uploads** — one shared `_uploads.put_upload(spec, path)` echoes the
   server's signed `spec.headers` verbatim; replaced the two divergent
   `_put_upload` copies (grids had been missing the GCS content-length-range).
+
+## Post-regen backlog (2026-08-04)
+
+Client re-synced against the live spec: 94 operations, 236 schemas. 19
+operations have no SDK surface. Ordered by what unblocks a user workflow.
+
+### Breaking (landed with the regen)
+
+- `get_inventory_data` split into `get_inventory_data_json` (adds
+  `json_orientation`) and `get_inventory_data_csv`; `InventoryDataFormat` is
+  gone. `Inventory.get_data_partition` now calls the JSON variant — behavior
+  unchanged. The CSV variant is unused (see *data out* below).
+- Second spec title collision — the point cloud and topography 3DEP
+  pre-flight responses are both titled `ThreeDepCoverageResponse`, which
+  silently dropped the point cloud coverage endpoint from the client.
+  `generate_client.sh` now re-titles the point cloud one to
+  `PointCloudThreeDepCoverageResponse`, alongside the `Feature` patch.
+  Same long-term fix: re-title in FastFuels-API-v2 so the spec is clean.
+
+### Quotas — cross-cutting, affects every creator
+
+41 of 94 operations can now return **429** with a structured
+`QuotaExceededDetail` (`quota`, `current`, `limit`, `window_reset_on`).
+`exceptions.py` has no 429 mapping, so today it degrades to a bare
+`ApiException`. Needs a `QuotaExceededException` carrying those fields —
+`window_reset_on` is what a caller retries on.
+
+- `ff.get_quotas()` / `ff.get_usage()` ← `users/me`, `users/me/usage`
+  (`Quotas`, `Usage` per resource type: active/total counts, storage bytes,
+  weekly dispatch windows, TTL policy). Top-level functions: owner-scoped,
+  no held resource.
+
+### New resource sources
+
+- **3DEP point clouds** — `ff.point_clouds.create_point_cloud_from_3dep(
+  domain, datasets=)` + `ff.point_clouds.check_3dep_coverage(domain)`
+  (returns `available`, `coverage_fraction`, `estimated_point_count`,
+  `point_budget`, `exceeds_point_budget`, per-acquisition `datasets`).
+  Mirrors the existing `grids.check_3dep_coverage` pre-flight pattern; this
+  is the first non-upload point cloud source.
+- **Point cloud → CHM** — `ff.grids.create_canopy_height_grid_from_point_cloud(
+  point_cloud, ...)`. First consumer of a point cloud, which closes the
+  3DEP → CHM → tree inventory chain entirely inside the SDK.
+
+### New grid creators
+
+- **DUET** — `ff.grids.create_surface_fuel_grid_from_duet(source_grid,
+  years_since_burn=, wind_direction=, wind_variability=, bands=,
+  calibration=)`. Needs a `duet_calibration(...)` builder in the
+  `modifications.py`/`treatments.py` family: `DuetCalibration` nests
+  fuel_load/fuel_depth/fuel_moisture → per-fuel-type
+  (grass/coniferous/deciduous/litter/all) targets in three shapes
+  (constant / max-min / mean-sd).
+- **FBFM13** — `create_fuel_model_grid_from_landfire_fbfm13` (version
+  2023/2024, `remove_non_burnable=`) and
+  `create_fuel_grid_from_fbfm13_lookup` (9 bands), matching the FBFM40 pair.
+- **FCCS lookup** — `create_fuel_grid_from_fccs_lookup` (12 bands incl. duff
+  and live components). The FCCS *source* creator exists; the lookup that
+  turns it into fuel parameters does not.
+- **Compose** — `create_grid_from_compose(inputs, select=, compute=)`: grid
+  algebra over aliased input bands (`add`/`subtract`/`multiply`/`divide`/
+  `min`/`max`/`average`, conditional `select` with `else_`). The largest
+  design question in this batch — it is a small DSL, not a creator with
+  kwargs, and it needs builders to be usable from Python.
+
+### New export
+
+- **Landscape (LCP)** — `ff.exports.create_landscape_export(...)`: 8-band
+  FlamMap/IFTDSS/WFDSS GeoTIFF assembled from 8 named
+  `LandscapeFieldSource` (grid_id + band) plus `fire_behavior_fuel_model`
+  (fbfm13/fbfm40) and alignment. Assembled-from-many → function, same shape
+  as `create_quicfire_export`.
+
+### Records and data out
+
+- `Inventory.forestry_metrics` — new `TreeForestryMetrics` on the inventory
+  record (tree_count, basal area/acre, TPA, QMD, dominant FIA species
+  groups). Read-only accessor; the parallel of `Grid.band_summary`.
+- `Inventory.column_summary(column)` — `Column.summary` is new
+  (categorical/continuous), exactly mirroring `Band.summary`; reuse the
+  `band_summary` shape.
+- `Inventory.to_dataframe` should fetch CSV partitions and `pd.read_csv`
+  them instead of rebuilding frames from JSON row lists.
+- `get_chunk_metadata` / `get_grid_data_json` stay unwrapped — the binary
+  chunk path already covers `to_numpy`/`to_xarray`.
+
+### Account management (unwrapped, lowest priority)
+
+`applications` (6) and `keys` (4) are entirely unwrapped. These are console
+concerns; wrap only if the SDK is meant to provision its own credentials.
+`Application` gained `tier`/`quota_overrides`.

--- a/fastfuels_sdk/v2/v2_api_design.md
+++ b/fastfuels_sdk/v2/v2_api_design.md
@@ -267,12 +267,11 @@ operations have no SDK surface. Ordered by what unblocks a user workflow.
   `json_orientation`) and `get_inventory_data_csv`; `InventoryDataFormat` is
   gone. `Inventory.get_data_partition` now calls the JSON variant — behavior
   unchanged. The CSV variant is unused (see *data out* below).
-- Second spec title collision — the point cloud and topography 3DEP
-  pre-flight responses are both titled `ThreeDepCoverageResponse`, which
-  silently dropped the point cloud coverage endpoint from the client.
-  `generate_client.sh` now re-titles the point cloud one to
-  `PointCloudThreeDepCoverageResponse`, alongside the `Feature` patch.
-  Same long-term fix: re-title in FastFuels-API-v2 so the spec is clean.
+- FastFuels-API-v2#489 resolved both schema-title collisions at the source.
+  `generate_client.sh` now consumes the production spec without patching it.
+  The generated domain request model is `GeoJsonFeatureCollection`, and the
+  two 3DEP coverage models are `PointCloudThreeDepCoverageResponse` and
+  `TopographyThreeDepCoverageResponse`.
 
 ### Quotas — cross-cutting, affects every creator
 

--- a/tests/v2/conftest.py
+++ b/tests/v2/conftest.py
@@ -23,6 +23,7 @@ from fastfuels_sdk.v2.features import (
 from fastfuels_sdk.v2.grids import (
     create_fuel_model_grid_from_landfire_fbfm13,
     create_fuel_model_grid_from_landfire_fbfm40,
+    create_fuel_model_grid_from_landfire_fccs,
     create_pim_grid_from_treemap,
     create_topography_grid_from_3dep,
 )
@@ -110,6 +111,21 @@ def completed_fbfm13_grid(test_domain):
         output_resolution_m=30,
         name="test_fbfm13",
         description="FBFM13 grid for testing v2 grid lookup operations",
+        tags=["test"],
+    )
+    grid.wait()
+    return grid
+
+
+@pytest.fixture(scope="session")
+def completed_fccs_grid(test_domain):
+    """A completed LANDFIRE FCCS fuelbed grid. READ-ONLY."""
+    grid = create_fuel_model_grid_from_landfire_fccs(
+        test_domain,
+        remove_bare_ground=True,
+        output_resolution_m=30,
+        name="test_fccs",
+        description="FCCS grid for testing v2 grid lookup operations",
         tags=["test"],
     )
     grid.wait()

--- a/tests/v2/conftest.py
+++ b/tests/v2/conftest.py
@@ -21,6 +21,7 @@ from fastfuels_sdk.v2.features import (
     create_road_feature_from_osm,
 )
 from fastfuels_sdk.v2.grids import (
+    create_fuel_model_grid_from_landfire_fbfm13,
     create_fuel_model_grid_from_landfire_fbfm40,
     create_pim_grid_from_treemap,
     create_topography_grid_from_3dep,
@@ -93,6 +94,22 @@ def completed_fbfm40_grid(test_domain):
         output_resolution_m=30,
         name="test_fbfm40",
         description="FBFM40 grid for testing v2 grid lookup operations",
+        tags=["test"],
+    )
+    grid.wait()
+    return grid
+
+
+@pytest.fixture(scope="session")
+def completed_fbfm13_grid(test_domain):
+    """A completed LANDFIRE FBFM13 fuel model grid. READ-ONLY."""
+    grid = create_fuel_model_grid_from_landfire_fbfm13(
+        test_domain,
+        version="2024",
+        remove_non_burnable=["NB1", "NB2"],
+        output_resolution_m=30,
+        name="test_fbfm13",
+        description="FBFM13 grid for testing v2 grid lookup operations",
         tags=["test"],
     )
     grid.wait()

--- a/tests/v2/test_api.py
+++ b/tests/v2/test_api.py
@@ -1,0 +1,76 @@
+"""Tests for v2 client configuration and owner-scoped API helpers."""
+
+from http import HTTPStatus
+
+import fastfuels_sdk.v2 as ff
+import fastfuels_sdk.v2.api as api
+from fastfuels_sdk.v2.client_library.models import (
+    CountUsage,
+    JobResourceUsage,
+    Quotas,
+    Usage,
+    UsageCount,
+    UsageLifecycle,
+    UsageStorage,
+    UserMeResponse,
+    UserMeResponseKind,
+)
+from fastfuels_sdk.v2.client_library.types import Response
+
+
+def _response(parsed):
+    return Response(
+        status_code=HTTPStatus.OK,
+        content=b"",
+        headers={},
+        parsed=parsed,
+    )
+
+
+def test_get_quotas_returns_authenticated_owner_quotas(monkeypatch):
+    client = object()
+    quotas = Quotas(max_active_grids=3)
+    owner = UserMeResponse(
+        id="owner-id",
+        kind=UserMeResponseKind.USER,
+        tier="standard",
+        quotas=quotas,
+    )
+    monkeypatch.setattr(api, "ensure_client", lambda: client)
+    monkeypatch.setattr(
+        api.get_me,
+        "sync_detailed",
+        lambda *, client: _response(owner),
+    )
+
+    assert ff.get_quotas() is quotas
+
+
+def test_get_usage_returns_authenticated_owner_usage(monkeypatch):
+    client = object()
+    count = UsageCount(usage=1, limit=10)
+    storage = UsageStorage(usage_bytes=1024, limit_bytes=2048)
+    job_usage = JobResourceUsage(active=count, total=count, storage=storage)
+    count_usage = CountUsage(total=count)
+    usage = Usage(
+        grids=job_usage,
+        exports=job_usage,
+        inventories=job_usage,
+        features=job_usage,
+        pointclouds=job_usage,
+        domains=count_usage,
+        applications=count_usage,
+        api_keys=count_usage,
+        lifecycle=UsageLifecycle(
+            resource_ttl_days=180,
+            failed_resource_ttl_days=14,
+        ),
+    )
+    monkeypatch.setattr(api, "ensure_client", lambda: client)
+    monkeypatch.setattr(
+        api.get_me_usage,
+        "sync_detailed",
+        lambda *, client: _response(usage),
+    )
+
+    assert ff.get_usage() is usage

--- a/tests/v2/test_calibrations.py
+++ b/tests/v2/test_calibrations.py
@@ -1,0 +1,84 @@
+"""Tests for v2 calibration builders."""
+
+import pytest
+
+from fastfuels_sdk.v2.calibrations import duet_calibration
+from fastfuels_sdk.v2.client_library.models import (
+    DuetConstantCalibrationTarget,
+    DuetMaxMinCalibrationTarget,
+    DuetMeanSdCalibrationTarget,
+)
+
+
+def test_duet_calibration_builds_each_target_method():
+    calibration = duet_calibration(
+        fuel_load={
+            "grass": {"mean": 0.5, "sd": 0.25},
+            "litter": {"max": 5.0},
+        },
+        fuel_depth={"all": {"value": 0.3}},
+    )
+
+    assert isinstance(calibration.fuel_load.grass, DuetMeanSdCalibrationTarget)
+    assert isinstance(calibration.fuel_load.litter, DuetMaxMinCalibrationTarget)
+    assert calibration.fuel_load.litter.min_ == 0.0
+    assert isinstance(calibration.fuel_depth.all_, DuetConstantCalibrationTarget)
+    assert calibration.to_dict() == {
+        "fuel_load": {
+            "grass": {"method": "meansd", "mean": 0.5, "sd": 0.25},
+            "litter": {"method": "maxmin", "max": 5.0, "min": 0.0},
+        },
+        "fuel_depth": {
+            "all": {"method": "constant", "value": 0.3},
+        },
+    }
+
+
+def test_duet_calibration_accepts_explicit_method():
+    calibration = duet_calibration(
+        fuel_moisture={
+            "grass": {"method": "constant", "value": 12},
+        }
+    )
+
+    assert calibration.fuel_moisture.grass.value == 12
+
+
+def test_duet_calibration_requires_a_parameter():
+    with pytest.raises(ValueError, match="at least one"):
+        duet_calibration()
+
+
+def test_duet_calibration_all_is_exclusive():
+    with pytest.raises(ValueError, match="cannot be combined"):
+        duet_calibration(
+            fuel_load={
+                "all": {"value": 1},
+                "grass": {"value": 1},
+            }
+        )
+
+
+def test_duet_calibration_litter_is_exclusive_of_components():
+    with pytest.raises(ValueError, match="litter"):
+        duet_calibration(
+            fuel_load={
+                "litter": {"value": 1},
+                "coniferous": {"value": 1},
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "target,match",
+    [
+        ({"method": "unknown", "value": 1}, "Unknown calibration method"),
+        ({"mean": 1}, "missing required fields"),
+        ({"max": 1, "min": 2}, "greater than or equal"),
+        ({"value": -1}, "nonnegative"),
+        ({"value": 1, "max": 2}, "not used"),
+    ],
+)
+def test_duet_calibration_rejects_invalid_targets(target, match):
+    with pytest.raises(ValueError, match=match):
+        duet_calibration(fuel_load={"grass": target})

--- a/tests/v2/test_compose.py
+++ b/tests/v2/test_compose.py
@@ -1,0 +1,312 @@
+"""Tests for v2 grid-compose builders and creator."""
+
+from http import HTTPStatus
+
+import numpy as np
+import pytest
+
+from fastfuels_sdk.v2 import compose, grids
+from fastfuels_sdk.v2.client_library.models import (
+    Band,
+    BandType,
+    ComposeComparisonOperator,
+    ComposeCompute,
+    ComposeLiteral,
+    ComposeOperator,
+    ComposeSelect,
+    GridSource,
+    InlineCompute,
+    JobStatus,
+)
+from fastfuels_sdk.v2.client_library.types import Response
+from fastfuels_sdk.v2.grids import (
+    Grid,
+    create_fuel_grid_from_fbfm40_lookup,
+    create_grid_from_compose,
+)
+
+
+def _grid(
+    id_="source-grid",
+    domain_id="domain-id",
+    status=JobStatus.COMPLETED,
+    bands=None,
+):
+    return Grid(
+        id=id_,
+        domain_id=domain_id,
+        status=status,
+        source=GridSource(),
+        bands=bands
+        or [
+            Band(
+                key="fuel_load.1hr",
+                type_=BandType.CONTINUOUS,
+                index=0,
+                unit="kg/m**2",
+            ),
+            Band(
+                key="fuel_depth",
+                type_=BandType.CONTINUOUS,
+                index=1,
+                unit="m",
+            ),
+        ],
+    )
+
+
+class TestComposeBuilders:
+    def test_select(self):
+        operation = compose.select("fuel_depth", "fuels.fuel_depth")
+
+        assert isinstance(operation, ComposeSelect)
+        assert operation.to_dict() == {
+            "output": "fuel_depth",
+            "from": "fuels.fuel_depth",
+        }
+
+    def test_compute(self):
+        operation = compose.compute(
+            "fuel_load.1hr",
+            "multiply",
+            ["fuels.fuel_load.1hr", 0.5],
+            unit="kg/m**2",
+        )
+
+        assert isinstance(operation, ComposeCompute)
+        assert operation.operator == ComposeOperator.MULTIPLY
+        assert operation.to_dict() == {
+            "operator": "multiply",
+            "operands": ["fuels.fuel_load.1hr", 0.5],
+            "output": "fuel_load.1hr",
+            "unit": "kg/m**2",
+        }
+
+    def test_conditional_typed_literal_fallback(self):
+        where = compose.condition("fuels.fbfm", "in", ["GR1", "GR2"])
+        fallback = compose.literal(0, unit="kg/m**2")
+        operation = compose.select(
+            "fuel_load.1hr",
+            "fuels.fuel_load.1hr",
+            conditions=[where],
+            else_=fallback,
+        )
+
+        assert where.operator == ComposeComparisonOperator.IN
+        assert isinstance(fallback, ComposeLiteral)
+        assert operation.to_dict()["conditions"] == [
+            {
+                "band": "fuels.fbfm",
+                "operator": "in",
+                "value": ["GR1", "GR2"],
+            }
+        ]
+        assert operation.to_dict()["else"] == {
+            "type": "literal",
+            "value": 0,
+            "unit": "kg/m**2",
+        }
+
+    def test_inline_compute(self):
+        fallback = compose.inline_compute(
+            "average",
+            ["base.fuel_load.1hr", "alternate.fuel_load.1hr"],
+        )
+
+        assert isinstance(fallback, InlineCompute)
+        assert fallback.to_dict() == {
+            "operator": "average",
+            "operands": [
+                "base.fuel_load.1hr",
+                "alternate.fuel_load.1hr",
+            ],
+        }
+
+    @pytest.mark.parametrize(
+        "operator,operands",
+        [
+            ("add", ["fuels.fuel_load.1hr"]),
+            ("subtract", ["fuels.fuel_load.1hr", 1, 2]),
+            ("divide", [1, 2]),
+        ],
+    )
+    def test_compute_rejects_invalid_operands(self, operator, operands):
+        with pytest.raises(ValueError):
+            compose.compute("output", operator, operands)
+
+    def test_condition_in_requires_list(self):
+        with pytest.raises(ValueError, match="requires a list"):
+            compose.condition("fuels.fbfm", "in", "GR1")
+
+    def test_condition_ordering_requires_scalar(self):
+        with pytest.raises(ValueError, match="requires a scalar"):
+            compose.condition("fuels.fuel_depth", "gt", [0, 1])
+
+    def test_conditions_require_fallback(self):
+        with pytest.raises(ValueError, match="else_"):
+            compose.select(
+                "fuel_depth",
+                "fuels.fuel_depth",
+                conditions=[compose.condition("fuels.fuel_depth", "gt", 0)],
+            )
+
+    def test_string_literal_cannot_have_unit(self):
+        with pytest.raises(ValueError, match="cannot carry a unit"):
+            compose.literal("GR1", unit="kg/m**2")
+
+
+class TestCreateGridFromCompose:
+    def test_builds_request(self, monkeypatch):
+        source = _grid()
+        created = _grid(id_="composed-grid", status=JobStatus.PENDING)
+        captured = {}
+
+        def fake_create(domain_id, *, client, body):
+            captured.update(domain_id=domain_id, client=client, body=body)
+            return Response(
+                status_code=HTTPStatus.CREATED,
+                content=b"",
+                headers={},
+                parsed=created,
+            )
+
+        client = object()
+        monkeypatch.setattr(grids, "ensure_client", lambda: client)
+        monkeypatch.setattr(
+            grids.create_compose_grid,
+            "sync_detailed",
+            fake_create,
+        )
+
+        result = create_grid_from_compose(
+            {"fuels": source},
+            select=[compose.select("fuel_depth", "fuels.fuel_depth")],
+            compute=[
+                compose.compute(
+                    "fuel_load.1hr",
+                    "multiply",
+                    ["fuels.fuel_load.1hr", 0.5],
+                )
+            ],
+            name="Composed fuels",
+            tags=["test"],
+        )
+
+        assert result.id == "composed-grid"
+        assert captured["domain_id"] == "domain-id"
+        assert captured["client"] is client
+        assert [item.to_dict() for item in captured["body"].inputs] == [
+            {"grid_id": "source-grid", "alias": "fuels"}
+        ]
+        assert captured["body"].select[0].output == "fuel_depth"
+        assert captured["body"].compute[0].operator == ComposeOperator.MULTIPLY
+        assert captured["body"].name == "Composed fuels"
+        assert captured["body"].tags == ["test"]
+
+    @pytest.mark.parametrize(
+        "inputs,match,error",
+        [
+            ([], "mapping", TypeError),
+            ({}, "at least one", ValueError),
+            ({"1bad": _grid()}, "Invalid compose alias", ValueError),
+            (
+                {"a": _grid(status=JobStatus.PENDING)},
+                "Cannot compose",
+                ValueError,
+            ),
+            (
+                {"a": _grid(), "b": _grid()},
+                "more than one alias",
+                ValueError,
+            ),
+            (
+                {"a": _grid(), "b": _grid(id_="other", domain_id="other")},
+                "same domain",
+                ValueError,
+            ),
+        ],
+    )
+    def test_rejects_invalid_inputs(self, inputs, match, error):
+        with pytest.raises(error, match=match):
+            create_grid_from_compose(
+                inputs,
+                select=[compose.select("fuel_depth", "a.fuel_depth")],
+            )
+
+    def test_requires_an_operation(self):
+        with pytest.raises(ValueError, match="At least one"):
+            create_grid_from_compose({"fuels": _grid()})
+
+    def test_rejects_duplicate_outputs(self):
+        with pytest.raises(ValueError, match="must be unique"):
+            create_grid_from_compose(
+                {"fuels": _grid()},
+                select=[compose.select("fuel", "fuels.fuel_depth")],
+                compute=[
+                    compose.compute(
+                        "fuel",
+                        "multiply",
+                        ["fuels.fuel_load.1hr", 0.5],
+                    )
+                ],
+            )
+
+    def test_rejects_empty_output(self):
+        with pytest.raises(ValueError, match="nonempty output"):
+            create_grid_from_compose(
+                {"fuels": _grid()},
+                select=[ComposeSelect(output="", from_="fuels.fuel_depth")],
+            )
+
+    @pytest.mark.parametrize(
+        "reference,match",
+        [
+            ("other.fuel_depth", "Unknown compose band reference"),
+            ("fuels.unknown", "has no 'unknown' band"),
+        ],
+    )
+    def test_rejects_unknown_references(self, reference, match):
+        with pytest.raises(ValueError, match=match):
+            create_grid_from_compose(
+                {"fuels": _grid()},
+                select=[compose.select("fuel_depth", reference)],
+            )
+
+    def test_create_live(self, completed_fbfm40_grid):
+        fuel_grid = create_fuel_grid_from_fbfm40_lookup(
+            completed_fbfm40_grid,
+            bands=["fuel_load.1hr", "fuel_depth"],
+            name="test_compose_source",
+            tags=["test"],
+        )
+        composed = None
+        try:
+            fuel_grid.wait()
+            composed = create_grid_from_compose(
+                {"fuels": fuel_grid},
+                select=[compose.select("fuel_depth", "fuels.fuel_depth")],
+                compute=[
+                    compose.compute(
+                        "fuel_load.1hr",
+                        "multiply",
+                        ["fuels.fuel_load.1hr", 0.5],
+                        conditions=[compose.condition("fuels.fuel_load.1hr", "gt", 0)],
+                        else_=compose.literal(0, unit="kg/m**2"),
+                    )
+                ],
+                name="test_composed_fuels",
+                tags=["test"],
+            )
+            composed.wait()
+            assert composed.status == JobStatus.COMPLETED
+            assert [band.key for band in composed.bands] == [
+                "fuel_depth",
+                "fuel_load.1hr",
+            ]
+            fuel_load = composed.to_numpy("fuel_load.1hr")
+            assert fuel_load.ndim == 2
+            assert np.isfinite(fuel_load).any()
+        finally:
+            if composed is not None:
+                composed.delete()
+            fuel_grid.delete()

--- a/tests/v2/test_domains.py
+++ b/tests/v2/test_domains.py
@@ -49,9 +49,8 @@ class TestCreateDomain:
         assert domain.description == self.domain_description
         assert domain.pad_to_resolution == self.pad_to_resolution
 
-        # v2 responses carry two named features: the working extent and
-        # the original input geometry
-        assert feature_names(domain) == {"domain", "input"}
+        # v2 responses carry the normalized working extent only.
+        assert feature_names(domain) == {"domain"}
 
         # If the input CRS is projected, the domain preserves it (echoing
         # the CRS name as sent, e.g. "urn:ogc:def:crs:EPSG::5070");
@@ -140,7 +139,7 @@ class TestPreviewDomain:
 
         # A preview is never persisted; its id is the "preview" sentinel
         assert previewed.id == "preview"
-        assert feature_names(previewed) == {"domain", "input"}
+        assert feature_names(previewed) == {"domain"}
         assert previewed.pad_to_resolution == 2.0
         assert len(previewed.bbox) >= 4
 
@@ -259,7 +258,7 @@ class TestToGeodataframe:
         gdf = test_domain.to_geodataframe()
 
         assert len(gdf) == len(test_domain.features)
-        assert set(gdf["name"]) == {"domain", "input"}
+        assert set(gdf["name"]) == {"domain"}
         assert (gdf["domain_id"] == test_domain.id).all()
         assert ":".join(gdf.crs.to_authority()) == test_domain.crs.properties.name
 

--- a/tests/v2/test_exceptions.py
+++ b/tests/v2/test_exceptions.py
@@ -1,0 +1,83 @@
+"""Tests for v2 API error translation."""
+
+import datetime
+import json
+from http import HTTPStatus
+
+import pytest
+
+from fastfuels_sdk.v2.client_library.models import QuotaExceededDetail
+from fastfuels_sdk.v2.client_library.types import Response
+from fastfuels_sdk.v2.exceptions import QuotaExceededException, expect
+
+
+def _quota_response(detail, *, parsed=True, retry_after=None):
+    headers = {}
+    if retry_after is not None:
+        headers["Retry-After"] = str(retry_after)
+    return Response(
+        status_code=HTTPStatus.TOO_MANY_REQUESTS,
+        content=json.dumps({"detail": detail.to_dict()}).encode(),
+        headers=headers,
+        parsed=detail if parsed else None,
+    )
+
+
+def test_quota_exceeded_exception_exposes_structured_detail():
+    detail = QuotaExceededDetail(
+        quota="max_active_grids",
+        current=25,
+        limit=25,
+        message="Too many active grid jobs.",
+    )
+
+    with pytest.raises(QuotaExceededException) as exc_info:
+        expect(_quota_response(detail, retry_after=60), HTTPStatus.CREATED)
+
+    error = exc_info.value
+    assert error.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert error.detail is detail
+    assert error.quota == "max_active_grids"
+    assert error.current == 25
+    assert error.limit == 25
+    assert error.window_reset_on is None
+    assert error.message == "Too many active grid jobs."
+    assert error.reason == "QUOTA_EXCEEDED"
+    assert error.retry_after == 60
+    assert str(error) == "(429) Too many active grid jobs."
+
+
+def test_quota_exceeded_exception_parses_raw_response_content():
+    reset = datetime.datetime(2026, 8, 10, tzinfo=datetime.timezone.utc)
+    detail = QuotaExceededDetail(
+        quota="max_weekly_grid_dispatches",
+        current=500,
+        limit=500,
+        window_reset_on=reset,
+        message="Weekly grid dispatch quota reached.",
+    )
+
+    with pytest.raises(QuotaExceededException) as exc_info:
+        expect(_quota_response(detail, parsed=False), HTTPStatus.CREATED)
+
+    error = exc_info.value
+    assert error.quota == "max_weekly_grid_dispatches"
+    assert error.window_reset_on == reset
+    assert error.message == "Weekly grid dispatch quota reached."
+    assert error.retry_after is None
+
+
+def test_generated_quota_parser_accepts_fastapi_detail_envelope():
+    detail = QuotaExceededDetail.from_dict(
+        {
+            "detail": {
+                "quota": "max_grids",
+                "current": 1000,
+                "limit": 1000,
+                "message": "Grid quota reached.",
+            }
+        }
+    )
+
+    assert detail.quota == "max_grids"
+    assert detail.message == "Grid quota reached."

--- a/tests/v2/test_exports.py
+++ b/tests/v2/test_exports.py
@@ -5,24 +5,41 @@ tests/v2/test_exports.py
 # Core imports
 import json
 import zipfile
+from http import HTTPStatus
+from types import SimpleNamespace
 from uuid import uuid4
 
 # Internal imports
 from fastfuels_sdk.v2.exports import (
     Export,
     _field_source,
+    _landscape_field_source,
+    create_landscape_export,
     create_quicfire_export,
     get_export,
     list_exports,
 )
 from fastfuels_sdk.v2.grids import (
+    create_canopy_fuel_grid_from_landfire,
     create_fuel_grid_from_fbfm40_lookup,
     create_fuel_model_grid_from_landfire_fbfm40,
     create_topography_grid_from_3dep,
     create_uniform_grid,
 )
-from fastfuels_sdk.v2.client_library.models import FieldSource, JobStatus
-from fastfuels_sdk.v2.exceptions import NotFoundException
+from fastfuels_sdk.v2.client_library.models import (
+    Export as ExportModel,
+    ExportSource,
+    FieldSource,
+    JobStatus,
+    LandscapeExportAlignmentDomainTarget,
+    LandscapeExportAlignmentGridTarget,
+    LandscapeFieldSource,
+)
+from fastfuels_sdk.v2.client_library.types import UNSET, Response
+from fastfuels_sdk.v2.exceptions import (
+    NotFoundException,
+    UnprocessableEntityException,
+)
 
 # External imports
 import numpy as np
@@ -53,6 +70,230 @@ class TestFieldSource:
     def test_invalid_value_raises(self):
         with pytest.raises(ValueError, match="surface_moisture"):
             _field_source("not-a-pair", "surface_moisture")
+
+
+def _landscape_roles():
+    return {
+        "elevation": ("topography-grid", "elevation"),
+        "slope": ("topography-grid", "slope"),
+        "aspect": ("topography-grid", "aspect"),
+        "fuel_model": ("fuel-model-grid", "fbfm"),
+        "canopy_cover": ("canopy-grid", "cc"),
+        "canopy_height": ("canopy-grid", "chm"),
+        "canopy_base_height": ("canopy-grid", "cbh"),
+        "canopy_bulk_density": ("canopy-grid", "cbd"),
+    }
+
+
+def _pending_export_model():
+    source = ExportSource()
+    source.additional_properties = {"name": "landscape"}
+    return ExportModel(
+        id="landscape-export-id",
+        domain_id="domain-id",
+        status=JobStatus.PENDING,
+        source=source,
+    )
+
+
+class TestLandscapeFieldSource:
+    def test_tuple_with_grid_object(self):
+        source = _landscape_field_source(
+            (SimpleNamespace(id="grid-id"), "elevation"), "elevation"
+        )
+
+        assert source.to_dict() == {"grid_id": "grid-id", "band": "elevation"}
+
+    def test_model_passes_through(self):
+        source = LandscapeFieldSource(grid_id="grid-id", band="elevation")
+        assert _landscape_field_source(source, "elevation") is source
+
+    def test_invalid_value_names_role(self):
+        with pytest.raises(ValueError, match="canopy_height"):
+            _landscape_field_source("not-a-pair", "canopy_height")
+
+
+class TestLandscapeExport:
+    @staticmethod
+    def _mock_endpoint(monkeypatch, response=None):
+        captured = {}
+        response = response or Response(
+            status_code=HTTPStatus.CREATED,
+            content=b"",
+            headers={},
+            parsed=_pending_export_model(),
+        )
+
+        def fake_create(domain_id, *, client, body):
+            captured.update(domain_id=domain_id, client=client, body=body)
+            return response
+
+        client = object()
+        monkeypatch.setattr("fastfuels_sdk.v2.exports.ensure_client", lambda: client)
+        monkeypatch.setattr(
+            "fastfuels_sdk.v2.exports.create_landscape_export_endpoint.sync_detailed",
+            fake_create,
+        )
+        return captured, client
+
+    def test_builds_request(self, monkeypatch):
+        captured, client = self._mock_endpoint(monkeypatch)
+
+        export = create_landscape_export(
+            SimpleNamespace(id="domain-id"),
+            fire_behavior_fuel_model="fbfm40",
+            name="Landscape",
+            tags=["test"],
+            **_landscape_roles(),
+        )
+
+        assert isinstance(export, Export)
+        assert export.id == "landscape-export-id"
+        assert captured["domain_id"] == "domain-id"
+        assert captured["client"] is client
+        assert captured["body"].alignment is UNSET
+        assert captured["body"].fire_behavior_fuel_model.value == "fbfm40"
+        assert captured["body"].elevation.to_dict() == {
+            "grid_id": "topography-grid",
+            "band": "elevation",
+        }
+        assert captured["body"].canopy_bulk_density.to_dict() == {
+            "grid_id": "canopy-grid",
+            "band": "cbd",
+        }
+        assert captured["body"].name == "Landscape"
+        assert captured["body"].tags == ["test"]
+
+    def test_domain_alignment(self, monkeypatch):
+        captured, _ = self._mock_endpoint(monkeypatch)
+
+        create_landscape_export(
+            "domain-id",
+            fire_behavior_fuel_model="fbfm40",
+            resolution_m=10,
+            **_landscape_roles(),
+        )
+
+        assert isinstance(
+            captured["body"].alignment, LandscapeExportAlignmentDomainTarget
+        )
+        assert captured["body"].alignment.resolution == 10
+
+    def test_grid_alignment(self, monkeypatch):
+        captured, _ = self._mock_endpoint(monkeypatch)
+
+        create_landscape_export(
+            "domain-id",
+            fire_behavior_fuel_model="fbfm13",
+            align_to=SimpleNamespace(id="master-grid"),
+            **_landscape_roles(),
+        )
+
+        assert isinstance(
+            captured["body"].alignment, LandscapeExportAlignmentGridTarget
+        )
+        assert captured["body"].alignment.grid_id == "master-grid"
+
+    def test_alignment_arguments_are_exclusive(self):
+        with pytest.raises(ValueError, match="not both"):
+            create_landscape_export(
+                "domain-id",
+                fire_behavior_fuel_model="fbfm40",
+                resolution_m=30,
+                align_to="master-grid",
+                **_landscape_roles(),
+            )
+
+    def test_alignment_error_is_preserved(self, monkeypatch):
+        response = Response(
+            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+            content=b'{"detail":"fuel_model grid is not aligned with landscape"}',
+            headers={},
+            parsed=None,
+        )
+        self._mock_endpoint(monkeypatch, response=response)
+
+        with pytest.raises(UnprocessableEntityException) as exc_info:
+            create_landscape_export(
+                "domain-id",
+                fire_behavior_fuel_model="fbfm40",
+                **_landscape_roles(),
+            )
+
+        assert exc_info.value.detail == (
+            "fuel_model grid is not aligned with landscape"
+        )
+
+    @pytest.fixture(scope="class")
+    def topography_grid(self, test_domain):
+        grid = create_topography_grid_from_3dep(
+            test_domain,
+            source_resolution_m=10,
+            output_resolution_m=30,
+            bands=["elevation", "slope", "aspect"],
+            name="landscape_topography",
+            tags=["test"],
+        )
+        grid.wait()
+        return grid
+
+    @pytest.fixture(scope="class")
+    def canopy_grid(self, test_domain):
+        grid = create_canopy_fuel_grid_from_landfire(
+            test_domain,
+            output_resolution_m=30,
+            bands=["cc", "chm", "cbh", "cbd"],
+            name="landscape_canopy",
+            tags=["test"],
+        )
+        grid.wait()
+        return grid
+
+    def test_landscape_roundtrip(
+        self,
+        test_domain,
+        topography_grid,
+        completed_fbfm40_grid,
+        canopy_grid,
+        tmp_path,
+    ):
+        export = create_landscape_export(
+            test_domain,
+            fire_behavior_fuel_model="fbfm40",
+            elevation=(topography_grid, "elevation"),
+            slope=(topography_grid, "slope"),
+            aspect=(topography_grid, "aspect"),
+            fuel_model=(completed_fbfm40_grid, "fbfm"),
+            canopy_cover=(canopy_grid, "cc"),
+            canopy_height=(canopy_grid, "chm"),
+            canopy_base_height=(canopy_grid, "cbh"),
+            canopy_bulk_density=(canopy_grid, "cbd"),
+            name="test_landscape",
+            tags=["test"],
+        )
+        try:
+            assert isinstance(export, Export)
+            assert export.status in (JobStatus.PENDING, JobStatus.RUNNING)
+            assert export.source["name"] == "landscape"
+            assert len(export.source["georeference"]["shape"]) == 2
+
+            export.wait()
+            destination = export.to_file(tmp_path / "landscape.tif")
+            with rasterio.open(destination) as dataset:
+                assert dataset.count == 8
+                assert dataset.dtypes == ("int16",) * 8
+                assert dataset.descriptions == (
+                    "Elevation",
+                    "Slope",
+                    "Aspect",
+                    "Fuel Model",
+                    "Canopy Cover",
+                    "Canopy Height",
+                    "Canopy Base Height",
+                    "Canopy Bulk Density",
+                )
+        finally:
+            export.delete()
 
 
 class TestGridExportLifecycle:

--- a/tests/v2/test_features.py
+++ b/tests/v2/test_features.py
@@ -248,10 +248,6 @@ class TestListFeatures:
         features = list_features(test_domain, tag="layerset-test")
         assert [feature.id for feature in features] == [layerset_feature.id]
 
-    @pytest.mark.xfail(
-        reason="v2 API returns 500 for feature sort_by combinations; "
-        "see FastFuels-API-v2#321",
-    )
     def test_sorting(self, test_domain, layerset_feature):
         features = list_features(
             test_domain, sort_by="created_on", sort_order="descending"

--- a/tests/v2/test_grids.py
+++ b/tests/v2/test_grids.py
@@ -26,6 +26,7 @@ from fastfuels_sdk.v2.grids import (
     create_canopy_height_grid_from_meta,
     create_canopy_height_grid_from_naip_chm,
     create_canopy_height_grid_from_point_cloud,
+    create_fuel_grid_from_fccs_lookup,
     create_fuel_grid_from_fbfm13_lookup,
     create_fuel_grid_from_fbfm40_lookup,
     create_fuel_model_grid_from_landfire_fbfm13,
@@ -47,6 +48,7 @@ from fastfuels_sdk.v2.client_library.models import (
     BandType,
     ContinuousBandSummary,
     DuetBand,
+    FccsLookupBand,
     Fbfm13LookupBand,
     GridAlignmentDomainTarget,
     GridAlignmentGridTarget,
@@ -954,6 +956,94 @@ class TestFbfm13Lookup:
             create_fuel_grid_from_fbfm13_lookup(
                 self._source(band="elevation"),
                 bands=["fuel_load.1hr"],
+            )
+
+
+class TestFccsLookup:
+    @staticmethod
+    def _source(status=JobStatus.COMPLETED, band="fccs"):
+        return Grid(
+            id="fccs-grid-id",
+            domain_id="domain-id",
+            status=status,
+            source=GridSource(),
+            bands=[Band(key=band, type_=BandType.CATEGORICAL, index=0)],
+        )
+
+    def test_builds_request(self, monkeypatch):
+        created = Grid(
+            id="fuel-grid-id",
+            domain_id="domain-id",
+            status=JobStatus.PENDING,
+            source=GridSource(),
+            bands=[],
+        )
+        captured = {}
+
+        def fake_create(domain_id, *, client, body):
+            captured.update(domain_id=domain_id, client=client, body=body)
+            return Response(
+                status_code=HTTPStatus.CREATED,
+                content=b"",
+                headers={},
+                parsed=created,
+            )
+
+        client = object()
+        monkeypatch.setattr(grids, "ensure_client", lambda: client)
+        monkeypatch.setattr(
+            grids.create_fccs_lookup,
+            "sync_detailed",
+            fake_create,
+        )
+
+        result = create_fuel_grid_from_fccs_lookup(
+            self._source(),
+            bands=["fuel_load.duff", FccsLookupBand.DUFF_DEPTH],
+            name="FCCS fuel parameters",
+            tags=["test"],
+        )
+
+        assert result.id == "fuel-grid-id"
+        assert captured["domain_id"] == "domain-id"
+        assert captured["client"] is client
+        assert captured["body"].source_grid_id == "fccs-grid-id"
+        assert captured["body"].source_band == "fccs"
+        assert captured["body"].bands == [
+            FccsLookupBand.FUEL_LOAD_DUFF,
+            FccsLookupBand.DUFF_DEPTH,
+        ]
+        assert captured["body"].name == "FCCS fuel parameters"
+        assert captured["body"].tags == ["test"]
+
+    def test_lookup_returns_new_pending_grid(self, completed_fccs_grid):
+        fuel_grid = create_fuel_grid_from_fccs_lookup(
+            completed_fccs_grid,
+            bands=[
+                "fuel_load.litter",
+                "fuel_load.duff",
+                "duff_depth",
+                "fuel_load.live_shrub",
+            ],
+            name="throwaway_fccs_lookup",
+        )
+        assert fuel_grid.id != completed_fccs_grid.id
+        assert fuel_grid.domain_id == completed_fccs_grid.domain_id
+        assert fuel_grid.status in (JobStatus.PENDING, JobStatus.RUNNING)
+        fuel_grid.delete()
+
+    def test_requires_completed_source(self):
+        with pytest.raises(ValueError, match="look up fuel"):
+            create_fuel_grid_from_fccs_lookup(
+                self._source(status=JobStatus.PENDING),
+                bands=["fuel_load.duff"],
+            )
+
+    def test_rejects_non_fccs_grid(self):
+        with pytest.raises(ValueError, match="fccs"):
+            create_fuel_grid_from_fccs_lookup(
+                self._source(band="elevation"),
+                bands=["fuel_load.duff"],
             )
 
 

--- a/tests/v2/test_grids.py
+++ b/tests/v2/test_grids.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 
 # Internal imports
 from fastfuels_sdk.v2 import grids
+from fastfuels_sdk.v2.calibrations import duet_calibration
 from fastfuels_sdk.v2.grids import (
     Grid,
     _build_alignment,
@@ -30,6 +31,7 @@ from fastfuels_sdk.v2.grids import (
     create_fuel_model_grid_from_landfire_fccs,
     create_grid_from_geotiff,
     create_pim_grid_from_treemap,
+    create_surface_fuel_grid_from_duet,
     create_topography_grid_from_3dep,
     create_topography_grid_from_landfire,
     create_uniform_grid,
@@ -42,6 +44,7 @@ from fastfuels_sdk.v2.client_library.models import (
     Band,
     BandType,
     ContinuousBandSummary,
+    DuetBand,
     GridAlignmentDomainTarget,
     GridAlignmentGridTarget,
     GridAlignmentNativeTarget,
@@ -315,6 +318,173 @@ class TestCreateCanopyHeightGridFromPointCloud:
             create_canopy_height_grid_from_point_cloud(
                 self._point_cloud(type_=PointCloudType.TLS)
             )
+
+
+class TestCreateSurfaceFuelGridFromDuet:
+    @staticmethod
+    def _source_grid(
+        status=JobStatus.COMPLETED,
+        omit=None,
+    ):
+        required = [
+            ("bulk_density.foliage.live", BandType.CONTINUOUS),
+            ("spcd", BandType.CATEGORICAL),
+            ("fuel_moisture.live", BandType.CONTINUOUS),
+        ]
+        return Grid(
+            id="tree-grid-id",
+            domain_id="domain-id",
+            status=status,
+            source=GridSource(),
+            bands=[
+                Band(key=key, type_=type_, index=index)
+                for index, (key, type_) in enumerate(required)
+                if key != omit
+            ],
+        )
+
+    def test_builds_request_from_completed_tree_grid(self, monkeypatch):
+        created = Grid(
+            id="duet-grid-id",
+            domain_id="domain-id",
+            status=JobStatus.PENDING,
+            source=GridSource(),
+            bands=[],
+        )
+        captured = {}
+
+        def fake_create(domain_id, *, client, body):
+            captured.update(domain_id=domain_id, client=client, body=body)
+            return Response(
+                status_code=HTTPStatus.CREATED,
+                content=b"",
+                headers={},
+                parsed=created,
+            )
+
+        client = object()
+        calibration = duet_calibration(fuel_load={"grass": {"mean": 0.5, "sd": 0.25}})
+        monkeypatch.setattr(grids, "ensure_client", lambda: client)
+        monkeypatch.setattr(
+            grids.create_duet_grid,
+            "sync_detailed",
+            fake_create,
+        )
+
+        grid = create_surface_fuel_grid_from_duet(
+            self._source_grid(),
+            years_since_burn=20,
+            wind_direction=225,
+            wind_variability=45,
+            bands=["fuel_load.grass", DuetBand.FUEL_LOAD_LITTER],
+            calibration=calibration,
+            name="DUET surface fuels",
+            tags=["test"],
+        )
+
+        assert grid.id == "duet-grid-id"
+        assert captured["domain_id"] == "domain-id"
+        assert captured["client"] is client
+        assert captured["body"].source_grid_id == "tree-grid-id"
+        assert captured["body"].years_since_burn == 20
+        assert captured["body"].wind_direction == 225
+        assert captured["body"].wind_variability == 45
+        assert captured["body"].bands == [
+            DuetBand.FUEL_LOAD_GRASS,
+            DuetBand.FUEL_LOAD_LITTER,
+        ]
+        assert captured["body"].calibration is calibration
+        assert captured["body"].name == "DUET surface fuels"
+        assert captured["body"].tags == ["test"]
+
+    def test_requires_completed_tree_grid(self):
+        with pytest.raises(ValueError, match=r"Call \.wait\(\)"):
+            create_surface_fuel_grid_from_duet(
+                self._source_grid(status=JobStatus.PENDING),
+                years_since_burn=20,
+            )
+
+    def test_requires_duet_source_bands(self):
+        with pytest.raises(ValueError, match="fuel_moisture.live"):
+            create_surface_fuel_grid_from_duet(
+                self._source_grid(omit="fuel_moisture.live"),
+                years_since_burn=20,
+            )
+
+    @pytest.mark.parametrize(
+        "kwargs,error",
+        [
+            ({"years_since_burn": 0}, ValueError),
+            ({"years_since_burn": 101}, ValueError),
+            ({"years_since_burn": 1.5}, TypeError),
+            ({"years_since_burn": 20, "wind_direction": 360}, ValueError),
+            ({"years_since_burn": 20, "wind_variability": 181}, ValueError),
+            ({"years_since_burn": 20, "bands": []}, ValueError),
+            (
+                {
+                    "years_since_burn": 20,
+                    "bands": ["fuel_load.grass", "fuel_load.grass"],
+                },
+                ValueError,
+            ),
+        ],
+    )
+    def test_validates_request_parameters(self, kwargs, error):
+        with pytest.raises(error):
+            create_surface_fuel_grid_from_duet(self._source_grid(), **kwargs)
+
+    def test_create_live(self, completed_tree_inventory):
+        voxels = completed_tree_inventory.voxelize(
+            horizontal_resolution_m=2,
+            vertical_resolution_m=1,
+            bands=[
+                "bulk_density.foliage.live",
+                "spcd",
+                "fuel_moisture.live",
+            ],
+            name="test_duet_source",
+            tags=["test"],
+        )
+        surface = None
+        try:
+            voxels.wait()
+            surface = create_surface_fuel_grid_from_duet(
+                voxels,
+                years_since_burn=25,
+                bands=[
+                    "fuel_load.grass",
+                    "fuel_load.litter",
+                    "fuel_depth.grass",
+                    "fuel_depth.litter",
+                ],
+                calibration=duet_calibration(
+                    fuel_load={
+                        "grass": {"mean": 0.5, "sd": 0.25},
+                        "litter": {"max": 5, "min": 0},
+                    },
+                    fuel_depth={
+                        "grass": {"value": 0.3},
+                        "litter": {"value": 0.06},
+                    },
+                ),
+                name="test_duet_surface_fuels",
+                tags=["test"],
+            )
+            surface.wait()
+            assert surface.status == JobStatus.COMPLETED
+            assert {band.key for band in surface.bands} == {
+                "fuel_load.grass",
+                "fuel_load.litter",
+                "fuel_depth.grass",
+                "fuel_depth.litter",
+            }
+            grass_load = surface.to_numpy("fuel_load.grass")
+            assert grass_load.ndim == 2
+            assert np.isfinite(grass_load).any()
+        finally:
+            if surface is not None:
+                surface.delete()
+            voxels.delete()
 
 
 class TestCreateFuelModelGridFromLandfireFbfm40:

--- a/tests/v2/test_grids.py
+++ b/tests/v2/test_grids.py
@@ -1074,9 +1074,25 @@ class TestListGrids:
         assert completed_topography_grid.id in grid_ids
 
     def test_list_cross_domain(self, completed_topography_grid):
-        # No domain: list grids across all the user's domains
-        grid_ids = [grid.id for grid in list_grids()]
-        assert completed_topography_grid.id in grid_ids
+        # No domain: list grids across all the user's domains. The SDK returns
+        # one page at a time, so search subsequent pages when the account has
+        # more than the default page size of 100 grids.
+        for page in range(100):
+            grids = list_grids(
+                page=page,
+                size=100,
+                sort_by="created_on",
+                sort_order="descending",
+            )
+            if completed_topography_grid.id in [grid.id for grid in grids]:
+                return
+            if len(grids) < 100:
+                break
+
+        pytest.fail(
+            f"Grid {completed_topography_grid.id} was not found in the "
+            "cross-domain grid pages."
+        )
 
     def test_filter_by_tag(self, test_domain, completed_topography_grid):
         grids_with_tag = list_grids(test_domain, tag="test")

--- a/tests/v2/test_grids.py
+++ b/tests/v2/test_grids.py
@@ -6,6 +6,7 @@ tests/v2/test_grids.py
 import inspect
 import json
 import math
+from http import HTTPStatus
 from types import SimpleNamespace
 from uuid import uuid4
 
@@ -23,6 +24,7 @@ from fastfuels_sdk.v2.grids import (
     create_canopy_fuel_grid_from_landfire,
     create_canopy_height_grid_from_meta,
     create_canopy_height_grid_from_naip_chm,
+    create_canopy_height_grid_from_point_cloud,
     create_fuel_grid_from_fbfm40_lookup,
     create_fuel_model_grid_from_landfire_fbfm40,
     create_fuel_model_grid_from_landfire_fccs,
@@ -52,11 +54,12 @@ from fastfuels_sdk.v2.client_library.models import (
     JobStatus,
     Modifier,
     Operator,
+    PointCloudType,
     ResamplingMethod,
     TopographyBand,
     UploadBandDefinition,
 )
-from fastfuels_sdk.v2.client_library.types import UNSET
+from fastfuels_sdk.v2.client_library.types import UNSET, Response
 from fastfuels_sdk.v2.exceptions import NotFoundException, expect
 from fastfuels_sdk.v2.modifications import mask
 
@@ -248,6 +251,70 @@ class TestCreateCanopyHeightGridFromNaipChm:
         assert grid.domain_id == test_domain.id
         assert grid.status in (JobStatus.PENDING, JobStatus.RUNNING)
         grid.delete()
+
+
+class TestCreateCanopyHeightGridFromPointCloud:
+    @staticmethod
+    def _point_cloud(status=JobStatus.COMPLETED, type_=PointCloudType.ALS):
+        return SimpleNamespace(
+            id="pc-id",
+            domain_id="domain-id",
+            status=status,
+            type_=type_,
+        )
+
+    def test_builds_request_from_completed_als_cloud(self, monkeypatch):
+        created = Grid(
+            id="grid-id",
+            domain_id="domain-id",
+            status=JobStatus.PENDING,
+            source=GridSource(),
+            bands=[Band(key="chm", type_=BandType.CONTINUOUS, index=0, unit="m")],
+        )
+        captured = {}
+
+        def fake_create(domain_id, *, client, body):
+            captured.update(domain_id=domain_id, client=client, body=body)
+            return Response(
+                status_code=HTTPStatus.CREATED,
+                content=b"",
+                headers={},
+                parsed=created,
+            )
+
+        client = object()
+        monkeypatch.setattr(grids, "ensure_client", lambda: client)
+        monkeypatch.setattr(
+            grids.create_point_cloud_chm,
+            "sync_detailed",
+            fake_create,
+        )
+
+        grid = create_canopy_height_grid_from_point_cloud(
+            self._point_cloud(),
+            output_resolution_m=2,
+            name="Point-cloud CHM",
+        )
+
+        assert isinstance(grid, Grid)
+        assert grid.id == "grid-id"
+        assert captured["domain_id"] == "domain-id"
+        assert captured["client"] is client
+        assert captured["body"].source_point_cloud_id == "pc-id"
+        assert captured["body"].alignment.resolution == 2
+        assert captured["body"].name == "Point-cloud CHM"
+
+    def test_requires_completed_cloud(self):
+        with pytest.raises(ValueError, match="must be completed"):
+            create_canopy_height_grid_from_point_cloud(
+                self._point_cloud(status=JobStatus.PENDING)
+            )
+
+    def test_requires_airborne_cloud(self):
+        with pytest.raises(ValueError, match="airborne"):
+            create_canopy_height_grid_from_point_cloud(
+                self._point_cloud(type_=PointCloudType.TLS)
+            )
 
 
 class TestCreateFuelModelGridFromLandfireFbfm40:

--- a/tests/v2/test_grids.py
+++ b/tests/v2/test_grids.py
@@ -26,7 +26,9 @@ from fastfuels_sdk.v2.grids import (
     create_canopy_height_grid_from_meta,
     create_canopy_height_grid_from_naip_chm,
     create_canopy_height_grid_from_point_cloud,
+    create_fuel_grid_from_fbfm13_lookup,
     create_fuel_grid_from_fbfm40_lookup,
+    create_fuel_model_grid_from_landfire_fbfm13,
     create_fuel_model_grid_from_landfire_fbfm40,
     create_fuel_model_grid_from_landfire_fccs,
     create_grid_from_geotiff,
@@ -45,6 +47,7 @@ from fastfuels_sdk.v2.client_library.models import (
     BandType,
     ContinuousBandSummary,
     DuetBand,
+    Fbfm13LookupBand,
     GridAlignmentDomainTarget,
     GridAlignmentGridTarget,
     GridAlignmentNativeTarget,
@@ -502,6 +505,58 @@ class TestCreateFuelModelGridFromLandfireFbfm40:
         grid.delete()
 
 
+class TestCreateFuelModelGridFromLandfireFbfm13:
+    def test_builds_request(self, monkeypatch):
+        created = Grid(
+            id="fbfm13-grid-id",
+            domain_id="domain-id",
+            status=JobStatus.PENDING,
+            source=GridSource(),
+            bands=[],
+        )
+        captured = {}
+
+        def fake_create(domain_id, *, client, body):
+            captured.update(domain_id=domain_id, client=client, body=body)
+            return Response(
+                status_code=HTTPStatus.CREATED,
+                content=b"",
+                headers={},
+                parsed=created,
+            )
+
+        client = object()
+        monkeypatch.setattr(grids, "ensure_client", lambda: client)
+        monkeypatch.setattr(
+            grids.create_landfire_fbfm13,
+            "sync_detailed",
+            fake_create,
+        )
+
+        grid = create_fuel_model_grid_from_landfire_fbfm13(
+            SimpleNamespace(id="domain-id"),
+            version="2024",
+            remove_non_burnable=["NB1", "NB2"],
+            output_resolution_m=30,
+            name="Anderson 13",
+        )
+
+        assert grid.id == "fbfm13-grid-id"
+        assert captured["domain_id"] == "domain-id"
+        assert captured["client"] is client
+        assert captured["body"].version.value == "2024"
+        assert [value.value for value in captured["body"].remove_non_burnable] == [
+            "NB1",
+            "NB2",
+        ]
+        assert captured["body"].alignment.resolution == 30
+        assert captured["body"].name == "Anderson 13"
+
+    def test_completed_fixture(self, completed_fbfm13_grid):
+        assert completed_fbfm13_grid.status == JobStatus.COMPLETED
+        assert [band.key for band in completed_fbfm13_grid.bands] == ["fbfm13"]
+
+
 class TestMask:
     def test_mask_payload_shape(self):
         # Unit: a single band masks one feature to one replacement value
@@ -820,6 +875,85 @@ class TestFbfm40Lookup:
         with pytest.raises(ValueError, match="fbfm"):
             create_fuel_grid_from_fbfm40_lookup(
                 completed_topography_grid, bands=["fuel_load.1hr"]
+            )
+
+
+class TestFbfm13Lookup:
+    @staticmethod
+    def _source(status=JobStatus.COMPLETED, band="fbfm13"):
+        return Grid(
+            id="fbfm13-grid-id",
+            domain_id="domain-id",
+            status=status,
+            source=GridSource(),
+            bands=[Band(key=band, type_=BandType.CATEGORICAL, index=0)],
+        )
+
+    def test_builds_request(self, monkeypatch):
+        created = Grid(
+            id="fuel-grid-id",
+            domain_id="domain-id",
+            status=JobStatus.PENDING,
+            source=GridSource(),
+            bands=[],
+        )
+        captured = {}
+
+        def fake_create(domain_id, *, client, body):
+            captured.update(domain_id=domain_id, client=client, body=body)
+            return Response(
+                status_code=HTTPStatus.CREATED,
+                content=b"",
+                headers={},
+                parsed=created,
+            )
+
+        client = object()
+        monkeypatch.setattr(grids, "ensure_client", lambda: client)
+        monkeypatch.setattr(
+            grids.create_fbfm13_lookup,
+            "sync_detailed",
+            fake_create,
+        )
+
+        result = create_fuel_grid_from_fbfm13_lookup(
+            self._source(),
+            bands=["fuel_load.1hr", Fbfm13LookupBand.FUEL_DEPTH],
+            name="Anderson fuel parameters",
+        )
+
+        assert result.id == "fuel-grid-id"
+        assert captured["body"].source_grid_id == "fbfm13-grid-id"
+        assert captured["body"].source_band == "fbfm13"
+        assert captured["body"].bands == [
+            Fbfm13LookupBand.FUEL_LOAD_1HR,
+            Fbfm13LookupBand.FUEL_DEPTH,
+        ]
+        assert captured["body"].name == "Anderson fuel parameters"
+
+    def test_lookup_returns_new_pending_grid(self, completed_fbfm13_grid):
+        fuel_grid = create_fuel_grid_from_fbfm13_lookup(
+            completed_fbfm13_grid,
+            bands=["fuel_load.1hr", "fuel_depth"],
+            name="throwaway_fbfm13_lookup",
+        )
+        assert fuel_grid.id != completed_fbfm13_grid.id
+        assert fuel_grid.domain_id == completed_fbfm13_grid.domain_id
+        assert fuel_grid.status in (JobStatus.PENDING, JobStatus.RUNNING)
+        fuel_grid.delete()
+
+    def test_requires_completed_source(self):
+        with pytest.raises(ValueError, match="look up fuel"):
+            create_fuel_grid_from_fbfm13_lookup(
+                self._source(status=JobStatus.PENDING),
+                bands=["fuel_load.1hr"],
+            )
+
+    def test_rejects_non_fbfm13_grid(self):
+        with pytest.raises(ValueError, match="fbfm13"):
+            create_fuel_grid_from_fbfm13_lookup(
+                self._source(band="elevation"),
+                bands=["fuel_load.1hr"],
             )
 
 

--- a/tests/v2/test_inventories.py
+++ b/tests/v2/test_inventories.py
@@ -388,20 +388,20 @@ class TestApplyModifications:
 
 
 class TestApplyTreatments:
-    def test_apply_treatments_rederives_in_place(self, completed_tree_inventory):
-        # Mutating, so work on a duplicate — the shared fixture is read-only
-        copy = completed_tree_inventory.duplicate(name="treat_test")
-        copy.wait()
+    def test_apply_treatments_rederives_in_place(self, throwaway_inventory):
+        copy = throwaway_inventory
         original_checksum = copy.checksum
 
         treated = copy.apply_treatments([basal_area_treatment("from_below", 25.0)])
 
         assert treated is copy  # in place: same object, same id
-        assert len(copy.treatments) == 1
+        assert copy.status == JobStatus.PENDING
+        assert copy.treatments == []  # ledger grows only after completion
+        assert copy.checksum != original_checksum  # rotates at dispatch
         copy.wait()
         assert copy.status == JobStatus.COMPLETED
+        assert len(copy.treatments) == 1
         assert copy.checksum != original_checksum  # data was re-derived
-        copy.delete()
 
     def test_requires_completed_source(self, test_domain, completed_pim_grid):
         inventory = create_tree_inventory_from_pim_grid(

--- a/tests/v2/test_inventories.py
+++ b/tests/v2/test_inventories.py
@@ -9,7 +9,6 @@ from types import SimpleNamespace
 from uuid import uuid4
 
 # Internal imports
-from fastfuels_sdk.v2._jobs import JobFailedError
 from fastfuels_sdk.v2.grids import Grid
 from fastfuels_sdk.v2.inventories import (
     Inventory,
@@ -344,17 +343,8 @@ class TestDuplicate:
 
 
 class TestApplyModifications:
-    @pytest.mark.xfail(
-        reason="v2 API bug: the in-place modifications job fails at the save "
-        "step (module-level gcsfs client is not fork-safe in standgen) — "
-        "FastFuels-API-v2#333",
-        raises=JobFailedError,
-        strict=True,
-    )
-    def test_apply_modifications_rederives_in_place(self, completed_tree_inventory):
-        # Mutating, so work on a duplicate — the shared fixture is read-only
-        copy = completed_tree_inventory.duplicate(name="modify_test")
-        copy.wait()
+    def test_apply_modifications_rederives_in_place(self, throwaway_inventory):
+        copy = throwaway_inventory
         # Rules need at least one condition; height > 0 matches every tree
         modification = InventoryModification(
             conditions=[
@@ -377,11 +367,13 @@ class TestApplyModifications:
         modified = copy.apply_modifications([modification])
 
         assert modified is copy  # in place: same object, same id
-        assert len(copy.modifications) == 1
+        assert copy.status == JobStatus.PENDING
+        assert copy.modifications == []  # ledger grows only after completion
+        assert copy.checksum != original_checksum  # rotates at dispatch
         copy.wait()
         assert copy.status == JobStatus.COMPLETED
+        assert len(copy.modifications) == 1
         assert copy.checksum != original_checksum  # data was re-derived
-        copy.delete()
 
     def test_requires_completed_source(self, test_domain, completed_pim_grid):
         inventory = create_tree_inventory_from_pim_grid(
@@ -427,9 +419,9 @@ class TestModificationBuilders:
     def test_remove_trees_at_creation(
         self, test_domain, completed_pim_grid, completed_tree_inventory
     ):
-        # In-place apply_modifications is #333-blocked, so verify the builders
-        # via the create-time path (which works). Same seed as the unmodified
-        # fixture, so removing dbh < 10 must yield strictly fewer trees.
+        # Verify the builders independently through the create-time path. Use
+        # the same seed as the unmodified fixture so removing dbh < 10 must
+        # yield strictly fewer trees.
         modified = create_tree_inventory_from_pim_grid(
             test_domain,
             completed_pim_grid,

--- a/tests/v2/test_inventories.py
+++ b/tests/v2/test_inventories.py
@@ -20,6 +20,10 @@ from fastfuels_sdk.v2.inventories import (
 from fastfuels_sdk.v2.treatments import basal_area_treatment, diameter_treatment
 from fastfuels_sdk.v2.modifications import remove_trees, tree_attribute
 from fastfuels_sdk.v2.client_library.models import (
+    CategoricalColumnSummary,
+    Column,
+    ColumnType,
+    ContinuousColumnSummary,
     FIASpeciesGroupShare,
     Inventory as InventoryModel,
     InventoryAttribute,
@@ -141,6 +145,83 @@ class TestForestryMetrics:
                 reverse=True,
             )
         )
+
+
+class TestColumnSummary:
+    @staticmethod
+    def _inventory_with_column(column):
+        return Inventory(
+            id="inventory-id",
+            domain_id="domain-id",
+            type_=InventoryType.TREE,
+            status=JobStatus.COMPLETED,
+            source=InventorySource(),
+            columns=[column],
+        )
+
+    def test_returns_continuous_summary(self):
+        summary = ContinuousColumnSummary(
+            type_="continuous",
+            count=10,
+            null_count=0,
+            min_=1.0,
+            max_=5.0,
+            mean=3.0,
+            std=1.0,
+        )
+        inventory = self._inventory_with_column(
+            Column(key="dbh", type_=ColumnType.CONTINUOUS, summary=summary)
+        )
+
+        assert inventory.column_summary("dbh") is summary
+        assert inventory.column_summary("dbh").mean == 3.0
+
+    def test_returns_categorical_summary(self):
+        summary = CategoricalColumnSummary(
+            type_="categorical", count=10, null_count=1, unique_count=3
+        )
+        inventory = self._inventory_with_column(
+            Column(
+                key="fia_species_code",
+                type_=ColumnType.CATEGORICAL,
+                summary=summary,
+            )
+        )
+
+        assert inventory.column_summary("fia_species_code") is summary
+        assert inventory.column_summary("fia_species_code").unique_count == 3
+
+    def test_none_when_not_computed(self):
+        inventory = self._inventory_with_column(
+            Column(key="dbh", type_=ColumnType.CONTINUOUS)
+        )
+
+        assert inventory.column_summary("dbh") is None
+
+    def test_unknown_column_raises(self):
+        inventory = self._inventory_with_column(
+            Column(key="dbh", type_=ColumnType.CONTINUOUS)
+        )
+
+        with pytest.raises(ValueError, match="no column"):
+            inventory.column_summary("height")
+
+    def test_summaries_live(self, completed_tree_inventory):
+        dbh = completed_tree_inventory.column_summary("dbh")
+        species = completed_tree_inventory.column_summary("fia_species_code")
+        tree_count = completed_tree_inventory.get_data_metadata().total_rows
+
+        assert isinstance(dbh, ContinuousColumnSummary)
+        assert dbh.type_ == "continuous"
+        assert dbh.count == tree_count
+        assert dbh.null_count == 0
+        assert dbh.mean > 0
+
+        assert isinstance(species, CategoricalColumnSummary)
+        assert species.type_ == "categorical"
+        assert species.count == tree_count
+        assert species.null_count == 0
+        assert species.unique_count > 0
 
 
 class TestCreateTreeInventoryFromFile:

--- a/tests/v2/test_inventories.py
+++ b/tests/v2/test_inventories.py
@@ -20,14 +20,20 @@ from fastfuels_sdk.v2.inventories import (
 from fastfuels_sdk.v2.treatments import basal_area_treatment, diameter_treatment
 from fastfuels_sdk.v2.modifications import remove_trees, tree_attribute
 from fastfuels_sdk.v2.client_library.models import (
+    FIASpeciesGroupShare,
+    Inventory as InventoryModel,
     InventoryAttribute,
     InventoryModification,
     InventoryModificationAction,
     InventoryModificationCondition,
+    InventorySource,
+    InventoryType,
     JobStatus,
     Modifier,
     Operator,
+    TreeForestryMetrics,
 )
+from fastfuels_sdk.v2.client_library.types import UNSET
 from fastfuels_sdk.v2.exceptions import NotFoundException
 
 # External imports
@@ -73,6 +79,68 @@ class TestCreateTreeInventoryFromPimGrid:
         assert completed_tree_inventory.status == JobStatus.COMPLETED
         assert completed_tree_inventory.georeference is not None
         assert completed_tree_inventory.checksum
+
+
+class TestForestryMetrics:
+    @staticmethod
+    def _model(forestry_metrics=UNSET):
+        return InventoryModel(
+            id="inventory-id",
+            domain_id="domain-id",
+            type_=InventoryType.TREE,
+            status=JobStatus.COMPLETED,
+            source=InventorySource(),
+            forestry_metrics=forestry_metrics,
+        )
+
+    def test_wraps_metrics_record(self):
+        metrics = TreeForestryMetrics(
+            type_="tree",
+            tree_count=120,
+            basal_area_per_area=87.5,
+            tree_density=240.0,
+            quadratic_mean_diameter=9.4,
+            dominant_species_groups=[
+                FIASpeciesGroupShare(
+                    spgrpcd=3,
+                    name="Douglas-fir",
+                    basal_area_share=0.62,
+                )
+            ],
+        )
+
+        inventory = Inventory._from_model(self._model(metrics))
+
+        assert isinstance(inventory.forestry_metrics, TreeForestryMetrics)
+        assert inventory.forestry_metrics.tree_count == 120
+        assert inventory.forestry_metrics.dominant_species_groups[0].spgrpcd == 3
+
+    def test_normalizes_missing_metrics_to_none(self):
+        inventory = Inventory._from_model(self._model())
+
+        assert inventory.forestry_metrics is None
+
+    def test_completed_inventory_metrics_live(self, completed_tree_inventory):
+        metrics = completed_tree_inventory.forestry_metrics
+
+        assert isinstance(metrics, TreeForestryMetrics)
+        assert metrics.type_ == "tree"
+        assert (
+            metrics.tree_count
+            == completed_tree_inventory.get_data_metadata().total_rows
+        )
+        assert metrics.basal_area_per_area > 0
+        assert metrics.tree_density > 0
+        assert metrics.quadratic_mean_diameter > 0
+        assert len(metrics.dominant_species_groups) > 0
+        assert [
+            group.basal_area_share for group in metrics.dominant_species_groups
+        ] == (
+            sorted(
+                (group.basal_area_share for group in metrics.dominant_species_groups),
+                reverse=True,
+            )
+        )
 
 
 class TestCreateTreeInventoryFromFile:

--- a/tests/v2/test_inventories.py
+++ b/tests/v2/test_inventories.py
@@ -4,6 +4,8 @@ tests/v2/test_inventories.py
 
 # Core imports
 import json
+from http import HTTPStatus
+from types import SimpleNamespace
 from uuid import uuid4
 
 # Internal imports
@@ -27,6 +29,8 @@ from fastfuels_sdk.v2.client_library.models import (
     FIASpeciesGroupShare,
     Inventory as InventoryModel,
     InventoryAttribute,
+    InventoryDataResponse,
+    InventoryJsonOrientation,
     InventoryModification,
     InventoryModificationAction,
     InventoryModificationCondition,
@@ -37,7 +41,7 @@ from fastfuels_sdk.v2.client_library.models import (
     Operator,
     TreeForestryMetrics,
 )
-from fastfuels_sdk.v2.client_library.types import UNSET
+from fastfuels_sdk.v2.client_library.types import UNSET, Response
 from fastfuels_sdk.v2.exceptions import NotFoundException
 
 # External imports
@@ -488,6 +492,113 @@ class TestExport:
 
 
 class TestInventoryData:
+    @staticmethod
+    def _inventory():
+        return Inventory(
+            id="inventory-id",
+            domain_id="domain-id",
+            type_=InventoryType.TREE,
+            status=JobStatus.COMPLETED,
+            source=InventorySource(),
+        )
+
+    def test_get_data_partition_passes_json_orientation(self, monkeypatch):
+        captured = {}
+
+        def fake_get(domain_id, inventory_id, partition_index, **kwargs):
+            captured.update(
+                domain_id=domain_id,
+                inventory_id=inventory_id,
+                partition_index=partition_index,
+                **kwargs,
+            )
+            return Response(
+                status_code=HTTPStatus.OK,
+                content=b"",
+                headers={},
+                parsed=InventoryDataResponse(
+                    partition=partition_index,
+                    num_rows=1,
+                    columns=["height"],
+                    data=[{"height": 12.0}],
+                ),
+            )
+
+        client = object()
+        monkeypatch.setattr(
+            "fastfuels_sdk.v2.inventories.ensure_client", lambda: client
+        )
+        monkeypatch.setattr(
+            "fastfuels_sdk.v2.inventories.get_inventory_data_json.sync_detailed",
+            fake_get,
+        )
+
+        partition = self._inventory().get_data_partition(
+            2, columns=["height"], json_orientation="records"
+        )
+
+        assert partition.data == [{"height": 12.0}]
+        assert captured == {
+            "domain_id": "domain-id",
+            "inventory_id": "inventory-id",
+            "partition_index": 2,
+            "client": client,
+            "json_orientation": InventoryJsonOrientation.RECORDS,
+            "columns": "height",
+        }
+
+    def test_get_data_partition_rejects_invalid_orientation(self):
+        with pytest.raises(ValueError, match="not a valid InventoryJsonOrientation"):
+            self._inventory().get_data_partition(0, json_orientation="columns")
+
+    def test_to_dataframe_uses_csv_partitions(self, monkeypatch):
+        inventory = self._inventory()
+        metadata = SimpleNamespace(
+            num_partitions=2, total_rows=3, columns=["x", "height"]
+        )
+        csv_partitions = [
+            "x,height\n1.0,10.0\n2.0,20.0\n",
+            "x,height\n3.0,30.0\n",
+        ]
+        captured = []
+
+        def fake_csv(domain_id, inventory_id, partition_index, **kwargs):
+            captured.append((domain_id, inventory_id, partition_index, kwargs))
+            return Response(
+                status_code=HTTPStatus.OK,
+                content=csv_partitions[partition_index].encode(),
+                headers={},
+                parsed=csv_partitions[partition_index],
+            )
+
+        def fail_json(*args, **kwargs):
+            raise AssertionError("to_dataframe must use the CSV endpoint")
+
+        client = object()
+        monkeypatch.setattr(inventory, "get_data_metadata", lambda: metadata)
+        monkeypatch.setattr(
+            "fastfuels_sdk.v2.inventories.ensure_client", lambda: client
+        )
+        monkeypatch.setattr(
+            "fastfuels_sdk.v2.inventories.get_inventory_data_csv.sync_detailed",
+            fake_csv,
+        )
+        monkeypatch.setattr(
+            "fastfuels_sdk.v2.inventories.get_inventory_data_json.sync_detailed",
+            fail_json,
+        )
+
+        trees = inventory.to_dataframe(columns=["x", "height"])
+
+        assert trees.to_dict(orient="list") == {
+            "x": [1.0, 2.0, 3.0],
+            "height": [10.0, 20.0, 30.0],
+        }
+        assert [call[2] for call in captured] == [0, 1]
+        assert all(
+            call[3] == {"client": client, "columns": "x,height"} for call in captured
+        )
+
     def test_get_data_metadata(self, completed_tree_inventory):
         metadata = completed_tree_inventory.get_data_metadata()
         assert metadata.inventory_id == completed_tree_inventory.id
@@ -505,6 +616,15 @@ class TestInventoryData:
         assert set(partition.columns) <= set(metadata.columns)
         assert "height" in partition.columns
         assert len(partition.data) == partition.num_rows
+
+    def test_get_data_partition_records(self, completed_tree_inventory):
+        partition = completed_tree_inventory.get_data_partition(
+            0, columns=["height"], json_orientation="records"
+        )
+
+        assert partition.columns == ["height"]
+        assert len(partition.data) == partition.num_rows
+        assert set(partition.data[0]) == {"height"}
 
     def test_to_dataframe(self, completed_tree_inventory):
         metadata = completed_tree_inventory.get_data_metadata()

--- a/tests/v2/test_point_clouds.py
+++ b/tests/v2/test_point_clouds.py
@@ -10,11 +10,14 @@ from uuid import uuid4
 from fastfuels_sdk.v2.point_clouds import (
     PointCloud,
     _point_cloud_type,
+    check_3dep_coverage,
+    create_point_cloud_from_3dep,
     create_point_cloud_from_file,
     get_point_cloud,
     list_point_clouds,
 )
 from fastfuels_sdk.v2.client_library.models import JobStatus, PointCloudType
+from fastfuels_sdk.v2.domains import Domain
 from fastfuels_sdk.v2.exceptions import NotFoundException
 
 # External imports
@@ -35,6 +38,40 @@ def _placeholder_laz(directory) -> str:
     return str(path)
 
 
+@pytest.fixture(scope="module")
+def covered_3dep_domain():
+    """A small Bondurant, WY domain with stable 3DEP LiDAR coverage."""
+    geojson = {
+        "type": "FeatureCollection",
+        "crs": {"type": "name", "properties": {"name": "EPSG:32612"}},
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [522800, 4720400],
+                            [523300, 4720400],
+                            [523300, 4720900],
+                            [522800, 4720900],
+                            [522800, 4720400],
+                        ]
+                    ],
+                },
+            }
+        ],
+    }
+    domain = Domain.from_geojson(
+        geojson,
+        name="test_3dep_point_cloud_domain",
+        tags=["sdk-test"],
+    )
+    yield domain
+    domain.delete(force=True)
+
+
 class TestPointCloudType:
     """Pure unit tests for the scan-type coercion (no API)."""
 
@@ -48,6 +85,43 @@ class TestPointCloudType:
     def test_invalid_raises(self):
         with pytest.raises(ValueError):
             _point_cloud_type("mls")
+
+
+class TestCreateFrom3dep:
+    def test_coverage_preflight(self, covered_3dep_domain):
+        coverage = check_3dep_coverage(covered_3dep_domain)
+
+        assert coverage.available is True
+        assert coverage.coverage_fraction == pytest.approx(1.0, abs=1e-3)
+        assert coverage.estimated_point_count > 0
+        assert coverage.point_budget > 0
+        assert coverage.exceeds_point_budget is False
+        assert coverage.datasets
+
+    def test_create_with_pinned_dataset(self, covered_3dep_domain):
+        coverage = check_3dep_coverage(covered_3dep_domain)
+        dataset = coverage.datasets[0].name
+        point_cloud = create_point_cloud_from_3dep(
+            covered_3dep_domain,
+            datasets=[dataset],
+            name="throwaway_3dep_pc",
+        )
+        try:
+            assert isinstance(point_cloud, PointCloud)
+            assert point_cloud.domain_id == covered_3dep_domain.id
+            assert point_cloud.type_ == PointCloudType.ALS
+            assert point_cloud.source["name"] == "3dep"
+            assert point_cloud.source["datasets"] == [dataset]
+            assert point_cloud.status in (
+                JobStatus.PENDING,
+                JobStatus.RUNNING,
+                JobStatus.COMPLETED,
+            )
+        finally:
+            try:
+                point_cloud.delete()
+            except NotFoundException:
+                pass
 
 
 class TestCreateAndLifecycle:


### PR DESCRIPTION
Closes #192
Part of #176

## What changed

- Regenerated the v2 client against the expanded production OpenAPI schema and restored all intended generated operations.
- Added structured quota errors plus owner quota and usage accessors.
- Added the 3DEP point-cloud workflow, point-cloud CHM creation, DUET surface fuels, LANDFIRE FBFM13, FCCS lookup, grid composition, and landscape exports.
- Exposed inventory forestry metrics and column summaries, and updated inventory data transport to use the JSON/CSV endpoints intentionally.
- Kept application/key provisioning outside the public SDK boundary while exposing authenticated owner account data.
- Removed the temporary OpenAPI title patches after FastFuels-API-v2#489, adopting the explicit GeoJSON and 3DEP model names.
- Corrected domain response, pagination, inventory lifecycle, and feature-sorting test expectations.
- Updated the v2 guides and reference docstrings alongside each SDK change.

## Why

The production v2 API expanded to 94 operations across 236 schemas, leaving 19 operations without a high-level SDK surface. Duplicate OpenAPI titles also caused generated endpoints to be omitted, while several live tests encoded stale assumptions about pagination and asynchronous inventory ledgers.

This completes the post-regeneration backlog and brings the SDK surface, generated client, tests, and documentation back into alignment with the deployed v2 API.

## Developer and user impact

Python users can now complete the new point-cloud, grid, export, quota, and inventory workflows through supported high-level SDK APIs. Generated model names are stable and unambiguous, and live tests now reflect production behavior.

## Validation

- `uv run pytest tests/v2 -q -rxX`: 320 passed, 1 skipped
- Focused production tests passed for cross-domain pagination, modification lifecycle, treatment lifecycle, feature sorting, and the domain response contract
- `uv run mkdocs build --strict`: passed
- Pre-commit hooks passed for every commit
- No temporary `sdk-test` domains remained after the full live suite
